### PR TITLE
Add support for Challenge questions resource type

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
+	challengeQuestions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/challengeQuestions"
 	claims "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/claims"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
@@ -45,12 +46,13 @@ var exportAllCmd = &cobra.Command{
 		}
 
 		exportFunctions := map[utils.ResourceType]func(string, string){
-			utils.CLAIMS:             claims.ExportAll,
-			utils.IDENTITY_PROVIDERS: identityproviders.ExportAll,
-			utils.APPLICATIONS:       applications.ExportAll,
-			utils.USERSTORES:         userstores.ExportAll,
-			utils.OIDC_SCOPES:        oidcScopes.ExportAll,
-			utils.ROLES:              roles.ExportAll,
+			utils.CLAIMS:              claims.ExportAll,
+			utils.IDENTITY_PROVIDERS:  identityproviders.ExportAll,
+			utils.APPLICATIONS:        applications.ExportAll,
+			utils.USERSTORES:          userstores.ExportAll,
+			utils.OIDC_SCOPES:         oidcScopes.ExportAll,
+			utils.ROLES:               roles.ExportAll,
+			utils.CHALLENGE_QUESTIONS: challengeQuestions.ExportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
+	challengeQuestions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/challengeQuestions"
 	claims "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/claims"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
@@ -44,12 +45,13 @@ var importAllCmd = &cobra.Command{
 		}
 
 		importFunctions := map[utils.ResourceType]func(string){
-			utils.CLAIMS:             claims.ImportAll,
-			utils.IDENTITY_PROVIDERS: identityproviders.ImportAll,
-			utils.APPLICATIONS:       applications.ImportAll,
-			utils.USERSTORES:         userstores.ImportAll,
-			utils.OIDC_SCOPES:        oidcScopes.ImportAll,
-			utils.ROLES:              roles.ImportAll,
+			utils.CLAIMS:              claims.ImportAll,
+			utils.IDENTITY_PROVIDERS:  identityproviders.ImportAll,
+			utils.APPLICATIONS:        applications.ImportAll,
+			utils.USERSTORES:          userstores.ImportAll,
+			utils.OIDC_SCOPES:         oidcScopes.ImportAll,
+			utils.ROLES:               roles.ImportAll,
+			utils.CHALLENGE_QUESTIONS: challengeQuestions.ImportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/pkg/challengeQuestions/challengeQuestionUtils.go
+++ b/iamctl/pkg/challengeQuestions/challengeQuestionUtils.go
@@ -1,0 +1,116 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package challengeQuestions
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+type challengeSet struct {
+	QuestionSetId string `json:"questionSetId"`
+}
+
+func getChallengeSetList() ([]challengeSet, error) {
+
+	var list []challengeSet
+	resp, err := utils.SendGetListRequest(utils.CHALLENGE_QUESTIONS, -1)
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving challenge question set list. %w", err)
+	}
+	defer resp.Body.Close()
+
+	statusCode := resp.StatusCode
+	if statusCode == 200 {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error when reading the retrieved challenge question set list. %w", err)
+		}
+		if err = json.Unmarshal(body, &list); err != nil {
+			return nil, fmt.Errorf("error when unmarshalling the retrieved challenge question set list. %w", err)
+		}
+		return list, nil
+	} else if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
+		return nil, fmt.Errorf("error while retrieving challenge question set list. Status code: %d, Error: %s", statusCode, errMsg)
+	}
+	return nil, fmt.Errorf("error while retrieving challenge question set list")
+}
+
+func getDeployedChallengeSetIds() []string {
+
+	sets, err := getChallengeSetList()
+	if err != nil {
+		return []string{}
+	}
+
+	var ids []string
+	for _, set := range sets {
+		ids = append(ids, set.QuestionSetId)
+	}
+	return ids
+}
+
+func getChallengeQuestionKeywordMapping(setId string) map[string]interface{} {
+
+	if utils.KEYWORD_CONFIGS.ChallengeQuestionConfigs != nil {
+		return utils.ResolveAdvancedKeywordMapping(setId, utils.KEYWORD_CONFIGS.ChallengeQuestionConfigs)
+	}
+	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func isChallengeSetExists(setId string, existingSets []challengeSet) bool {
+
+	for _, set := range existingSets {
+		if set.QuestionSetId == setId {
+			return true
+		}
+	}
+	return false
+}
+
+func buildUpdateRequestBody(requestBody []byte, format utils.Format) ([]byte, error) {
+
+	parsed, err := utils.Deserialize(requestBody, format, utils.CHALLENGE_QUESTIONS)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing data: %w", err)
+	}
+
+	if interfaceMap, ok := parsed.(map[interface{}]interface{}); ok {
+		parsed = utils.ConvertToStringKeyMap(interfaceMap)
+	}
+	dataMap, ok := parsed.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected format for challenge question set")
+	}
+
+	questions, ok := dataMap["questions"]
+	if !ok {
+		return nil, fmt.Errorf("questions field not found in the question set data")
+	}
+
+	questionsBytes, err := utils.Serialize(questions, utils.FormatJSON, utils.CHALLENGE_QUESTIONS)
+	if err != nil {
+		return nil, fmt.Errorf("error serializing to JSON: %w", err)
+	}
+
+	return questionsBytes, nil
+}

--- a/iamctl/pkg/challengeQuestions/export.go
+++ b/iamctl/pkg/challengeQuestions/export.go
@@ -1,0 +1,94 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package challengeQuestions
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ExportAll(exportFilePath string, format string) {
+
+	log.Println("Exporting challenge question sets...")
+	exportFilePath = filepath.Join(exportFilePath, utils.CHALLENGE_QUESTIONS.String())
+
+	if utils.IsResourceTypeExcluded(utils.CHALLENGE_QUESTIONS) {
+		return
+	}
+	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
+		os.MkdirAll(exportFilePath, 0700)
+	} else {
+		if utils.TOOL_CONFIGS.AllowDelete {
+			deployedSetIds := getDeployedChallengeSetIds()
+			utils.RemoveDeletedLocalResources(exportFilePath, deployedSetIds)
+		}
+	}
+
+	sets, err := getChallengeSetList()
+	if err != nil {
+		log.Println("Error: when exporting challenge question sets.", err)
+		return
+	}
+
+	for _, set := range sets {
+		if !utils.IsResourceExcluded(set.QuestionSetId, utils.TOOL_CONFIGS.ChallengeQuestionConfigs) {
+			log.Println("Exporting challenge question set:", set.QuestionSetId)
+			err := exportChallengeSet(set.QuestionSetId, exportFilePath, format)
+			if err != nil {
+				utils.UpdateFailureSummary(utils.CHALLENGE_QUESTIONS, set.QuestionSetId)
+				log.Printf("Error while exporting challenge question set: %s. %s", set.QuestionSetId, err)
+			} else {
+				utils.UpdateSuccessSummary(utils.CHALLENGE_QUESTIONS, utils.EXPORT)
+				log.Println("Challenge question set exported successfully:", set.QuestionSetId)
+			}
+		}
+	}
+}
+
+func exportChallengeSet(setId string, outputDirPath string, formatString string) error {
+
+	set, err := utils.SendGetRequest(utils.CHALLENGE_QUESTIONS, setId)
+	if err != nil {
+		return fmt.Errorf("error while getting challenge question set: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, setId, format)
+
+	keywordMapping := getChallengeQuestionKeywordMapping(setId)
+	modifiedSet, err := utils.ProcessExportedData(set, exportedFileName, format, keywordMapping, utils.CHALLENGE_QUESTIONS)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedSet, format, utils.CHALLENGE_QUESTIONS)
+	if err != nil {
+		return fmt.Errorf("error while serializing challenge question set: %w", err)
+	}
+
+	if err = os.WriteFile(exportedFileName, modifiedFile, 0644); err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/challengeQuestions/import.go
+++ b/iamctl/pkg/challengeQuestions/import.go
@@ -1,0 +1,168 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package challengeQuestions
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ImportAll(inputDirPath string) {
+
+	log.Println("Importing challenge question sets...")
+	importFilePath := filepath.Join(inputDirPath, utils.CHALLENGE_QUESTIONS.String())
+
+	if utils.IsResourceTypeExcluded(utils.CHALLENGE_QUESTIONS) {
+		return
+	}
+	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
+		log.Println("No challenge question sets to import.")
+		return
+	}
+
+	existingSets, err := getChallengeSetList()
+	if err != nil {
+		log.Println("Error retrieving the deployed challenge question set list:", err)
+		return
+	}
+
+	files, err := os.ReadDir(importFilePath)
+	if err != nil {
+		log.Println("Error importing challenge question sets:", err)
+		return
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		removeDeletedDeployedChallengeSets(files, existingSets)
+	}
+
+	for _, file := range files {
+		setFilePath := filepath.Join(importFilePath, file.Name())
+		fileInfo := utils.GetFileInfo(setFilePath)
+		setId := fileInfo.ResourceName
+
+		if !utils.IsResourceExcluded(setId, utils.TOOL_CONFIGS.ChallengeQuestionConfigs) {
+			setExists := isChallengeSetExists(setId, existingSets)
+			err := importChallengeSet(setId, setExists, setFilePath)
+			if err != nil {
+				log.Println("Error importing challenge question set:", err)
+				utils.UpdateFailureSummary(utils.CHALLENGE_QUESTIONS, setId)
+			}
+		}
+	}
+}
+
+func importChallengeSet(setId string, setExists bool, importFilePath string) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format for challenge question set: %w", err)
+	}
+
+	fileBytes, err := os.ReadFile(importFilePath)
+	if err != nil {
+		return fmt.Errorf("error when reading the file for challenge question set: %w", err)
+	}
+
+	keywordMapping := getChallengeQuestionKeywordMapping(setId)
+	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), keywordMapping)
+
+	if !setExists {
+		return createChallengeSet([]byte(modifiedFileData), format, setId)
+	}
+	return updateChallengeSet(setId, []byte(modifiedFileData), format)
+}
+
+func createChallengeSet(requestBody []byte, format utils.Format, setId string) error {
+
+	log.Println("Creating new challenge question set:", setId)
+
+	parsed, err := utils.Deserialize(requestBody, format, utils.CHALLENGE_QUESTIONS)
+	if err != nil {
+		return fmt.Errorf("error deserializing data: %w", err)
+	}
+	wrappedBody, err := utils.Serialize([]interface{}{parsed}, utils.FormatJSON, utils.CHALLENGE_QUESTIONS)
+	if err != nil {
+		return fmt.Errorf("error serializing to JSON: %w", err)
+	}
+
+	resp, err := utils.SendPostRequest(utils.CHALLENGE_QUESTIONS, wrappedBody)
+	if err != nil {
+		return fmt.Errorf("error when creating challenge question set: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.CHALLENGE_QUESTIONS, utils.IMPORT)
+	log.Println("Challenge question set created successfully.")
+	return nil
+}
+
+func updateChallengeSet(setId string, requestBody []byte, format utils.Format) error {
+
+	log.Println("Updating challenge question set:", setId)
+
+	questionsBytes, err := buildUpdateRequestBody(requestBody, format)
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPutRequest(utils.CHALLENGE_QUESTIONS, setId, questionsBytes)
+	if err != nil {
+		return fmt.Errorf("error when updating challenge question set: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.CHALLENGE_QUESTIONS, utils.UPDATE)
+	log.Println("Challenge question set updated successfully.")
+	return nil
+}
+
+func removeDeletedDeployedChallengeSets(localFiles []os.DirEntry, deployedSets []challengeSet) {
+
+	if len(deployedSets) == 0 {
+		return
+	}
+
+	localResourceNames := make(map[string]struct{})
+	for _, file := range localFiles {
+		resourceName := utils.GetFileInfo(file.Name()).ResourceName
+		localResourceNames[resourceName] = struct{}{}
+	}
+
+	for _, set := range deployedSets {
+		if _, existsLocally := localResourceNames[set.QuestionSetId]; existsLocally {
+			continue
+		}
+		if utils.IsResourceExcluded(set.QuestionSetId, utils.TOOL_CONFIGS.ChallengeQuestionConfigs) {
+			log.Println("Challenge question set is excluded from deletion:", set.QuestionSetId)
+			continue
+		}
+
+		log.Printf("Challenge question set: %s not found locally. Deleting.\n", set.QuestionSetId)
+		if err := utils.SendDeleteRequest(set.QuestionSetId, utils.CHALLENGE_QUESTIONS); err != nil {
+			utils.UpdateFailureSummary(utils.CHALLENGE_QUESTIONS, set.QuestionSetId)
+			log.Println("Error deleting challenge question set:", set.QuestionSetId, err)
+		} else {
+			utils.UpdateSuccessSummary(utils.CHALLENGE_QUESTIONS, utils.DELETE)
+		}
+	}
+}

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -480,6 +480,8 @@ func getResourcePath(resourceType ResourceType) string {
 		return "claim-dialects"
 	case OIDC_SCOPES:
 		return "oidc/scopes"
+	case CHALLENGE_QUESTIONS:
+		return "challenges"
 	}
 	return ""
 }

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -25,6 +25,7 @@ const CLAIM_CONFIG = "CLAIMS"
 const USERSTORES_CONFIG = "USERSTORES"
 const OIDC_SCOPES_CONFIG = "OIDC_SCOPES"
 const ROLES_CONFIG = "ROLES"
+const CHALLENGE_QUESTIONS_CONFIG = "CHALLENGE_QUESTIONS"
 
 // Tool configs
 const EXCLUDE_CONFIG = "EXCLUDE"
@@ -49,12 +50,13 @@ const TOKEN_CONFIG = "TOKEN"
 type ResourceType string
 
 const (
-	APPLICATIONS       ResourceType = "Applications"
-	IDENTITY_PROVIDERS ResourceType = "IdentityProviders"
-	CLAIMS             ResourceType = "Claims"
-	USERSTORES         ResourceType = "UserStores"
-	OIDC_SCOPES        ResourceType = "OidcScopes"
-	ROLES              ResourceType = "Roles"
+	APPLICATIONS        ResourceType = "Applications"
+	IDENTITY_PROVIDERS  ResourceType = "IdentityProviders"
+	CLAIMS              ResourceType = "Claims"
+	USERSTORES          ResourceType = "UserStores"
+	OIDC_SCOPES         ResourceType = "OidcScopes"
+	ROLES               ResourceType = "Roles"
+	CHALLENGE_QUESTIONS ResourceType = "ChallengeQuestions"
 )
 
 // Config file names
@@ -142,6 +144,11 @@ var claimArrayIdentifiers = map[string]string{
 	"claims":           "id",
 }
 
+var challengeQuestionsArrayIdentifiers = map[string]string{
+
+	"questions": "questionId",
+}
+
 type ResourceIdentifierMeta struct {
 	IdentifierPath  string // Path to the ID field in the resource object
 	UniqueValuePath string // Path to the unique identifier field
@@ -168,8 +175,13 @@ var rolesArrayFields = []string{
 	"schemas",
 }
 
+var challengeQuestionsArrayFields = []string{
+	"questions",
+}
+
 // XML root element tags for each resource type
 const (
-	XML_ROOT_OIDC_SCOPE = "Scope"
-	XML_ROOT_ROLE       = "Role"
+	XML_ROOT_OIDC_SCOPE         = "Scope"
+	XML_ROOT_ROLE               = "Role"
+	XML_ROOT_CHALLENGE_QUESTION = "ChallengeSet"
 )

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -35,7 +35,8 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_application_script_update internal_org_application_script_update " +
 	"internal_application_business_api_update internal_application_internal_api_update internal_org_application_business_api_update internal_org_application_internal_api_update " +
 	"internal_oidc_scope_mgt_view internal_oidc_scope_mgt_create internal_oidc_scope_mgt_update internal_oidc_scope_mgt_delete " +
-	"internal_role_mgt_view internal_role_mgt_create internal_role_mgt_update internal_role_mgt_delete"
+	"internal_role_mgt_view internal_role_mgt_create internal_role_mgt_update internal_role_mgt_delete " +
+	"internal_identity_mgt_view internal_identity_mgt_create internal_identity_mgt_update internal_identity_mgt_delete"
 
 const (
 	AppName       = "IAM-CTL"

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -173,6 +173,8 @@ func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 		return userStoreArrayIdentifiers
 	case CLAIMS:
 		return claimArrayIdentifiers
+	case CHALLENGE_QUESTIONS:
+		return challengeQuestionsArrayIdentifiers
 	default:
 		return make(map[string]string)
 	}

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -31,4 +31,5 @@ var ResourceOrder = []ResourceType{
 	APPLICATIONS,
 	OIDC_SCOPES,
 	ROLES, // Dependency: Applications
+	CHALLENGE_QUESTIONS,
 }

--- a/iamctl/pkg/utils/serializationUtils.go
+++ b/iamctl/pkg/utils/serializationUtils.go
@@ -156,8 +156,9 @@ func XMLToMap(data []byte) (map[string]interface{}, error) {
 func GetXMLRootTag(resourceType ResourceType) string {
 
 	xmlRootTags := map[ResourceType]string{
-		OIDC_SCOPES: XML_ROOT_OIDC_SCOPE,
-		ROLES:       XML_ROOT_ROLE,
+		OIDC_SCOPES:         XML_ROOT_OIDC_SCOPE,
+		ROLES:               XML_ROOT_ROLE,
+		CHALLENGE_QUESTIONS: XML_ROOT_CHALLENGE_QUESTION,
 	}
 	return xmlRootTags[resourceType]
 }
@@ -192,6 +193,8 @@ func GetArrayFieldPaths(resourceType ResourceType) []string {
 		return oidcScopeArrayFields
 	case ROLES:
 		return rolesArrayFields
+	case CHALLENGE_QUESTIONS:
+		return challengeQuestionsArrayFields
 	default:
 		return []string{}
 	}

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -49,26 +49,28 @@ type ServerConfigs struct {
 }
 
 type ToolConfigs struct {
-	AllowDelete        bool                   `json:"ALLOW_DELETE"`
-	Exclude            []string               `json:"EXCLUDE"`
-	IncludeOnly        []string               `json:"INCLUDE_ONLY"`
-	ExcludeSecrets     bool                   `json:"EXCLUDE_SECRETS"`
-	ApplicationConfigs map[string]interface{} `json:"APPLICATIONS"`
-	IdpConfigs         map[string]interface{} `json:"IDENTITY_PROVIDERS"`
-	ClaimConfigs       map[string]interface{} `json:"CLAIMS"`
-	UserStoreConfigs   map[string]interface{} `json:"USERSTORES"`
-	OidcScopeConfigs   map[string]interface{} `json:"OIDC_SCOPES"`
-	RoleConfigs        map[string]interface{} `json:"ROLES"`
+	AllowDelete              bool                   `json:"ALLOW_DELETE"`
+	Exclude                  []string               `json:"EXCLUDE"`
+	IncludeOnly              []string               `json:"INCLUDE_ONLY"`
+	ExcludeSecrets           bool                   `json:"EXCLUDE_SECRETS"`
+	ApplicationConfigs       map[string]interface{} `json:"APPLICATIONS"`
+	IdpConfigs               map[string]interface{} `json:"IDENTITY_PROVIDERS"`
+	ClaimConfigs             map[string]interface{} `json:"CLAIMS"`
+	UserStoreConfigs         map[string]interface{} `json:"USERSTORES"`
+	OidcScopeConfigs         map[string]interface{} `json:"OIDC_SCOPES"`
+	RoleConfigs              map[string]interface{} `json:"ROLES"`
+	ChallengeQuestionConfigs map[string]interface{} `json:"CHALLENGE_QUESTIONS"`
 }
 
 type KeywordConfigs struct {
-	KeywordMappings    map[string]interface{} `json:"KEYWORD_MAPPINGS"`
-	ApplicationConfigs map[string]interface{} `json:"APPLICATIONS"`
-	IdpConfigs         map[string]interface{} `json:"IDENTITY_PROVIDERS"`
-	ClaimConfigs       map[string]interface{} `json:"CLAIMS"`
-	UserStoreConfigs   map[string]interface{} `json:"USERSTORES"`
-	OidcScopeConfigs   map[string]interface{} `json:"OIDC_SCOPES"`
-	RoleConfigs        map[string]interface{} `json:"ROLES"`
+	KeywordMappings          map[string]interface{} `json:"KEYWORD_MAPPINGS"`
+	ApplicationConfigs       map[string]interface{} `json:"APPLICATIONS"`
+	IdpConfigs               map[string]interface{} `json:"IDENTITY_PROVIDERS"`
+	ClaimConfigs             map[string]interface{} `json:"CLAIMS"`
+	UserStoreConfigs         map[string]interface{} `json:"USERSTORES"`
+	OidcScopeConfigs         map[string]interface{} `json:"OIDC_SCOPES"`
+	RoleConfigs              map[string]interface{} `json:"ROLES"`
+	ChallengeQuestionConfigs map[string]interface{} `json:"CHALLENGE_QUESTIONS"`
 }
 
 var SERVER_CONFIGS ServerConfigs


### PR DESCRIPTION
## Purpose                                                                                                                                                   
                                                                                                                                                             
Add support for challenge question management in the IAM-CTL tool to enable export and import of challenge question sets between Identity Server environments.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662  
                                                                                                                                                               
## Goals                                                                                                                                                   

Enable users to:
   - Export/import challenge question sets between IS environments
   - Apply keyword replacement for environment-specific variables
   - Filter question sets using EXCLUDE and INCLUDE_ONLY configurations
   - Delete question sets when ALLOW_DELETE is enabled

## Approach

   - Created new `pkg/challengeQuestions` package following existing resource type pattern
   - Implemented export/import using the IS Challenge Question Management API
   - Handled API-specific requirements: POST body must be a wrapped array, PUT body contains only the `questions` array, not the full set.
   - Integrated challenge question operations into `exportAll` and `importAll` CLI commands
   - Added `CHALLENGE_QUESTIONS` resource type to configuration system (constants, array identifiers, XML root tag, array field paths, tool/keyword configs)
   - Updated authentication scope to include challenge question management permissions 

## User Stories

As a system administrator, I want to export and import challenge question sets across environments to enable version control and maintain consistent IAM configurations.

## Release Note

Added challenge question set management support to IAM-CTL tool. 

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.