### PR TITLE
Remove Interactive mode related section from the main documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ You need to [setup](https://is.docs.wso2.com/en/latest/get-started/sample-use-ca
 
 ### Run the tool
 
-1. Download the latest binary file from [Releases](https://github.com/wso2-extensions/identity-tools-cli/releases).
- based on your Operating System.
+1. Download the latest binary file from [Releases](https://github.com/wso2-extensions/identity-tools-cli/releases) based on your Operating System.
 
 2. Extract the `tar` or `zip` file.
 
@@ -34,11 +33,9 @@ You need to [setup](https://is.docs.wso2.com/en/latest/get-started/sample-use-ca
 5. Start WSO2 IS and [create an application](https://is.docs.wso2.com/en/6.1.0/guides/applications/register-sp) with **Management Application** enabled.
 6. Update the Oauth inbound authentication configuration with a dummy callback URL and take note of the client ID and client secret.
 
-
-The IAM CTL can be used in two basic modes.
 ## CLI mode
 
-The CLI mode can be used to handle bulk configurations in the target environment. This can be used to propagate resources across multiple environments, deploy new configurations to target environments, and act as a backup of each environment's configurations.
+The CLI mode of the tool can be used to handle bulk configurations in the target environment. This can be used to promote resources across multiple environments, deploy new configurations to target environments, and act as a backup of each environment's configurations.
 
 This mode consists of the `exportAll` and `importAll` commands that can be used to export and import all configurations of the supported resource types from or to a target environment. 
 
@@ -85,82 +82,8 @@ iamctl importAll -c ./configs/env
 ```
 All resources available inside each resource type folder in the current directory will be imported to WSO2 IS.
 
-## Interactive Mode
-The interactive mode can be used to handle application configurations in an interactive manner. This can be used to add, list, export, and import applications in the target environment.
-> Note: This mode does not provide support for bulk resource export or import.
-
-### Run the tool in interactive mode
-
-See the topics given below to run the tool in interactive mode.
-#### Tool Initialization
-1. Run the following command to initialize the tool by providing details of WSO2 IS and the client ID/secret of the app you created earlier.
-```
-iamctl init
-```
-Provide the details as prompted by the tool.
-```
-:~$ iamctl init
-  ___      _      __  __            ____   _____   _     
- |_ _|    / \    |  \/  |          / ___| |_   _| | |    
-  | |    / _ \   | |\/| |  _____  | |       | |   | |    
-  | |   / ___ \  | |  | | |_____| | |___    | |   | |___ 
- |___| /_/   \_\ |_|  |_|          \____|   |_|   |_____|
-      
-? Enter IAM URL [<schema>://<host>]: https://localhost:9443                                                   
-? Enter clientID: *******
-? Enter clientSecret: *******
-? Enter Tenant domain: carbon.super
-```
-2. Run the following command to provide admin user credentials.
-```
-iamctl serverConfiguration
-```
-```
-~$ iamctl serverConfiguration
-? Enter IAM URL [<schema>://<host>]: https://localhost:9443
-? Enter Username: admin
-? Enter Password: admin
-```
-
-### Create new applications and list existing applications interactively
-Run the following command to get the options available for applications.
-```
-iamctl application
-```
-```
-$ iamctl application                                                      
-? Select the option to move on:  [Use arrows to move, type to filter]
-> Add application
-  Get List
-  Exit
-```
-* To add an application, select ```Add application``` and proceed by providing the application details.
-
-* To view the list of applications, select ```Get List```.
-
-### Application-related commands
-After initializing the tool, the following commands can be used to add, list, export, and import applications in the target environment.
-#### Add application
-```
-iamctl application add -n=TestApplication 
-```
-#### List applications
-```
-iamctl application list
-```
-#### Export application
-```
-iamctl application export -s <applicationID> -p <path-to-export-location>
-```
-#### Import application
-```
-iamctl application import -i <path-to-import-file>
-```
-Find more comprehensive details about the commands used in the interactive mode [here](docs/interactive-mode.md).
-
 ## Documentation
 
 * [CLI Mode](docs/cli-mode.md)
-* [Interactive Mode](docs/interactive-mode.md)
 * [Environment Specific Variables](docs/env-specific-variables.md)
 * [Resource Propagation](docs/resource-propagation.md)

--- a/docs/cli-mode.md
+++ b/docs/cli-mode.md
@@ -4,7 +4,7 @@ The CLI mode can be used for bulk resource management.
 Usages:
 * Export all/selected resources from a WSO2 IS to a local directory.
 * Import all/selected resources from a local directory to a WSO2 IS.
-* Propagate resources across multiple environments.
+* Promote resources across multiple environments.
 * Deploy new resources from resource configuration files to a WSO2 IS.
 * Have a backup of resources in a local directory.
 

--- a/iamctl/cmd/interactive/README.md
+++ b/iamctl/cmd/interactive/README.md
@@ -6,7 +6,7 @@ The interactive mode can be used to handle application configurations in an inte
 
 See the topics given below to run the tool in interactive mode.
 #### Tool initialization
-1. Set up the tool and WSO2 IS following the steps in the [How to run the tool ](../README.md##How to run the tool ) section.
+1. Set up the tool and WSO2 IS following the steps in the [How to run the tool ](../../../README.md##How to run the tool ) section.
 2. Run the following command to initialize the tool by providing details of WSO2 IS and the client ID/secret of the app you created.
 ```
 iamctl init


### PR DESCRIPTION
Remove interactive mode section from the main README file since that mode is no longer used. The Interative mode related file is moved inside the iamctl/cmd/interactive folder from mains do