### PR TITLE
feat: Add cross-resource reference handling utilities

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -30,8 +30,8 @@ import (
 
 var exportAllCmd = &cobra.Command{
 	Use:   "exportAll",
-	Short: "Export all applications",
-	Long:  `You can export all applications available in the target environment`,
+	Short: "Export all resources",
+	Long:  `You can export all resources available in the target environment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		outputDirPath, _ := cmd.Flags().GetString("outputDir")
 		format, _ := cmd.Flags().GetString("format")
@@ -42,10 +42,18 @@ var exportAllCmd = &cobra.Command{
 			outputDirPath = baseDir
 		}
 
-		claims.ExportAll(outputDirPath, format)
-		identityproviders.ExportAll(outputDirPath, format)
-		applications.ExportAll(outputDirPath, format)
-		userstores.ExportAll(outputDirPath, format)
+		exportFunctions := map[utils.ResourceType]func(string, string){
+			utils.CLAIMS:             claims.ExportAll,
+			utils.IDENTITY_PROVIDERS: identityproviders.ExportAll,
+			utils.APPLICATIONS:       applications.ExportAll,
+			utils.USERSTORES:         userstores.ExportAll,
+		}
+
+		for _, resourceType := range utils.ResourceOrder {
+			if exportFunc, exists := exportFunctions[resourceType]; exists {
+				exportFunc(outputDirPath, format)
+			}
+		}
 
 		utils.PrintSummary(utils.EXPORT)
 	},

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -30,8 +30,8 @@ import (
 
 var importAllCmd = &cobra.Command{
 	Use:   "importAll",
-	Short: "Import all applications",
-	Long:  `You can import all applications to the target environment`,
+	Short: "Import all resources",
+	Long:  `You can import all resources to the target environment`,
 	Run: func(cmd *cobra.Command, args []string) {
 		inputDirPath, _ := cmd.Flags().GetString("inputDir")
 		configFile, _ := cmd.Flags().GetString("config")
@@ -41,10 +41,18 @@ var importAllCmd = &cobra.Command{
 			inputDirPath = baseDir
 		}
 
-		claims.ImportAll(inputDirPath)
-		identityproviders.ImportAll(inputDirPath)
-		applications.ImportAll(inputDirPath)
-		userstores.ImportAll(inputDirPath)
+		importFunctions := map[utils.ResourceType]func(string){
+			utils.CLAIMS:             claims.ImportAll,
+			utils.IDENTITY_PROVIDERS: identityproviders.ImportAll,
+			utils.APPLICATIONS:       applications.ImportAll,
+			utils.USERSTORES:         userstores.ImportAll,
+		}
+
+		for _, resourceType := range utils.ResourceOrder {
+			if importFunc, exists := importFunctions[resourceType]; exists {
+				importFunc(inputDirPath)
+			}
+		}
 
 		utils.PrintSummary(utils.IMPORT)
 	},

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -33,7 +33,7 @@ func ExportAll(exportFilePath string, format string) {
 
 	// Export all applications to the Applications folder.
 	log.Println("Exporting applications...")
-	exportFilePath = filepath.Join(exportFilePath, utils.APPLICATIONS)
+	exportFilePath = filepath.Join(exportFilePath, utils.APPLICATIONS.String())
 
 	if utils.IsResourceTypeExcluded(utils.APPLICATIONS) {
 		return

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -33,7 +33,7 @@ import (
 func ImportAll(inputDirPath string) {
 
 	log.Println("Importing applications...")
-	importFilePath := filepath.Join(inputDirPath, utils.APPLICATIONS)
+	importFilePath := filepath.Join(inputDirPath, utils.APPLICATIONS.String())
 
 	if utils.IsResourceTypeExcluded(utils.APPLICATIONS) {
 		return

--- a/iamctl/pkg/claims/export.go
+++ b/iamctl/pkg/claims/export.go
@@ -37,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 		log.Println("Exporting claims for sub organization not supported.")
 		return
 	}
-	exportFilePath = filepath.Join(exportFilePath, utils.CLAIMS)
+	exportFilePath = filepath.Join(exportFilePath, utils.CLAIMS.String())
 
 	if utils.IsResourceTypeExcluded(utils.CLAIMS) {
 		return

--- a/iamctl/pkg/claims/import.go
+++ b/iamctl/pkg/claims/import.go
@@ -37,7 +37,7 @@ func ImportAll(inputDirPath string) {
 		log.Println("Importing claims for sub organization not supported.")
 		return
 	}
-	importFilePath := filepath.Join(inputDirPath, utils.CLAIMS)
+	importFilePath := filepath.Join(inputDirPath, utils.CLAIMS.String())
 
 	if utils.IsResourceTypeExcluded(utils.CLAIMS) {
 		return

--- a/iamctl/pkg/identityProviders/export.go
+++ b/iamctl/pkg/identityProviders/export.go
@@ -33,7 +33,7 @@ func ExportAll(exportFilePath string, format string) {
 
 	// Export all identity providers to the IdentityProviders folder.
 	log.Println("Exporting identity providers...")
-	exportFilePath = filepath.Join(exportFilePath, utils.IDENTITY_PROVIDERS)
+	exportFilePath = filepath.Join(exportFilePath, utils.IDENTITY_PROVIDERS.String())
 
 	if utils.IsResourceTypeExcluded(utils.IDENTITY_PROVIDERS) {
 		return

--- a/iamctl/pkg/identityProviders/import.go
+++ b/iamctl/pkg/identityProviders/import.go
@@ -33,7 +33,7 @@ import (
 func ImportAll(inputDirPath string) {
 
 	log.Println("Importing identity providers...")
-	importFilePath := filepath.Join(inputDirPath, utils.IDENTITY_PROVIDERS)
+	importFilePath := filepath.Join(inputDirPath, utils.IDENTITY_PROVIDERS.String())
 
 	if utils.IsResourceTypeExcluded(utils.IDENTITY_PROVIDERS) {
 		return

--- a/iamctl/pkg/userStores/export.go
+++ b/iamctl/pkg/userStores/export.go
@@ -34,7 +34,7 @@ func ExportAll(exportFilePath string, format string) {
 
 	// Export all userstores to the UserStores folder.
 	log.Println("Exporting user stores...")
-	exportFilePath = filepath.Join(exportFilePath, utils.USERSTORES)
+	exportFilePath = filepath.Join(exportFilePath, utils.USERSTORES.String())
 
 	if utils.IsResourceTypeExcluded(utils.USERSTORES) {
 		return

--- a/iamctl/pkg/userStores/import.go
+++ b/iamctl/pkg/userStores/import.go
@@ -32,7 +32,7 @@ import (
 func ImportAll(inputDirPath string) {
 
 	log.Println("Importing user stores...")
-	importFilePath := filepath.Join(inputDirPath, utils.USERSTORES)
+	importFilePath := filepath.Join(inputDirPath, utils.USERSTORES.String())
 
 	if utils.IsResourceTypeExcluded(utils.USERSTORES) {
 		return

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -43,7 +43,7 @@ const GET = "get"
 const POST = "post"
 const PUT = "put"
 
-func PrepareJSONRequestBody(data []byte, format Format, resourceType string, excludeFields ...string) ([]byte, error) {
+func PrepareJSONRequestBody(data []byte, format Format, resourceType ResourceType, excludeFields ...string) ([]byte, error) {
 
 	parsed, err := Deserialize(data, format, resourceType)
 	if err != nil {
@@ -70,7 +70,7 @@ func PrepareJSONRequestBody(data []byte, format Format, resourceType string, exc
 	return jsonBody, nil
 }
 
-func SendExportRequest(resourceId, fileType, resourceType string, excludeSecrets bool) (resp *http.Response, err error) {
+func SendExportRequest(resourceId, fileType string, resourceType ResourceType, excludeSecrets bool) (resp *http.Response, err error) {
 
 	reqUrl := buildRequestUrl(EXPORT, resourceType, resourceId)
 	req, err := http.NewRequest("GET", reqUrl, strings.NewReader(""))
@@ -114,7 +114,7 @@ func SendExportRequest(resourceId, fileType, resourceType string, excludeSecrets
 	return resp, fmt.Errorf("unexpected error while exporting the resource with status code: %s", strconv.FormatInt(int64(statusCode), 10))
 }
 
-func SendImportRequest(importFilePath, fileData, resourceType string) error {
+func SendImportRequest(importFilePath, fileData string, resourceType ResourceType) error {
 
 	reqUrl := buildRequestUrl(IMPORT, resourceType, "")
 
@@ -178,7 +178,7 @@ func SendImportRequest(importFilePath, fileData, resourceType string) error {
 	return fmt.Errorf("unexpected error when importing resource: %s", resp.Status)
 }
 
-func SendUpdateRequest(resourceId, importFilePath, fileData, resourceType string) error {
+func SendUpdateRequest(resourceId, importFilePath, fileData string, resourceType ResourceType) error {
 
 	reqUrl := buildRequestUrl(UPDATE, resourceType, resourceId)
 	formattedReqUrl := addQueryParams(reqUrl, resourceType)
@@ -246,7 +246,7 @@ func SendUpdateRequest(resourceId, importFilePath, fileData, resourceType string
 	return fmt.Errorf("unexpected error when importing resource: %s", resp.Status)
 }
 
-func SendDeleteRequest(resourceId string, resourceType string) error {
+func SendDeleteRequest(resourceId string, resourceType ResourceType) error {
 
 	reqUrl := buildRequestUrl(DELETE, resourceType, resourceId)
 	request, err := http.NewRequest("DELETE", reqUrl, bytes.NewBuffer(nil))
@@ -279,7 +279,7 @@ func SendDeleteRequest(resourceId string, resourceType string) error {
 	return fmt.Errorf("unexpected error when deleting resource: %s", resp.Status)
 }
 
-func SendGetRequest(resourceType, resourceId string) (interface{}, error) {
+func SendGetRequest(resourceType ResourceType, resourceId string) (interface{}, error) {
 
 	reqUrl := buildRequestUrl(GET, resourceType, resourceId)
 	request, err := http.NewRequest("GET", reqUrl, nil)
@@ -324,7 +324,7 @@ func SendGetRequest(resourceType, resourceId string) (interface{}, error) {
 	return data, nil
 }
 
-func SendPostRequest(resourceType string, requestBody []byte) (*http.Response, error) {
+func SendPostRequest(resourceType ResourceType, requestBody []byte) (*http.Response, error) {
 
 	reqUrl := buildRequestUrl(POST, resourceType, "")
 	request, err := http.NewRequest("POST", reqUrl, bytes.NewBuffer(requestBody))
@@ -359,7 +359,7 @@ func SendPostRequest(resourceType string, requestBody []byte) (*http.Response, e
 	return resp, nil
 }
 
-func SendPutRequest(resourceType, resourceId string, requestBody []byte) (*http.Response, error) {
+func SendPutRequest(resourceType ResourceType, resourceId string, requestBody []byte) (*http.Response, error) {
 
 	reqUrl := buildRequestUrl(PUT, resourceType, resourceId)
 	request, err := http.NewRequest("PUT", reqUrl, bytes.NewBuffer(requestBody))
@@ -394,7 +394,7 @@ func SendPutRequest(resourceType, resourceId string, requestBody []byte) (*http.
 	return resp, nil
 }
 
-func SendGetListRequest(resourceType string, resourceLimit int) (*http.Response, error) {
+func SendGetListRequest(resourceType ResourceType, resourceLimit int) (*http.Response, error) {
 
 	var reqUrl = buildRequestUrl(LIST, resourceType, "")
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
@@ -418,7 +418,7 @@ func SendGetListRequest(resourceType string, resourceLimit int) (*http.Response,
 	return resp, nil
 }
 
-func getResourcePath(resourceType string) string {
+func getResourcePath(resourceType ResourceType) string {
 
 	switch resourceType {
 	case APPLICATIONS:
@@ -433,7 +433,7 @@ func getResourcePath(resourceType string) string {
 	return ""
 }
 
-func getResourceBaseUrl(resourceType string) string {
+func getResourceBaseUrl(resourceType ResourceType) string {
 
 	basePath := "/t/" + SERVER_CONFIGS.TenantDomain
 	if IsSubOrganization() {
@@ -443,7 +443,7 @@ func getResourceBaseUrl(resourceType string) string {
 	return SERVER_CONFIGS.ServerUrl + basePath
 }
 
-func buildRequestUrl(requestType, resourceType, resourceId string) (reqUrl string) {
+func buildRequestUrl(requestType string, resourceType ResourceType, resourceId string) (reqUrl string) {
 
 	switch requestType {
 	case EXPORT:
@@ -474,7 +474,7 @@ func buildRequestUrl(requestType, resourceType, resourceId string) (reqUrl strin
 	return reqUrl
 }
 
-func addQueryParams(reqURL, resourceType string) string {
+func addQueryParams(reqURL string, resourceType ResourceType) string {
 
 	url, err := url.Parse(reqURL)
 	if err != nil {

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -44,10 +44,14 @@ const KEYWORD_CONFIG_PATH = "KEYWORD_CONFIG_PATH"
 const TOKEN_CONFIG = "TOKEN"
 
 // Resource types
-const APPLICATIONS = "Applications"
-const IDENTITY_PROVIDERS = "IdentityProviders"
-const CLAIMS = "Claims"
-const USERSTORES = "UserStores"
+type ResourceType string
+
+const (
+	APPLICATIONS       ResourceType = "Applications"
+	IDENTITY_PROVIDERS ResourceType = "IdentityProviders"
+	CLAIMS             ResourceType = "Claims"
+	USERSTORES         ResourceType = "UserStores"
+)
 
 // Config file names
 const SERVER_CONFIG_FILE = "serverConfig.json"

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -78,6 +78,7 @@ const RESIDENT_IDP_NAME = "LOCAL"
 const CONSOLE = "Console"
 const MY_ACCOUNT = "My Account"
 const OAUTH2 = "oauth2"
+const ALL_ITEMS = "all_items" // Wildcard to match all elements in an array
 
 // Error codes
 var ErrorCodes = map[int]string{
@@ -135,3 +136,19 @@ var claimArrayIdentifiers = map[string]string{
 	"attributeMapping": "mappedAttribute",
 	"claims":           "id",
 }
+
+type ResourceIdentifierMeta struct {
+	IdentifierPath  string // Path to the ID field in the resource object
+	UniqueValuePath string // Path to the unique identifier field
+}
+
+type ResourceReferenceMeta struct {
+	ReferencedResourceType ResourceType // The resource type being referenced
+	ReferencePaths         []string     // Paths to where the referenced resource's ID appears
+}
+
+// Maps resource types to their identifier metadata.
+var RESOURCE_IDENTIFIER_METADATA = map[ResourceType]ResourceIdentifierMeta{}
+
+// Maps resource types to the resources they reference.
+var RESOURCE_REFERENCE_METADATA = map[ResourceType][]ResourceReferenceMeta{}

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -396,3 +396,10 @@ func ReplacePlaceholders(configFile []byte) []byte {
 	}
 	return []byte(configStr)
 }
+
+func extendPath(base, segment string) string {
+	if base == "" {
+		return segment
+	}
+	return base + "." + segment
+}

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -44,7 +44,7 @@ func ReplaceKeywords(fileContent string, keywordMapping map[string]interface{}) 
 	return fileContent
 }
 
-func ProcessExportedData(exportedData interface{}, localFilePath string, format Format, keywordMapping map[string]interface{}, resourceType string) (interface{}, error) {
+func ProcessExportedData(exportedData interface{}, localFilePath string, format Format, keywordMapping map[string]interface{}, resourceType ResourceType) (interface{}, error) {
 
 	localFileContent, err := ioutil.ReadFile(localFilePath)
 	if err != nil {
@@ -62,7 +62,7 @@ func ProcessExportedData(exportedData interface{}, localFilePath string, format 
 	return modifiedData, nil
 }
 
-func ProcessExportedContent(exportedFileName string, exportedFileContent []byte, keywordMapping map[string]interface{}, resourceType string) ([]byte, error) {
+func ProcessExportedContent(exportedFileName string, exportedFileContent []byte, keywordMapping map[string]interface{}, resourceType ResourceType) ([]byte, error) {
 
 	format, err := FormatFromExtension(filepath.Ext(exportedFileName))
 	if err != nil {
@@ -100,11 +100,11 @@ func ProcessExportedContent(exportedFileName string, exportedFileContent []byte,
 
 // Adds local keywords for exported content specifically in YAML format.
 // Use AddLocalKeywords for granular control over different formats.
-func AddKeywords(exportedYaml interface{}, localFileContent []byte, keywordMapping map[string]interface{}, resourceType string) (interface{}, error) {
+func AddKeywords(exportedYaml interface{}, localFileContent []byte, keywordMapping map[string]interface{}, resourceType ResourceType) (interface{}, error) {
 	return AddLocalKeywords(exportedYaml, FormatYAML, localFileContent, keywordMapping, resourceType)
 }
 
-func AddLocalKeywords(exportedData interface{}, format Format, localFileContent []byte, keywordMapping map[string]interface{}, resourceType string) (interface{}, error) {
+func AddLocalKeywords(exportedData interface{}, format Format, localFileContent []byte, keywordMapping map[string]interface{}, resourceType ResourceType) (interface{}, error) {
 
 	localData, err := Deserialize(localFileContent, format, resourceType)
 	if err != nil || localData == nil {
@@ -120,7 +120,7 @@ func AddLocalKeywords(exportedData interface{}, format Format, localFileContent 
 	return exportedData, nil
 }
 
-func GetKeywordLocations(fileData interface{}, path []string, keywordMapping map[string]interface{}, resourceType string) []string {
+func GetKeywordLocations(fileData interface{}, path []string, keywordMapping map[string]interface{}, resourceType ResourceType) []string {
 
 	var keys []string
 	switch v := fileData.(type) {
@@ -162,7 +162,7 @@ func GetKeywordLocations(fileData interface{}, path []string, keywordMapping map
 	return keys
 }
 
-func GetArrayIdentifiers(resourceType string) map[string]string {
+func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 
 	switch resourceType {
 	case APPLICATIONS:

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package utils
+
+/*
+* ResourceOrder defines the sequence in which resources should be processed during
+* export and import operations.
+*
+* IMPORTANT: This order is critical because some resources may have dependencies on others.
+ */
+var ResourceOrder = []ResourceType{
+	CLAIMS,
+	IDENTITY_PROVIDERS,
+	USERSTORES,
+	APPLICATIONS,
+}

--- a/iamctl/pkg/utils/resourceProperties.go
+++ b/iamctl/pkg/utils/resourceProperties.go
@@ -26,6 +26,10 @@ import (
 	"strings"
 )
 
+func (rt ResourceType) String() string {
+	return string(rt)
+}
+
 func IsResourceExcluded(resourceName string, resourceConfigs map[string]interface{}) bool {
 
 	// Include only the resources added to INCLUDE_ONLY config. Note: INCLUDE_ONLY config overrides the EXCLUDE config.
@@ -53,12 +57,12 @@ func IsResourceExcluded(resourceName string, resourceConfigs map[string]interfac
 	}
 }
 
-func IsResourceTypeExcluded(resourceType string) bool {
+func IsResourceTypeExcluded(resourceType ResourceType) bool {
 
 	// Include only the resource types added to INCLUDE_ONLY config. Note: INCLUDE_ONLY config overrides the EXCLUDE config.
 	if len(TOOL_CONFIGS.IncludeOnly) > 0 {
 		for _, resource := range TOOL_CONFIGS.IncludeOnly {
-			if resource == resourceType {
+			if resource == resourceType.String() {
 				return false
 			}
 		}
@@ -67,7 +71,7 @@ func IsResourceTypeExcluded(resourceType string) bool {
 	} else if len(TOOL_CONFIGS.Exclude) > 0 {
 		// Exclude resource types added to EXCLUDE config.
 		for _, resource := range TOOL_CONFIGS.Exclude {
-			if resource == resourceType {
+			if resource == resourceType.String() {
 				log.Println("Skipping Excluded resource: " + resourceType)
 				return true
 			}

--- a/iamctl/pkg/utils/resourceReferenceUtils.go
+++ b/iamctl/pkg/utils/resourceReferenceUtils.go
@@ -142,7 +142,7 @@ func ReplaceArrayReferences(arrayVal []interface{}, identifierMap map[string]str
 
 		newValue, exists := identifierMap[strElem]
 		if !exists {
-			return nil, fmt.Errorf("referenced resource with identifier '%s' has not been exported'", strElem)
+			return nil, fmt.Errorf("referenced resource with identifier '%s' has not been exported", strElem)
 		}
 		newArray[i] = newValue
 	}

--- a/iamctl/pkg/utils/resourceReferenceUtils.go
+++ b/iamctl/pkg/utils/resourceReferenceUtils.go
@@ -1,0 +1,221 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package utils
+
+import (
+	"fmt"
+	"log"
+	"strings"
+)
+
+type ResourceIdentifierMap map[ResourceType]map[string]string
+
+var resourceIdentifierMap = make(ResourceIdentifierMap)
+
+func AddToResourceIdentifierMap(resourceType ResourceType, resourceData interface{}, operation string) error {
+
+	resourceMeta, exists := RESOURCE_IDENTIFIER_METADATA[resourceType]
+	if !exists {
+		return nil
+	}
+
+	idValue := GetValue(resourceData, resourceMeta.IdentifierPath)
+	uniqueValue := GetValue(resourceData, resourceMeta.UniqueValuePath)
+
+	if idValue == "" || uniqueValue == "" {
+		log.Println("Warning: Could not extract identifier or unique value. Skipping resource identifier map entry.")
+		return nil
+	}
+
+	if resourceIdentifierMap[resourceType] == nil {
+		resourceIdentifierMap[resourceType] = make(map[string]string)
+	}
+
+	switch operation {
+	case EXPORT:
+		resourceIdentifierMap[resourceType][idValue] = uniqueValue
+	case IMPORT:
+		resourceIdentifierMap[resourceType][uniqueValue] = idValue
+	}
+
+	return nil
+}
+
+func ReplaceReferences(resourceType ResourceType, resourceData interface{}) (interface{}, error) {
+
+	references, exists := RESOURCE_REFERENCE_METADATA[resourceType]
+	if !exists || len(references) == 0 {
+		return resourceData, nil
+	}
+
+	for _, refData := range references {
+		referencedType := refData.ReferencedResourceType
+		identifierMap := resourceIdentifierMap[referencedType]
+
+		for _, refPath := range refData.ReferencePaths {
+			err := replaceReferenceValue(resourceData, refPath, identifierMap)
+			if err != nil {
+				return nil, fmt.Errorf("error replacing references for referenced type %s: %w", referencedType, err)
+			}
+		}
+	}
+
+	return resourceData, nil
+}
+
+func replaceReferenceValue(resourceData interface{}, refPath string, identifierMap map[string]string) error {
+
+	concretePaths, err := ResolveAllItemsPaths(resourceData, refPath)
+	if err != nil {
+		return fmt.Errorf("error resolving paths for '%s': %w", refPath, err)
+	}
+
+	for _, path := range concretePaths {
+		err := ReplaceValueAtPath(resourceData, path, identifierMap)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func ReplaceValueAtPath(resourceData interface{}, path string, identifierMap map[string]string) error {
+
+	rawValue := getRawValue(resourceData, path)
+	if rawValue == nil {
+		return nil
+	}
+
+	switch v := rawValue.(type) {
+	case string:
+		if v == "" {
+			return nil
+		}
+		newValue, exists := identifierMap[v]
+		if !exists {
+			return fmt.Errorf("referenced resource with identifier '%s' has not been exported", v)
+		}
+		ReplaceValue(resourceData, path, newValue)
+	case []interface{}:
+		newArray, err := ReplaceArrayReferences(v, identifierMap, path)
+		if err != nil {
+			return err
+		}
+		ReplaceRawValue(resourceData, path, newArray)
+	default:
+		return fmt.Errorf("unexpected value type %T at path '%s': expected string or string array", rawValue, path)
+	}
+
+	return nil
+}
+
+func ReplaceArrayReferences(arrayVal []interface{}, identifierMap map[string]string, refPath string) ([]interface{}, error) {
+
+	newArray := make([]interface{}, len(arrayVal))
+
+	for i, elem := range arrayVal {
+		strElem, ok := elem.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string array at path '%s' but found an element of type %T", refPath, elem)
+		}
+		if strElem == "" {
+			newArray[i] = strElem
+			continue
+		}
+
+		newValue, exists := identifierMap[strElem]
+		if !exists {
+			return nil, fmt.Errorf("referenced resource with identifier '%s' has not been exported'", strElem)
+		}
+		newArray[i] = newValue
+	}
+
+	return newArray, nil
+}
+
+func ResolveAllItemsPaths(data interface{}, pathString string) ([]string, error) {
+
+	if !containsAllItemsWildcard(pathString) {
+		return []string{pathString}, nil
+	}
+
+	return expandAllItemsPaths(data, GetPathKeys(pathString), "")
+}
+
+func expandAllItemsPaths(data interface{}, parts []string, prefix string) ([]string, error) {
+
+	if len(parts) == 0 {
+		return []string{prefix}, nil
+	}
+	part := parts[0]
+	rest := parts[1:]
+
+	if containsAllItemsWildcard(part) {
+		// data at this point must be an array
+		arr, ok := data.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("expected array for value at ALL_ITEMS wildcard path '%s'", prefix)
+		}
+
+		keyName := strings.SplitN(part[1:len(part)-1], "=", 2)[0]
+		remainingPath := strings.Join(rest, ".")
+		hasMoreWildcards := containsAllItemsWildcard(remainingPath)
+
+		var allPaths []string
+		for _, elem := range arr {
+			keyVal := GetValue(elem, keyName)
+			if keyVal == "" {
+				return nil, fmt.Errorf("could not find key '%s' in array element at path '%s'", keyName, prefix)
+			}
+			concretePrefix := extendPath(prefix, fmt.Sprintf("[%s=%s]", keyName, keyVal))
+
+			if hasMoreWildcards {
+				subPaths, err := expandAllItemsPaths(elem, rest, concretePrefix)
+				if err != nil {
+					return nil, err
+				}
+				allPaths = append(allPaths, subPaths...)
+			} else {
+				if remainingPath == "" {
+					allPaths = append(allPaths, concretePrefix)
+				} else {
+					allPaths = append(allPaths, concretePrefix+"."+remainingPath)
+				}
+			}
+		}
+
+		return allPaths, nil
+	}
+
+	var nextData interface{}
+	switch v := data.(type) {
+	case map[interface{}]interface{}:
+		nextData = v[part]
+	case map[string]interface{}:
+		nextData = v[part]
+	}
+
+	return expandAllItemsPaths(nextData, rest, extendPath(prefix, part))
+}
+
+func containsAllItemsWildcard(pathString string) bool {
+
+	return strings.Contains(pathString, "="+ALL_ITEMS+"]")
+}

--- a/iamctl/pkg/utils/resourceReferenceUtils.go
+++ b/iamctl/pkg/utils/resourceReferenceUtils.go
@@ -219,3 +219,13 @@ func containsAllItemsWildcard(pathString string) bool {
 
 	return strings.Contains(pathString, "="+ALL_ITEMS+"]")
 }
+
+func ResetResourceIdentifierMap() {
+
+	resourceIdentifierMap = make(ResourceIdentifierMap)
+}
+
+func GetResourceIdentifierMap(resourceType ResourceType) map[string]string {
+
+	return resourceIdentifierMap[resourceType]
+}

--- a/iamctl/pkg/utils/serializationUtils.go
+++ b/iamctl/pkg/utils/serializationUtils.go
@@ -65,7 +65,7 @@ func FormatFromString(format string) Format {
 	}
 }
 
-func Serialize(data interface{}, format Format, resourceType string) ([]byte, error) {
+func Serialize(data interface{}, format Format, resourceType ResourceType) ([]byte, error) {
 
 	switch format {
 	case FormatYAML:
@@ -92,7 +92,7 @@ func Serialize(data interface{}, format Format, resourceType string) ([]byte, er
 	}
 }
 
-func Deserialize(data []byte, format Format, resourceType string) (interface{}, error) {
+func Deserialize(data []byte, format Format, resourceType ResourceType) (interface{}, error) {
 
 	switch format {
 	case FormatYAML:
@@ -153,13 +153,13 @@ func XMLToMap(data []byte) (map[string]interface{}, error) {
 	return m, nil
 }
 
-func GetXMLRootTag(resourceType string) string {
+func GetXMLRootTag(resourceType ResourceType) string {
 
-	xmlRootTags := map[string]string{}
+	xmlRootTags := map[ResourceType]string{}
 	return xmlRootTags[resourceType]
 }
 
-func AddXMLRootTag(data map[string]interface{}, resourceType string) map[string]interface{} {
+func AddXMLRootTag(data map[string]interface{}, resourceType ResourceType) map[string]interface{} {
 
 	xmlRootTag := GetXMLRootTag(resourceType)
 	if xmlRootTag != "" {
@@ -168,7 +168,7 @@ func AddXMLRootTag(data map[string]interface{}, resourceType string) map[string]
 	return data
 }
 
-func RemoveXMLRootTag(xmlMap map[string]interface{}, resourceType string) (interface{}, error) {
+func RemoveXMLRootTag(xmlMap map[string]interface{}, resourceType ResourceType) (interface{}, error) {
 
 	xmlRootTag := GetXMLRootTag(resourceType)
 	if xmlRootTag == "" {
@@ -182,7 +182,7 @@ func RemoveXMLRootTag(xmlMap map[string]interface{}, resourceType string) (inter
 	return nil, fmt.Errorf("expected root element <%s> not found in XML", xmlRootTag)
 }
 
-func GetArrayFieldPaths(resourceType string) []string {
+func GetArrayFieldPaths(resourceType ResourceType) []string {
 
 	switch resourceType {
 	default:
@@ -190,7 +190,7 @@ func GetArrayFieldPaths(resourceType string) []string {
 	}
 }
 
-func FixArrayFields(data interface{}, resourceType string) interface{} {
+func FixArrayFields(data interface{}, resourceType ResourceType) interface{} {
 
 	arrayPaths := GetArrayFieldPaths(resourceType)
 

--- a/iamctl/pkg/utils/summaryUtils.go
+++ b/iamctl/pkg/utils/summaryUtils.go
@@ -89,7 +89,7 @@ func PrintImportSummary() {
 		if summary.Failed > 0 {
 			PrintFailedResources(summary)
 		}
-		if summary.ResourceType == APPLICATIONS {
+		if summary.ResourceType == APPLICATIONS.String() {
 			printNewSecretApplications(summary)
 		}
 	}
@@ -132,27 +132,27 @@ func AddNewSecretIndicatorToSummary(appName string) {
 
 	InitializeResourceSummary()
 
-	summary, ok := ResourceSummaries[APPLICATIONS]
+	summary, ok := ResourceSummaries[APPLICATIONS.String()]
 	if !ok {
 		summary = ResourceSummary{
-			ResourceType: APPLICATIONS,
+			ResourceType: APPLICATIONS.String(),
 		}
 	}
 	summary.SecretGeneratedApplications = append(summary.SecretGeneratedApplications, appName)
-	ResourceSummaries[APPLICATIONS] = summary
+	ResourceSummaries[APPLICATIONS.String()] = summary
 }
 
-func UpdateSuccessSummary(resourceType string, operation string) {
+func UpdateSuccessSummary(resourceType ResourceType, operation string) {
 
 	InitializeResourceSummary()
 
 	SummaryData.TotalRequests++
 	SummaryData.SuccessfulOperations++
 
-	summary, ok := ResourceSummaries[resourceType]
+	summary, ok := ResourceSummaries[resourceType.String()]
 	if !ok {
 		summary = ResourceSummary{
-			ResourceType: resourceType,
+			ResourceType: resourceType.String(),
 		}
 	}
 	switch operation {
@@ -165,25 +165,25 @@ func UpdateSuccessSummary(resourceType string, operation string) {
 	case DELETE:
 		summary.Deleted++
 	}
-	ResourceSummaries[resourceType] = summary
+	ResourceSummaries[resourceType.String()] = summary
 }
 
-func UpdateFailureSummary(resourceType string, resourceName string) {
+func UpdateFailureSummary(resourceType ResourceType, resourceName string) {
 
 	InitializeResourceSummary()
 
 	SummaryData.TotalRequests++
 	SummaryData.FailedOperations++
 
-	summary, ok := ResourceSummaries[resourceType]
+	summary, ok := ResourceSummaries[resourceType.String()]
 	if !ok {
 		summary = ResourceSummary{
-			ResourceType: resourceType,
+			ResourceType: resourceType.String(),
 		}
 	}
 	summary.Failed++
 	summary.FailedResources = append(summary.FailedResources, resourceName)
-	ResourceSummaries[resourceType] = summary
+	ResourceSummaries[resourceType.String()] = summary
 }
 
 func InitializeResourceSummary() {

--- a/iamctl/tests/resourceReferenceUtils_test.go
+++ b/iamctl/tests/resourceReferenceUtils_test.go
@@ -1,0 +1,578 @@
+package tests
+
+import (
+	"fmt"
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func TestAddToResourceIdentifierMap(t *testing.T) {
+
+	testCases := []struct {
+		description  string
+		resourceType utils.ResourceType
+		metadata     map[utils.ResourceType]utils.ResourceIdentifierMeta
+		resourceData interface{}
+		operation    string
+		expectedMap  map[string]string
+	}{
+		{
+			description:  "Export: maps id to name",
+			resourceType: utils.APPLICATIONS,
+			metadata: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			resourceData: map[string]interface{}{
+				"id":   "app-uuid-123",
+				"name": "MyApp",
+			},
+			operation:   utils.EXPORT,
+			expectedMap: map[string]string{"app-uuid-123": "MyApp"},
+		},
+		{
+			description:  "Import: maps name to id",
+			resourceType: utils.APPLICATIONS,
+			metadata: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			resourceData: map[string]interface{}{
+				"id":   "app-uuid-456",
+				"name": "MyApp",
+			},
+			operation:   utils.IMPORT,
+			expectedMap: map[string]string{"MyApp": "app-uuid-456"},
+		},
+		{
+			description:  "Resource type not in metadata: no entry added",
+			resourceType: utils.IDENTITY_PROVIDERS,
+			metadata: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			resourceData: map[string]interface{}{
+				"id":   "idp-uuid-123",
+				"name": "MyIDP",
+			},
+			operation:   utils.EXPORT,
+			expectedMap: nil,
+		},
+		{
+			description:  "Missing id value: no entry added",
+			resourceType: utils.APPLICATIONS,
+			metadata: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			resourceData: map[string]interface{}{
+				"name": "MyApp",
+			},
+			operation:   utils.EXPORT,
+			expectedMap: nil,
+		},
+		{
+			description:  "Missing name value: no entry added",
+			resourceType: utils.APPLICATIONS,
+			metadata: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			resourceData: map[string]interface{}{
+				"id": "app-uuid-123",
+			},
+			operation:   utils.EXPORT,
+			expectedMap: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			utils.RESOURCE_IDENTIFIER_METADATA = tc.metadata
+			utils.ResetResourceIdentifierMap()
+
+			utils.AddToResourceIdentifierMap(tc.resourceType, tc.resourceData, tc.operation)
+
+			result := utils.GetResourceIdentifierMap(tc.resourceType)
+			if !reflect.DeepEqual(result, tc.expectedMap) {
+				t.Errorf("Unexpected result for %s: expected %v, but got %v", tc.description, tc.expectedMap, result)
+			}
+		})
+	}
+}
+
+func TestResolveAllItemsPaths(t *testing.T) {
+
+	data := map[string]interface{}{
+		"applicationId": "app-id-1",
+		"properties": []interface{}{
+			map[string]interface{}{"name": "prop1", "value": "val1"},
+			map[string]interface{}{"name": "prop2", "value": "val2"},
+		},
+		"configs": []interface{}{
+			map[string]interface{}{
+				"type": "typeA",
+				"items": []interface{}{
+					map[string]interface{}{"key": "k1", "appId": "id1"},
+					map[string]interface{}{"key": "k2", "appId": "id2"},
+				},
+			},
+			map[string]interface{}{
+				"type": "typeB",
+				"items": []interface{}{
+					map[string]interface{}{"key": "k3", "appId": "id3"},
+				},
+			},
+		},
+	}
+
+	allItems := utils.ALL_ITEMS
+
+	testCases := []struct {
+		description   string
+		path          string
+		expectedPaths []string
+		expectError   bool
+	}{
+		{
+			description:   "Path with no wildcard: returned unchanged",
+			path:          "applicationId",
+			expectedPaths: []string{"applicationId"},
+		},
+		{
+			description:   "Nested path with no wildcard: returned unchanged",
+			path:          "properties.[name=prop1].value",
+			expectedPaths: []string{"properties.[name=prop1].value"},
+		},
+		{
+			description: "Wildcard on array with remaining path: expands to one path per element",
+			path:        fmt.Sprintf("properties.[name=%s].value", allItems),
+			expectedPaths: []string{
+				"properties.[name=prop1].value",
+				"properties.[name=prop2].value",
+			},
+		},
+		{
+			description: "Wildcard with no remaining path: expands to array element identifiers",
+			path:        fmt.Sprintf("properties.[name=%s]", allItems),
+			expectedPaths: []string{
+				"properties.[name=prop1]",
+				"properties.[name=prop2]",
+			},
+		},
+		{
+			description: "Nested wildcards: full cartesian expansion",
+			path:        fmt.Sprintf("configs.[type=%s].items.[key=%s].appId", allItems, allItems),
+			expectedPaths: []string{
+				"configs.[type=typeA].items.[key=k1].appId",
+				"configs.[type=typeA].items.[key=k2].appId",
+				"configs.[type=typeB].items.[key=k3].appId",
+			},
+		},
+		{
+			description: "Wildcard on non-array field: error",
+			path:        fmt.Sprintf("applicationId.[name=%s].value", allItems),
+			expectError: true,
+		},
+		{
+			description: "Array element missing wildcard key: error",
+			path:        fmt.Sprintf("properties.[missingKey=%s].value", allItems),
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := utils.ResolveAllItemsPaths(data, tc.path)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for %s but got none", tc.description)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error for %s: %v", tc.description, err)
+				return
+			}
+
+			sort.Strings(result)
+			sort.Strings(tc.expectedPaths)
+			if !reflect.DeepEqual(result, tc.expectedPaths) {
+				t.Errorf("Unexpected result for %s: expected %v, but got %v", tc.description, tc.expectedPaths, result)
+			}
+		})
+	}
+}
+
+func TestReplaceArrayReferences(t *testing.T) {
+
+	testCases := []struct {
+		description   string
+		arrayVal      []interface{}
+		identifierMap map[string]string
+		refPath       string
+		expectedArray []interface{}
+		expectError   bool
+	}{
+		{
+			description:   "All elements replaced successfully",
+			arrayVal:      []interface{}{"id-1", "id-2", "id-3"},
+			identifierMap: map[string]string{"id-1": "App1", "id-2": "App2", "id-3": "App3"},
+			refPath:       "applicationIds",
+			expectedArray: []interface{}{"App1", "App2", "App3"},
+		},
+		{
+			description:   "Empty string elements are kept as-is",
+			arrayVal:      []interface{}{"id-1", "", "id-3"},
+			identifierMap: map[string]string{"id-1": "App1", "id-3": "App3"},
+			refPath:       "applicationIds",
+			expectedArray: []interface{}{"App1", "", "App3"},
+		},
+		{
+			description:   "Empty array: returns empty array",
+			arrayVal:      []interface{}{},
+			identifierMap: map[string]string{"id-1": "App1"},
+			refPath:       "applicationIds",
+			expectedArray: []interface{}{},
+		},
+		{
+			description:   "Element not found in identifier map: error",
+			arrayVal:      []interface{}{"id-1", "id-unknown"},
+			identifierMap: map[string]string{"id-1": "App1"},
+			refPath:       "applicationIds",
+			expectError:   true,
+		},
+		{
+			description:   "Non-string int element in array: error",
+			arrayVal:      []interface{}{"id-1", 42},
+			identifierMap: map[string]string{"id-1": "App1"},
+			refPath:       "applicationIds",
+			expectError:   true,
+		},
+		{
+			description:   "Map element in array: error",
+			arrayVal:      []interface{}{"id-1", map[string]interface{}{"key": "val"}},
+			identifierMap: map[string]string{"id-1": "App1"},
+			refPath:       "applicationIds",
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			result, err := utils.ReplaceArrayReferences(tc.arrayVal, tc.identifierMap, tc.refPath)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for %s but got none", tc.description)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error for %s: %v", tc.description, err)
+				return
+			}
+			if !reflect.DeepEqual(result, tc.expectedArray) {
+				t.Errorf("Unexpected result for %s: expected %v, but got %v", tc.description, tc.expectedArray, result)
+			}
+		})
+	}
+}
+
+func TestReplaceValueAtPath(t *testing.T) {
+
+	testCases := []struct {
+		description   string
+		resourceData  interface{}
+		path          string
+		identifierMap map[string]string
+		expectedData  interface{}
+		expectError   bool
+	}{
+		{
+			description: "Single string value: replaced with mapped value",
+			resourceData: map[string]interface{}{
+				"applicationId": "app-uuid-1",
+			},
+			path:          "applicationId",
+			identifierMap: map[string]string{"app-uuid-1": "MyApp"},
+			expectedData: map[string]interface{}{
+				"applicationId": "MyApp",
+			},
+		},
+		{
+			description: "String array: each element replaced individually",
+			resourceData: map[string]interface{}{
+				"applicationIds": []interface{}{"app-uuid-1", "app-uuid-2"},
+			},
+			path:          "applicationIds",
+			identifierMap: map[string]string{"app-uuid-1": "App1", "app-uuid-2": "App2"},
+			expectedData: map[string]interface{}{
+				"applicationIds": []interface{}{"App1", "App2"},
+			},
+		},
+		{
+			description: "Nil value at path: no-op, no error",
+			resourceData: map[string]interface{}{
+				"otherField": "value",
+			},
+			path:          "applicationId",
+			identifierMap: map[string]string{"app-uuid-1": "MyApp"},
+			expectedData: map[string]interface{}{
+				"otherField": "value",
+			},
+		},
+		{
+			description: "Empty string at path: no-op, no error",
+			resourceData: map[string]interface{}{
+				"applicationId": "",
+			},
+			path:          "applicationId",
+			identifierMap: map[string]string{"app-uuid-1": "MyApp"},
+			expectedData: map[string]interface{}{
+				"applicationId": "",
+			},
+		},
+		{
+			description: "String value not in identifier map: error",
+			resourceData: map[string]interface{}{
+				"applicationId": "app-uuid-unknown",
+			},
+			path:          "applicationId",
+			identifierMap: map[string]string{"app-uuid-1": "MyApp"},
+			expectError:   true,
+		},
+		{
+			description: "Non-string non-array value at path: error",
+			resourceData: map[string]interface{}{
+				"applicationId": 12345,
+			},
+			path:          "applicationId",
+			identifierMap: map[string]string{},
+			expectError:   true,
+		},
+		{
+			description: "Nested path replaced correctly",
+			resourceData: map[string]interface{}{
+				"config": map[string]interface{}{
+					"appId": "app-uuid-1",
+				},
+			},
+			path:          "config.appId",
+			identifierMap: map[string]string{"app-uuid-1": "MyApp"},
+			expectedData: map[string]interface{}{
+				"config": map[string]interface{}{
+					"appId": "MyApp",
+				},
+			},
+		},
+		{
+			description: "Non-string element in string array at path: error",
+			resourceData: map[string]interface{}{
+				"applicationIds": []interface{}{"app-uuid-1", 42},
+			},
+			path:          "applicationIds",
+			identifierMap: map[string]string{"app-uuid-1": "App1"},
+			expectError:   true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			err := utils.ReplaceValueAtPath(tc.resourceData, tc.path, tc.identifierMap)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for %s but got none", tc.description)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error for %s: %v", tc.description, err)
+				return
+			}
+			if !reflect.DeepEqual(tc.resourceData, tc.expectedData) {
+				t.Errorf("Unexpected result for %s: expected %v, but got %v", tc.description, tc.expectedData, tc.resourceData)
+			}
+		})
+	}
+}
+
+func TestReplaceReferences(t *testing.T) {
+
+	allItems := utils.ALL_ITEMS
+
+	testCases := []struct {
+		description          string
+		resourceType         utils.ResourceType
+		referencedType       utils.ResourceType
+		refMetadata          map[utils.ResourceType][]utils.ResourceReferenceMeta
+		identifierMeta       map[utils.ResourceType]utils.ResourceIdentifierMeta
+		identifierData       []interface{}
+		operation            string
+		resourceData         interface{}
+		expectedData         interface{}
+		expectError          bool
+	}{
+		{
+			description:  "Resource type with no reference metadata: returns data unchanged",
+			resourceType: utils.IDENTITY_PROVIDERS,
+			refMetadata:  map[utils.ResourceType][]utils.ResourceReferenceMeta{},
+			resourceData: map[string]interface{}{
+				"applicationId": "app-uuid-1",
+			},
+			expectedData: map[string]interface{}{
+				"applicationId": "app-uuid-1",
+			},
+		},
+		{
+			description:    "Single string reference replaced correctly",
+			resourceType:   utils.IDENTITY_PROVIDERS,
+			referencedType: utils.APPLICATIONS,
+			refMetadata: map[utils.ResourceType][]utils.ResourceReferenceMeta{
+				utils.IDENTITY_PROVIDERS: {
+					{ReferencedResourceType: utils.APPLICATIONS, ReferencePaths: []string{"applicationId"}},
+				},
+			},
+			identifierMeta: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			identifierData: []interface{}{
+				map[string]interface{}{"id": "app-uuid-1", "name": "MyApp"},
+			},
+			operation: utils.EXPORT,
+			resourceData: map[string]interface{}{
+				"applicationId": "app-uuid-1",
+			},
+			expectedData: map[string]interface{}{
+				"applicationId": "MyApp",
+			},
+		},
+		{
+			description:    "String array reference: each element replaced",
+			resourceType:   utils.IDENTITY_PROVIDERS,
+			referencedType: utils.APPLICATIONS,
+			refMetadata: map[utils.ResourceType][]utils.ResourceReferenceMeta{
+				utils.IDENTITY_PROVIDERS: {
+					{ReferencedResourceType: utils.APPLICATIONS, ReferencePaths: []string{"applicationIds"}},
+				},
+			},
+			identifierMeta: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			identifierData: []interface{}{
+				map[string]interface{}{"id": "app-uuid-1", "name": "App1"},
+				map[string]interface{}{"id": "app-uuid-2", "name": "App2"},
+			},
+			operation: utils.EXPORT,
+			resourceData: map[string]interface{}{
+				"applicationIds": []interface{}{"app-uuid-1", "app-uuid-2"},
+			},
+			expectedData: map[string]interface{}{
+				"applicationIds": []interface{}{"App1", "App2"},
+			},
+		},
+		{
+			description:    "ALL_ITEMS wildcard path: all array elements processed",
+			resourceType:   utils.IDENTITY_PROVIDERS,
+			referencedType: utils.APPLICATIONS,
+			refMetadata: map[utils.ResourceType][]utils.ResourceReferenceMeta{
+				utils.IDENTITY_PROVIDERS: {
+					{
+						ReferencedResourceType: utils.APPLICATIONS,
+						ReferencePaths:         []string{fmt.Sprintf("properties.[name=%s].appId", allItems)},
+					},
+				},
+			},
+			identifierMeta: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			identifierData: []interface{}{
+				map[string]interface{}{"id": "app-uuid-1", "name": "App1"},
+				map[string]interface{}{"id": "app-uuid-2", "name": "App2"},
+			},
+			operation: utils.EXPORT,
+			resourceData: map[string]interface{}{
+				"properties": []interface{}{
+					map[string]interface{}{"name": "prop1", "appId": "app-uuid-1"},
+					map[string]interface{}{"name": "prop2", "appId": "app-uuid-2"},
+				},
+			},
+			expectedData: map[string]interface{}{
+				"properties": []interface{}{
+					map[string]interface{}{"name": "prop1", "appId": "App1"},
+					map[string]interface{}{"name": "prop2", "appId": "App2"},
+				},
+			},
+		},
+		{
+			description:    "Referenced identifier not in map: error",
+			resourceType:   utils.IDENTITY_PROVIDERS,
+			referencedType: utils.APPLICATIONS,
+			refMetadata: map[utils.ResourceType][]utils.ResourceReferenceMeta{
+				utils.IDENTITY_PROVIDERS: {
+					{ReferencedResourceType: utils.APPLICATIONS, ReferencePaths: []string{"applicationId"}},
+				},
+			},
+			identifierMeta: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			identifierData: []interface{}{
+				map[string]interface{}{"id": "app-uuid-1", "name": "App1"},
+			},
+			operation: utils.EXPORT,
+			resourceData: map[string]interface{}{
+				"applicationId": "app-uuid-unknown",
+			},
+			expectError: true,
+		},
+		{
+			description:    "Non-string element in referenced array: error",
+			resourceType:   utils.IDENTITY_PROVIDERS,
+			referencedType: utils.APPLICATIONS,
+			refMetadata: map[utils.ResourceType][]utils.ResourceReferenceMeta{
+				utils.IDENTITY_PROVIDERS: {
+					{ReferencedResourceType: utils.APPLICATIONS, ReferencePaths: []string{"applicationIds"}},
+				},
+			},
+			identifierMeta: map[utils.ResourceType]utils.ResourceIdentifierMeta{
+				utils.APPLICATIONS: {IdentifierPath: "id", UniqueValuePath: "name"},
+			},
+			identifierData: []interface{}{
+				map[string]interface{}{"id": "app-uuid-1", "name": "App1"},
+			},
+			operation: utils.EXPORT,
+			resourceData: map[string]interface{}{
+				"applicationIds": []interface{}{"app-uuid-1", 42},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			utils.RESOURCE_REFERENCE_METADATA = tc.refMetadata
+			utils.RESOURCE_IDENTIFIER_METADATA = tc.identifierMeta
+			utils.ResetResourceIdentifierMap()
+
+			for _, data := range tc.identifierData {
+				utils.AddToResourceIdentifierMap(tc.referencedType, data, tc.operation)
+			}
+
+			result, err := utils.ReplaceReferences(tc.resourceType, tc.resourceData)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected error for %s but got none", tc.description)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("Unexpected error for %s: %v", tc.description, err)
+				return
+			}
+			if !reflect.DeepEqual(result, tc.expectedData) {
+				t.Errorf("Unexpected result for %s: expected %v, but got %v", tc.description, tc.expectedData, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Purpose

When migrating IAM resources across environments using the tool, some resources embed the UUIDs of other resources. Since UUIDs are environment-specific and differ between environments, these embedded references become invalid after import, causing broken configurations in the target environment.

This PR introduces a utility framework to handle cross-resource references transparently during export and import operations.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662

## Goals

- **Introduce a Reference Framework**: Allows future resource types to declare cross-resource references so that environment-specific IDs are automatically replaced with environment-agnostic unique values (e.g., names) during export and resolved back to the correct IDs during import.
- **Support Nested & Array References**: Supports references embedded in both single fields and arrays, including references nested inside arrays of objects at intermediate path levels.
- **Enforce Processing Order**: Defines a processing sequence for resources during export and import so that referenced resources are always processed before the resources that depend on them.
- **Refactor Resource Types**: Refactors resource type identifiers to a named type for improved type safety across the codebase.

## Approach

### Cross-Resource Reference Handling

Two metadata maps are introduced in `constants.go`:

- **`RESOURCE_IDENTIFIER_METADATA`**: Declares, for each resource type, which field holds the environment-specific ID and which field holds the stable unique identifier (e.g., `name`) that is consistent across environments.
- **`RESOURCE_REFERENCE_METADATA`**: Declares, for each resource type, which other resource types it references and the paths within the object where those references appear.

These maps are intentionally empty at this stage, serving as extension points for future resource types with no impact on existing functionality.

A new `resourceReferenceUtils.go` provides the runtime logic:

- **`AddToResourceIdentifierMap`**: Builds an in-memory ID ↔ Name map per resource type. For export, it maps `ID → Name`; for import, it maps `Name → ID`.
- **`ReplaceReferences`**: Walks all declared reference paths and replaces values using the identifier map. If a referenced resource is not found, an error is returned and the operation is aborted.
- **`resolveAllItemsPaths`**: Supports an `[key=all_items]` wildcard in path definitions. This expands wildcards into concrete paths by walking the actual object structure (e.g., `properties.[name=all_items].applicationId`).
- **`replaceArrayReferences`**: Handles fields that are string arrays of IDs (e.g., `["id-1", "id-2"]`), mapping each element individually.

### Resource Processing Order

`resourceOrder.go` introduces a `ResourceOrder` slice that defines the sequence in which resources are processed:

> **Claims → IdentityProviders → UserStores → Applications**

The export and import commands now iterate over this order instead of processing resources arbitrarily, ensuring that dependency requirements are met.

### ResourceType Refactor

Resource type identifiers (`APPLICATIONS`, `IDENTITY_PROVIDERS`, etc.) are changed from plain `string` constants to a named `ResourceType` type. This enables compile-time type checking and is a prerequisite for using them as keys in the new metadata structures.

### Unit Tests

Unit tests are added in `resourceReferenceUtils_test.go` covering the core behaviors of the new utilities:

- **`AddToResourceIdentifierMap`** — verifies correct ID→Name mapping for export and Name→ID mapping for import.
- **`ResolveAllItemsPaths`** — verifies that paths with no wildcards are returned unchanged, that `[key=all_items]` wildcards are correctly expanded into concrete paths using the actual object structure.
- **`ReplaceReferences`** — verifies end-to-end reference replacement for single string fields, string array fields, and paths expanded from wildcards, for both export and import directions.
- **`TestReplaceArrayReferences`** — verifies that each element in a string array is replaced individually using the identifier map.
- **`TestReplaceValueAtPath`** — verifies replacement of a single string value, a full string array, and a nested path.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.