### PR TITLE
Extend IAM CLI to support B2B use cases

### DIFF
--- a/iamctl/cmd/cli/setupCLI.go
+++ b/iamctl/cmd/cli/setupCLI.go
@@ -35,6 +35,7 @@ var serverConfigTemplate = map[string]string{
 	utils.CLIENT_ID_CONFIG:     "",
 	utils.CLIENT_SECRET_CONFIG: "",
 	utils.TENANT_DOMAIN_CONFIG: "",
+	utils.ORGANIZATION_CONFIG: "",
 }
 
 var setupCmd = &cobra.Command{

--- a/iamctl/pkg/claims/export.go
+++ b/iamctl/pkg/claims/export.go
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+* Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
 *
 * WSO2 LLC. licenses this file to you under the Apache License,
 * Version 2.0 (the "License"); you may not use this file except
@@ -33,6 +33,10 @@ func ExportAll(exportFilePath string, format string) {
 
 	// Export all claim dialects with related claims.
 	log.Println("Exporting claims...")
+	if utils.IsSubOrganization() {
+		log.Println("Exporting claims for sub organization not supported.")
+		return
+	}
 	exportFilePath = filepath.Join(exportFilePath, utils.CLAIMS)
 
 	if utils.IsResourceTypeExcluded(utils.CLAIMS) {

--- a/iamctl/pkg/claims/import.go
+++ b/iamctl/pkg/claims/import.go
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+* Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
 *
 * WSO2 LLC. licenses this file to you under the Apache License,
 * Version 2.0 (the "License"); you may not use this file except
@@ -33,6 +33,10 @@ import (
 func ImportAll(inputDirPath string) {
 
 	log.Println("Importing claims...")
+	if utils.IsSubOrganization() {
+		log.Println("Importing claims for sub organization not supported.")
+		return
+	}
 	importFilePath := filepath.Join(inputDirPath, utils.CLAIMS)
 
 	if utils.IsResourceTypeExcluded(utils.CLAIMS) {

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+* Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
 *
 * WSO2 LLC. licenses this file to you under the Apache License,
 * Version 2.0 (the "License"); you may not use this file except
@@ -289,7 +289,12 @@ func getResourcePath(resourceType string) string {
 
 func getResourceBaseUrl(resourceType string) string {
 
-	return SERVER_CONFIGS.ServerUrl + "/t/" + SERVER_CONFIGS.TenantDomain + "/api/server/v1/" + getResourcePath(resourceType) + "/"
+	basePath := "/t/" + SERVER_CONFIGS.TenantDomain
+	if IsSubOrganization() {
+		basePath += "/o"
+	}
+	basePath += "/api/server/v1/" + getResourcePath(resourceType) + "/"
+	return SERVER_CONFIGS.ServerUrl + basePath
 }
 
 func buildRequestUrl(requestType, resourceType, resourceId string) (reqUrl string) {

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -1,5 +1,5 @@
 /**
-* Copyright (c) 2023, WSO2 LLC. (https://www.wso2.com) All Rights Reserved.
+* Copyright (c) 2023-2025, WSO2 LLC. (https://www.wso2.com).
 *
 * WSO2 LLC. licenses this file to you under the Apache License,
 * Version 2.0 (the "License"); you may not use this file except
@@ -15,7 +15,7 @@
 * specific language governing permissions and limitations
 * under the License.
  */
-
+ 
 package utils
 
 // Resource type configs
@@ -38,6 +38,7 @@ const SERVER_URL_CONFIG = "SERVER_URL"
 const CLIENT_ID_CONFIG = "CLIENT_ID"
 const CLIENT_SECRET_CONFIG = "CLIENT_SECRET"
 const TENANT_DOMAIN_CONFIG = "TENANT_DOMAIN"
+const ORGANIZATION_CONFIG = "ORGANIZATION"
 const TOOL_CONFIG_PATH = "TOOL_CONFIG_PATH"
 const KEYWORD_CONFIG_PATH = "KEYWORD_CONFIG_PATH"
 const TOKEN_CONFIG = "TOKEN"

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -1,19 +1,19 @@
-/*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
- *
- * WSO2 Inc. licenses this file to you under the Apache License,
- * Version 2.0 (the "License"); you may not use this file except
- * in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+/**
+* Copyright (c) 2020-2025, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
  */
 
 package utils
@@ -30,7 +30,7 @@ var dir, _ = os.Getwd()
 var Path = dir + "/iamctl.json"
 var PathSampleSPDetails = dir + "/init.json"
 
-const SCOPE string = "internal_application_mgt_update internal_application_mgt_create internal_application_mgt_view internal_application_mgt_delete internal_idp_update internal_idp_create internal_idp_view internal_idp_delete internal_userstore_view internal_userstore_create internal_userstore_update internal_userstore_delete internal_claim_meta_create internal_claim_meta_view internal_claim_meta_update internal_claim_meta_delete"
+const SCOPE string = "internal_application_mgt_update internal_application_mgt_create internal_application_mgt_view internal_application_mgt_delete internal_idp_update internal_idp_create internal_idp_view internal_idp_delete internal_userstore_view internal_userstore_create internal_userstore_update internal_userstore_delete internal_claim_meta_create internal_claim_meta_view internal_claim_meta_update internal_claim_meta_delete internal_org_idp_delete internal_org_idp_view internal_org_idp_update internal_org_idp_create internal_org_claim_meta_update internal_org_claim_meta_view internal_org_application_mgt_update internal_org_application_mgt_create internal_org_application_mgt_view internal_org_application_mgt_delete internal_org_userstore_create internal_org_userstore_view internal_org_userstore_delete internal_org_userstore_update"
 
 const (
 	AppName       = "IAM-CTL"


### PR DESCRIPTION
**Demo**: https://github.com/wso2/product-is/issues/23809#issuecomment-2985128949

## Purpose
Public issue: https://github.com/wso2/product-is/issues/23809

Currently the tool can be used to handle bulk configurations between target environments. With this change it can be used to **transfer resources across sub organisations.**

Currently resources can be created in the parent organization and shared with the sub organisations, but any resources created within a sub organization cannot be shared to another sibling organization.

Currently, the supported resource types are: **Applications, Identity Providers, and User Stores** 

## Approach
Add the organization ID in the server config. For example: 
```
{
    "CLIENT_ID":"tXMZQQhquWK5RsdZKw_87POqGjQa",
    "CLIENT_SECRET":"FIPC_4a53jq7Mb4Nt48Vfpc1Kqf9B8KX0tWtuJY1Rswa",
    "SERVER_URL":"https://localhost:9443",
    "TENANT_DOMAIN":"carbon.super",
    "ORGANIZATION":"d04f6218-3b51-4073-b5b0-ef859755c0fe"
}
```
If the ORGANIZATION config is defined, it is assumed that the API calls will be called against a sub organization. The access token will be switched with the organization access token and the API calls will be called through the `/o` path.