### PR TITLE
Add Export & Import Commands to the Interactive Mode

### DIFF
--- a/iamctl/cmd/interactive/export.go
+++ b/iamctl/cmd/interactive/export.go
@@ -99,8 +99,7 @@ func exportApplication(serviceProviderID string, exportlocation string, fileType
 	exported := false
 
 	SERVER, CLIENTID, CLIENTSECRET, TENANTDOMAIN = utils.ReadSPConfig()
-
-	start(SERVER, "admin", "admin")
+	setServer()
 
 	var ADDAPPURL = SERVER + "/t/" + TENANTDOMAIN + "/api/server/v1/applications"
 	var err error
@@ -140,17 +139,17 @@ func exportApplication(serviceProviderID string, exportlocation string, fileType
 
 	var fileName = params["filename"]
 
-	body1, err := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	if body1 != nil {
+	if body != nil {
 		exported = true
 	}
 
 	var exportedFilePath = exportlocation + "/" + fileName
-	ioutil.WriteFile(exportedFilePath, body1, 0644)
+	ioutil.WriteFile(exportedFilePath, body, 0644)
 	print("Successfully created the export file : " + exportedFilePath)
 
 	return exported

--- a/iamctl/cmd/interactive/export.go
+++ b/iamctl/cmd/interactive/export.go
@@ -32,8 +32,6 @@ import (
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
-var ADDAPPURL string
-
 var exportCmd = &cobra.Command{
 	Use:   "export",
 	Short: "You can export a service provider",
@@ -94,9 +92,7 @@ func setExportInfo() {
 	exportApplication(exportAnswers.ServiceProviderID, exportAnswers.Exportlocation, exportAnswers.FileType)
 }
 
-func exportApplication(serviceProviderID string, exportlocation string, fileType string) bool {
-
-	exported := false
+func exportApplication(serviceProviderID string, exportlocation string, fileType string) {
 
 	SERVER, CLIENTID, CLIENTSECRET, TENANTDOMAIN = utils.ReadSPConfig()
 	setServer()
@@ -144,16 +140,10 @@ func exportApplication(serviceProviderID string, exportlocation string, fileType
 		log.Fatalln(err)
 	}
 
-	if body != nil {
-		exported = true
-	}
-
 	var exportedFilePath = exportlocation + "/" + fileName
 	err = ioutil.WriteFile(exportedFilePath, body, 0644)
 	if err != nil {
 		log.Fatalln(err)
 	}
 	log.Println("Successfully created the export file : " + exportedFilePath)
-
-	return exported
 }

--- a/iamctl/cmd/interactive/export.go
+++ b/iamctl/cmd/interactive/export.go
@@ -20,7 +20,6 @@ package interactive
 
 import (
 	"crypto/tls"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -60,26 +59,6 @@ func init() {
 	exportCmd.Flags().StringP("fileType", "t", "application/yaml", "set the file type")
 }
 
-type applicationsStruct struct {
-	TotalResults int `json:"totalResults"`
-	StartIndex   int `json:"startIndex"`
-	Count        int `json:"count"`
-	Applications []struct {
-		appSummary
-	} `json:"applications"`
-	Links []interface{} `json:"links"`
-}
-
-type appSummary struct {
-	ID          string `json:"id"`
-	Name        string `json:"name"`
-	Description string `json:"description"`
-	Image       string `json:"image,omitempty"`
-	AccessURL   string `json:"accessUrl"`
-	Access      string `json:"access"`
-	Self        string `json:"self"`
-}
-
 var exportQuestions = []*survey.Question{
 	{
 		Name:     "exportlocation",
@@ -115,7 +94,7 @@ func setExportInfo() {
 	exportApplication(exportAnswers.ServiceProviderID, exportAnswers.Exportlocation, exportAnswers.FileType)
 }
 
-func exportApplication(exportlocation string, serviceProviderID string, fileType string) bool {
+func exportApplication(serviceProviderID string, exportlocation string, fileType string) bool {
 
 	exported := false
 
@@ -153,12 +132,11 @@ func exportApplication(exportlocation string, serviceProviderID string, fileType
 	defer resp.Body.Close()
 
 	var attachmentDetail = resp.Header.Get("Content-Disposition")
-	disposition, params, err := mime.ParseMediaType(attachmentDetail)
+	_, params, err := mime.ParseMediaType(attachmentDetail)
 
 	if err != nil {
 		panic(err)
 	}
-	log.Println("Disposition" + disposition)
 
 	var fileName = params["filename"]
 

--- a/iamctl/cmd/interactive/export.go
+++ b/iamctl/cmd/interactive/export.go
@@ -1,0 +1,179 @@
+/**
+* Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package interactive
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/AlecAivazis/survey/v2"
+	"github.com/spf13/cobra"
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+var ADDAPPURL string
+
+var exportCmd = &cobra.Command{
+	Use:   "export",
+	Short: "You can export a service provider",
+	Long:  `You can export a service provider`,
+	Run: func(cmd *cobra.Command, args []string) {
+		appId, _ := cmd.Flags().GetString("serviceProviderID")
+		exportLocation, _ := cmd.Flags().GetString("exportlocation")
+		fileType, _ := cmd.Flags().GetString("fileType")
+
+		if appId == "" || exportLocation == "" {
+			setExportInfo()
+		} else {
+			exportApplication(appId, exportLocation, fileType)
+		}
+	},
+}
+
+func init() {
+
+	createSPCmd.AddCommand(exportCmd)
+	exportCmd.Flags().StringP("serviceProviderID", "s", "", "set the service provide ID")
+	exportCmd.Flags().StringP("exportlocation", "p", "", "set the export location")
+	exportCmd.Flags().StringP("fileType", "t", "application/yaml", "set the file type")
+}
+
+type applicationsStruct struct {
+	TotalResults int `json:"totalResults"`
+	StartIndex   int `json:"startIndex"`
+	Count        int `json:"count"`
+	Applications []struct {
+		appSummary
+	} `json:"applications"`
+	Links []interface{} `json:"links"`
+}
+
+type appSummary struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Image       string `json:"image,omitempty"`
+	AccessURL   string `json:"accessUrl"`
+	Access      string `json:"access"`
+	Self        string `json:"self"`
+}
+
+var exportQuestions = []*survey.Question{
+	{
+		Name:     "exportlocation",
+		Prompt:   &survey.Input{Message: "Enter export location : "},
+		Validate: survey.Required,
+	},
+	{
+		Name:     "serviceProviderID",
+		Prompt:   &survey.Input{Message: "Enter service provider id to be exported :"},
+		Validate: survey.Required,
+	},
+	{
+		Name:     "fileType",
+		Prompt:   &survey.Input{Message: "Enter file type i.e application/json or application/yaml :"},
+		Validate: survey.Required,
+	},
+}
+
+func setExportInfo() {
+
+	exportAnswers := struct {
+		Exportlocation    string `survey:"exportlocation"`
+		ServiceProviderID string `survey:"serviceProviderID"`
+		FileType          string `survey:"fileType"`
+	}{}
+
+	err := survey.Ask(exportQuestions, &exportAnswers)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	exportApplication(exportAnswers.ServiceProviderID, exportAnswers.Exportlocation, exportAnswers.FileType)
+}
+
+func exportApplication(exportlocation string, serviceProviderID string, fileType string) bool {
+
+	exported := false
+
+	SERVER, CLIENTID, CLIENTSECRET, TENANTDOMAIN = utils.ReadSPConfig()
+
+	start(SERVER, "admin", "admin")
+
+	var ADDAPPURL = SERVER + "/t/" + TENANTDOMAIN + "/api/server/v1/applications"
+	var err error
+
+	token := utils.ReadFile()
+
+	var reqUrl = ADDAPPURL + "/" + serviceProviderID + "/exportFile"
+	req, err := http.NewRequest("GET", reqUrl, strings.NewReader(""))
+	if err != nil {
+		log.Fatalln(err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("accept", fileType)
+	req.Header.Set("Authorization", "Bearer "+token)
+	defer req.Body.Close()
+
+	httpClient := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	defer resp.Body.Close()
+
+	var attachmentDetail = resp.Header.Get("Content-Disposition")
+	disposition, params, err := mime.ParseMediaType(attachmentDetail)
+
+	if err != nil {
+		panic(err)
+	}
+	log.Println("Disposition" + disposition)
+
+	var fileName = params["filename"]
+
+	body1, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	if body1 != nil {
+		exported = true
+	}
+
+	var exportedFilePath = exportlocation + "/" + fileName
+	ioutil.WriteFile(exportedFilePath, body1, 0644)
+	print("Successfully created the export file : " + exportedFilePath)
+
+	return exported
+}

--- a/iamctl/cmd/interactive/export.go
+++ b/iamctl/cmd/interactive/export.go
@@ -149,8 +149,11 @@ func exportApplication(serviceProviderID string, exportlocation string, fileType
 	}
 
 	var exportedFilePath = exportlocation + "/" + fileName
-	ioutil.WriteFile(exportedFilePath, body, 0644)
-	print("Successfully created the export file : " + exportedFilePath)
+	err = ioutil.WriteFile(exportedFilePath, body, 0644)
+	if err != nil {
+		log.Fatalln(err)
+	}
+	log.Println("Successfully created the export file : " + exportedFilePath)
 
 	return exported
 }

--- a/iamctl/cmd/interactive/import.go
+++ b/iamctl/cmd/interactive/import.go
@@ -55,9 +55,7 @@ func init() {
 	importCmd.Flags().StringP("importFilePath", "i", "", "set the export file name")
 }
 
-func importApplication(importFilePath string) bool {
-
-	importedSp := false
+func importApplication(importFilePath string) {
 
 	SERVER, CLIENTID, CLIENTSECRET, TENANTDOMAIN = utils.ReadSPConfig()
 	setServer()
@@ -129,6 +127,4 @@ func importApplication(importFilePath string) bool {
 	case 201:
 		log.Println("Application imported successfully.")
 	}
-
-	return importedSp
 }

--- a/iamctl/cmd/interactive/import.go
+++ b/iamctl/cmd/interactive/import.go
@@ -56,11 +56,11 @@ func init() {
 }
 
 func importApplication(importFilePath string) bool {
+
 	importedSp := false
 
 	SERVER, CLIENTID, CLIENTSECRET, TENANTDOMAIN = utils.ReadSPConfig()
-
-	start(SERVER, "admin", "admin")
+	setServer()
 
 	var ADDAPPURL = SERVER + "/t/" + TENANTDOMAIN + "/api/server/v1/applications/import"
 
@@ -75,6 +75,7 @@ func importApplication(importFilePath string) bool {
 
 	body := new(bytes.Buffer)
 	writer := multipart.NewWriter(body)
+    defer writer.Close()
 
 	mime.AddExtensionType(".yml", "text/yaml")
 	mime.AddExtensionType(".xml", "application/xml")
@@ -92,8 +93,6 @@ func importApplication(importFilePath string) bool {
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	defer writer.Close()
 
 	request, err := http.NewRequest("POST", ADDAPPURL, body)
 	request.Header.Add("Content-Type", writer.FormDataContentType())
@@ -116,8 +115,7 @@ func importApplication(importFilePath string) bool {
 		log.Fatal(err)
 	}
 
-	statusCode := resp.StatusCode
-	switch statusCode {
+	switch resp.StatusCode {
 	case 401:
 		log.Println("Unauthorized access.\nPlease check your Username and password.")
 	case 400:

--- a/iamctl/cmd/interactive/import.go
+++ b/iamctl/cmd/interactive/import.go
@@ -1,0 +1,117 @@
+/**
+* Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package interactive
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"mime/multipart"
+	"net/http"
+
+	"github.com/spf13/cobra"
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+var importCmd = &cobra.Command{
+	Use:   "import",
+	Short: "You can import a service provider",
+	Long:  `You can import a service provider`,
+	Run: func(cmd *cobra.Command, args []string) {
+		importFilePath, errEXL := cmd.Flags().GetString("importFilePath")
+
+		if errEXL != nil {
+			log.Fatalln(errEXL)
+		}
+		importApplication(importFilePath)
+	},
+}
+
+func init() {
+
+	createSPCmd.AddCommand(importCmd)
+	importCmd.Flags().StringP("importFilePath", "i", "", "set the export file name")
+}
+
+func importApplication(importFilePath string) bool {
+	importedSp := false
+
+	SERVER, CLIENTID, CLIENTSECRET, TENANTDOMAIN = utils.ReadSPConfig()
+
+	start(SERVER, "admin", "admin")
+
+	var ADDAPPURL = SERVER + "/t/" + TENANTDOMAIN + "/api/server/v1/applications/import"
+	var err error
+
+	token := utils.ReadFile()
+
+	fileBytes, err := ioutil.ReadFile(importFilePath)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	extraParams := map[string]string{
+		"file": string(fileBytes),
+	}
+
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+
+	for key, val := range extraParams {
+		err := writer.WriteField(key, val)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+	defer writer.Close()
+
+	request, err := http.NewRequest("POST", ADDAPPURL, body)
+	request.Header.Add("Content-Type", writer.FormDataContentType())
+	request.Header.Set("Authorization", "Bearer "+token)
+	defer request.Body.Close()
+
+	if err != nil {
+		log.Fatal(err)
+	}
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{
+				InsecureSkipVerify: true,
+			},
+		},
+	}
+	resp, err := client.Do(request)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		fmt.Println(resp.StatusCode)
+		fmt.Println(resp.Header)
+		bodyBytes, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			log.Fatal(err)
+		}
+		fmt.Println(string(bodyBytes))
+
+		importedSp = true
+	}
+
+	return importedSp
+}

--- a/iamctl/cmd/interactive/import.go
+++ b/iamctl/cmd/interactive/import.go
@@ -75,7 +75,7 @@ func importApplication(importFilePath string) bool {
 
 	body := new(bytes.Buffer)
 	writer := multipart.NewWriter(body)
-    defer writer.Close()
+	defer writer.Close()
 
 	mime.AddExtensionType(".yml", "text/yaml")
 	mime.AddExtensionType(".xml", "application/xml")


### PR DESCRIPTION
This PR adds the import and export commands to the interactive mode. 
In the interactive mode, first, the tool should be initialized with the server configurations. Then the following 2 commands can be used to export and import an app with the given app ID.

- application export
```
Flags:
  -p, --exportlocation string      set the export location
  -t, --fileType string            set the file type (default "application/yaml")
  -h, --help                       help for export
  -s, --serviceProviderID string   set the service provide ID
  ```
- application import
```
Flags:
  -h, --help                    help for import
  -i, --importFilePath string   set the export file name
  ```

Related issue: https://github.com/wso2/product-is/issues/15461