### PR TITLE
Add support for Email templates resource type

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
 	challengeQuestions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/challengeQuestions"
 	claims "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/claims"
+	emailTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/emailTemplates"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
@@ -53,6 +54,7 @@ var exportAllCmd = &cobra.Command{
 			utils.OIDC_SCOPES:         oidcScopes.ExportAll,
 			utils.ROLES:               roles.ExportAll,
 			utils.CHALLENGE_QUESTIONS: challengeQuestions.ExportAll,
+			utils.EMAIL_TEMPLATES:     emailTemplates.ExportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -24,6 +24,7 @@ import (
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
 	challengeQuestions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/challengeQuestions"
 	claims "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/claims"
+	emailTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/emailTemplates"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
@@ -52,6 +53,7 @@ var importAllCmd = &cobra.Command{
 			utils.OIDC_SCOPES:         oidcScopes.ImportAll,
 			utils.ROLES:               roles.ImportAll,
 			utils.CHALLENGE_QUESTIONS: challengeQuestions.ImportAll,
+			utils.EMAIL_TEMPLATES:     emailTemplates.ImportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/pkg/challengeQuestions/export.go
+++ b/iamctl/pkg/challengeQuestions/export.go
@@ -67,7 +67,7 @@ func ExportAll(exportFilePath string, format string) {
 
 func exportChallengeSet(setId string, outputDirPath string, formatString string) error {
 
-	set, err := utils.SendGetRequest(utils.CHALLENGE_QUESTIONS, setId)
+	set, err := utils.GetResourceData(utils.CHALLENGE_QUESTIONS, setId)
 	if err != nil {
 		return fmt.Errorf("error while getting challenge question set: %w", err)
 	}

--- a/iamctl/pkg/emailTemplates/emailTemplateUtils.go
+++ b/iamctl/pkg/emailTemplates/emailTemplateUtils.go
@@ -1,0 +1,185 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package emailTemplates
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+type emailTemplateType struct {
+	ID          string          `json:"id"`
+	DisplayName string          `json:"displayName"`
+	Templates   []emailTemplate `json:"templates,omitempty"`
+}
+
+type emailTemplate struct {
+	ID string `json:"id"`
+}
+
+func getEmailTemplateTypeList() ([]emailTemplateType, error) {
+
+	var list []emailTemplateType
+	resp, err := utils.SendGetListRequest(utils.EMAIL_TEMPLATES, -1)
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving email template type list. %w", err)
+	}
+	defer resp.Body.Close()
+
+	statusCode := resp.StatusCode
+	if statusCode == 200 {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error when reading the retrieved email template type list. %w", err)
+		}
+		if err = json.Unmarshal(body, &list); err != nil {
+			return nil, fmt.Errorf("error when unmarshalling the retrieved email template type list. %w", err)
+		}
+		return list, nil
+	} else if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
+		return nil, fmt.Errorf("error while retrieving email template type list. Status code: %d, Error: %s", statusCode, errMsg)
+	}
+	return nil, fmt.Errorf("error while retrieving email template type list")
+}
+
+func getDeployedEmailTemplateTypeNames() []string {
+
+	types, err := getEmailTemplateTypeList()
+	if err != nil {
+		return []string{}
+	}
+
+	var typeNames []string
+	for _, t := range types {
+		typeNames = append(typeNames, t.DisplayName)
+	}
+	return typeNames
+}
+
+func getDeployedEmailTemplatesList(templateType emailTemplateType) []string {
+
+	var templateIds []string
+	for _, t := range templateType.Templates {
+		templateIds = append(templateIds, t.ID)
+	}
+	return templateIds
+}
+
+func getEmailTemplateTypeDetails(typeId string) (*emailTemplateType, error) {
+
+	jsonBytes, err := utils.SendGetRequest(utils.EMAIL_TEMPLATES, typeId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting email template type details: %w", err)
+	}
+
+	var templateType emailTemplateType
+	if err := json.Unmarshal(jsonBytes, &templateType); err != nil {
+		return nil, fmt.Errorf("error deserializing email template type details: %w", err)
+	}
+	return &templateType, nil
+}
+
+func createEmailTemplateType(displayName string) (*emailTemplateType, error) {
+
+	body := map[string]string{"displayName": displayName}
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling create type request: %w", err)
+	}
+
+	resp, err := utils.SendPostRequest(utils.EMAIL_TEMPLATES, jsonBody)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading create type response: %w", err)
+	}
+
+	var created emailTemplateType
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return nil, fmt.Errorf("error parsing create type response: %w", err)
+	}
+
+	return &created, nil
+}
+
+func isEmailTemplateTypeExists(displayName string, types []emailTemplateType) *emailTemplateType {
+
+	for i := range types {
+		if types[i].DisplayName == displayName {
+			return &types[i]
+		}
+	}
+	return nil
+}
+
+func isTemplateExists(templateId string, deployedTemplates []emailTemplate) bool {
+
+	for _, t := range deployedTemplates {
+		if t.ID == templateId {
+			return true
+		}
+	}
+	return false
+}
+
+func getEmailTemplateKeywordMapping(typeName string) map[string]interface{} {
+
+	if utils.KEYWORD_CONFIGS.EmailTemplateConfigs != nil {
+		return utils.ResolveAdvancedKeywordMapping(typeName, utils.KEYWORD_CONFIGS.EmailTemplateConfigs)
+	}
+	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func removeDeletedLocalTypeDirectories(parentDir string, deployedTypeNames []string) {
+
+	localEntries, err := os.ReadDir(parentDir)
+	if err != nil {
+		log.Println("Error loading directory:", err)
+		return
+	}
+
+	deployedNames := make(map[string]struct{})
+	for _, name := range deployedTypeNames {
+		deployedNames[name] = struct{}{}
+	}
+
+	for _, entry := range localEntries {
+		if !entry.IsDir() {
+			continue
+		}
+		if _, exists := deployedNames[entry.Name()]; !exists {
+			typeDir := filepath.Join(parentDir, entry.Name())
+			if err := os.RemoveAll(typeDir); err != nil {
+				log.Printf("Error when removing the directory %s: %s", entry.Name(), err)
+			} else {
+				log.Println("Removed the directory:", entry.Name())
+			}
+		}
+	}
+}

--- a/iamctl/pkg/emailTemplates/export.go
+++ b/iamctl/pkg/emailTemplates/export.go
@@ -1,0 +1,125 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package emailTemplates
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ExportAll(exportFilePath string, format string) {
+
+	log.Println("Exporting email templates...")
+	exportFilePath = filepath.Join(exportFilePath, utils.EMAIL_TEMPLATES.String())
+
+	if utils.IsResourceTypeExcluded(utils.EMAIL_TEMPLATES) {
+		return
+	}
+	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
+		os.MkdirAll(exportFilePath, 0700)
+	} else {
+		if utils.TOOL_CONFIGS.AllowDelete {
+			deployedTypeNames := getDeployedEmailTemplateTypeNames()
+			removeDeletedLocalTypeDirectories(exportFilePath, deployedTypeNames)
+		}
+	}
+
+	types, err := getEmailTemplateTypeList()
+	if err != nil {
+		log.Println("Error: when exporting email templates.", err)
+	} else {
+		for _, emailType := range types {
+			if !utils.IsResourceExcluded(emailType.DisplayName, utils.TOOL_CONFIGS.EmailTemplateConfigs) {
+				log.Println("Exporting email template type:", emailType.DisplayName)
+				err := exportEmailTemplateType(emailType.ID, emailType.DisplayName, exportFilePath, format)
+				if err != nil {
+					utils.UpdateFailureSummary(utils.EMAIL_TEMPLATES, emailType.DisplayName)
+					log.Printf("Error while exporting email template type: %s. %s", emailType.DisplayName, err)
+				} else {
+					utils.UpdateSuccessSummary(utils.EMAIL_TEMPLATES, utils.EXPORT)
+					log.Println("Email template type exported successfully:", emailType.DisplayName)
+				}
+			}
+		}
+	}
+
+}
+
+func exportEmailTemplateType(typeId, displayName, parentDir, formatString string) error {
+
+	typeDetails, err := getEmailTemplateTypeDetails(typeId)
+	if err != nil {
+		return fmt.Errorf("error getting template type details: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	typeDir := filepath.Join(parentDir, displayName)
+
+	if _, err := os.Stat(typeDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(typeDir, 0700); err != nil {
+			return fmt.Errorf("error creating template type directory: %w", err)
+		}
+	} else {
+		if utils.TOOL_CONFIGS.AllowDelete {
+			deployedTemplateIds := getDeployedEmailTemplatesList(*typeDetails)
+			utils.RemoveDeletedLocalResources(typeDir, deployedTemplateIds)
+		}
+	}
+
+	keywordMapping := getEmailTemplateKeywordMapping(displayName)
+	for _, template := range typeDetails.Templates {
+		err := exportEmailTemplate(typeId, template.ID, typeDir, format, keywordMapping)
+		if err != nil {
+			return fmt.Errorf("error while exporting email template: %s. %w", template.ID, err)
+		}
+	}
+
+	return nil
+}
+
+func exportEmailTemplate(typeId, templateId, typeDir string, format utils.Format, keywordMapping map[string]interface{}) error {
+
+	templateData, err := utils.GetResourceData(utils.EMAIL_TEMPLATES, typeId+"/templates/"+templateId)
+	if err != nil {
+		return fmt.Errorf("error while getting email template: %w", err)
+	}
+
+	exportedFileName := utils.GetExportedFilePath(typeDir, templateId, format)
+
+	modifiedData, err := utils.ProcessExportedData(templateData, exportedFileName, format, keywordMapping, utils.EMAIL_TEMPLATES)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedData, format, utils.EMAIL_TEMPLATES)
+	if err != nil {
+		return fmt.Errorf("error while serializing email template: %w", err)
+	}
+
+	err = os.WriteFile(exportedFileName, modifiedFile, 0644)
+	if err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/emailTemplates/import.go
+++ b/iamctl/pkg/emailTemplates/import.go
@@ -1,0 +1,237 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package emailTemplates
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ImportAll(inputDirPath string) {
+
+	log.Println("Importing email templates...")
+	importFilePath := filepath.Join(inputDirPath, utils.EMAIL_TEMPLATES.String())
+
+	if utils.IsResourceTypeExcluded(utils.EMAIL_TEMPLATES) {
+		return
+	}
+	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
+		log.Println("No email templates to import.")
+		return
+	}
+
+	deployedTypes, err := getEmailTemplateTypeList()
+	if err != nil {
+		log.Println("Error retrieving deployed email template types:", err)
+		return
+	}
+
+	localTypeDirs, err := os.ReadDir(importFilePath)
+	if err != nil {
+		log.Println("Error reading email templates directory:", err)
+		return
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		removeDeletedDeployedTypes(localTypeDirs, deployedTypes)
+	}
+
+	for _, entry := range localTypeDirs {
+		if !entry.IsDir() {
+			continue
+		}
+		displayName := entry.Name()
+		localTypePath := filepath.Join(importFilePath, displayName)
+
+		if !utils.IsResourceExcluded(displayName, utils.TOOL_CONFIGS.EmailTemplateConfigs) {
+			err := importEmailTemplateType(localTypePath, displayName, deployedTypes)
+			if err != nil {
+				utils.UpdateFailureSummary(utils.EMAIL_TEMPLATES, displayName)
+				log.Printf("Error importing email template type %s: %s", displayName, err)
+			}
+		}
+	}
+}
+
+func importEmailTemplateType(localTypePath, displayName string, deployedTypes []emailTemplateType) error {
+
+	var typeId string
+	existingType := isEmailTemplateTypeExists(displayName, deployedTypes)
+	if existingType == nil {
+		log.Println("Creating new email template type:", displayName)
+		created, err := createEmailTemplateType(displayName)
+		if err != nil {
+			return fmt.Errorf("error creating email template type: %w", err)
+		}
+		typeId = created.ID
+	} else {
+		log.Println("Updating email template type:", displayName)
+		typeId = existingType.ID
+	}
+
+	typeDetails, err := getEmailTemplateTypeDetails(typeId)
+	if err != nil {
+		return fmt.Errorf("error getting deployed templates: %w", err)
+	}
+
+	localFiles, err := os.ReadDir(localTypePath)
+	if err != nil {
+		return fmt.Errorf("error reading local template files: %w", err)
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		err := removeDeletedDeployedTemplates(typeId, localFiles, typeDetails.Templates)
+		if err != nil {
+			return fmt.Errorf("error removing deleted deployed templates: %w", err)
+		}
+	}
+
+	keywordMapping := getEmailTemplateKeywordMapping(displayName)
+
+	for _, file := range localFiles {
+		filePath := filepath.Join(localTypePath, file.Name())
+		fileInfo := utils.GetFileInfo(filePath)
+		templateId := fileInfo.ResourceName
+
+		templateExists := isTemplateExists(templateId, typeDetails.Templates)
+
+		err := importEmailTemplate(typeId, templateId, filePath, keywordMapping, templateExists)
+		if err != nil {
+			return fmt.Errorf("error importing template: %s. %w", templateId, err)
+		}
+	}
+
+	if existingType != nil {
+		utils.UpdateSuccessSummary(utils.EMAIL_TEMPLATES, utils.UPDATE)
+		log.Println("Email template type updated successfully")
+	} else {
+		utils.UpdateSuccessSummary(utils.EMAIL_TEMPLATES, utils.IMPORT)
+		log.Println("Email template type imported successfully")
+	}
+
+	return nil
+}
+
+func importEmailTemplate(typeId, templateId, filePath string, keywordMapping map[string]interface{}, templateExists bool) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(filePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format for email template: %w", err)
+	}
+
+	fileBytes, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("error when reading the file for email template: %w", err)
+	}
+
+	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), keywordMapping)
+
+	if !templateExists {
+		return createTemplate(typeId, []byte(modifiedFileData), format)
+	}
+	return updateTemplate(typeId, templateId, []byte(modifiedFileData), format)
+}
+
+func createTemplate(typeId string, requestBody []byte, format utils.Format) error {
+
+	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.EMAIL_TEMPLATES)
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPostRequest(utils.EMAIL_TEMPLATES, jsonBody, typeId)
+	if err != nil {
+		return fmt.Errorf("error when creating email template: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func updateTemplate(typeId, templateId string, requestBody []byte, format utils.Format) error {
+
+	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.EMAIL_TEMPLATES)
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPutRequest(utils.EMAIL_TEMPLATES, typeId+"/templates/"+templateId, jsonBody)
+	if err != nil {
+		return fmt.Errorf("error when updating email template: %w", err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func removeDeletedDeployedTypes(localDirs []os.DirEntry, deployedTypes []emailTemplateType) {
+
+	if len(deployedTypes) == 0 {
+		return
+	}
+
+	localNames := make(map[string]struct{})
+	for _, dir := range localDirs {
+		if dir.IsDir() {
+			localNames[dir.Name()] = struct{}{}
+		}
+	}
+
+	for _, deployedType := range deployedTypes {
+		if _, existsLocally := localNames[deployedType.DisplayName]; existsLocally {
+			continue
+		}
+		if utils.IsResourceExcluded(deployedType.DisplayName, utils.TOOL_CONFIGS.EmailTemplateConfigs) {
+			log.Printf("Email template type: %s is excluded from deletion.", deployedType.DisplayName)
+			continue
+		}
+		log.Println("Email template type not found locally. Deleting template type:", deployedType.DisplayName)
+		if err := utils.SendDeleteRequest(deployedType.ID, utils.EMAIL_TEMPLATES); err != nil {
+			utils.UpdateFailureSummary(utils.EMAIL_TEMPLATES, deployedType.DisplayName)
+			log.Printf("Error deleting email template type: %s", err)
+		} else {
+			utils.UpdateSuccessSummary(utils.EMAIL_TEMPLATES, utils.DELETE)
+		}
+	}
+}
+
+func removeDeletedDeployedTemplates(typeId string, localFiles []os.DirEntry, deployedTemplates []emailTemplate) error {
+
+	if len(deployedTemplates) == 0 {
+		return nil
+	}
+
+	localIds := make(map[string]struct{})
+	for _, file := range localFiles {
+		resourceName := utils.GetFileInfo(file.Name()).ResourceName
+		localIds[resourceName] = struct{}{}
+	}
+
+	for _, template := range deployedTemplates {
+		if _, existsLocally := localIds[template.ID]; !existsLocally {
+			log.Println("Email template not found locally. Deleting template:", template.ID)
+			if err := utils.SendDeleteRequest(typeId+"/templates/"+template.ID, utils.EMAIL_TEMPLATES); err != nil {
+				return fmt.Errorf("error deleting email template: %w", err)
+			}
+		}
+	}
+	return nil
+}

--- a/iamctl/pkg/oidcScopes/export.go
+++ b/iamctl/pkg/oidcScopes/export.go
@@ -67,7 +67,7 @@ func ExportAll(exportFilePath string, format string) {
 
 func exportOidcScope(scopeName string, outputDirPath string, formatString string) error {
 
-	scope, err := utils.SendGetRequest(utils.OIDC_SCOPES, scopeName)
+	scope, err := utils.GetResourceData(utils.OIDC_SCOPES, scopeName)
 	if err != nil {
 		return fmt.Errorf("error while getting OIDC scope: %w", err)
 	}

--- a/iamctl/pkg/oidcScopes/import.go
+++ b/iamctl/pkg/oidcScopes/import.go
@@ -133,6 +133,7 @@ func updateScope(scopeId string, requestBody []byte, format utils.Format, scopeN
 }
 
 func removeDeletedDeployedScopes(localFiles []os.DirEntry, deployedScopes []oidcScope) {
+
 	if len(deployedScopes) == 0 {
 		return
 	}

--- a/iamctl/pkg/roles/export.go
+++ b/iamctl/pkg/roles/export.go
@@ -69,7 +69,7 @@ func ExportAll(exportFilePath string, format string) {
 
 func exportRole(r role, outputDirPath string, formatString string) error {
 
-	roleData, err := utils.SendGetRequest(utils.ROLES, r.Id)
+	roleData, err := utils.GetResourceData(utils.ROLES, r.Id)
 	if err != nil {
 		return fmt.Errorf("error while getting role: %w", err)
 	}

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -30,6 +30,7 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
+	"path"
 	"strconv"
 	"strings"
 )
@@ -292,7 +293,21 @@ func SendDeleteRequest(resourceId string, resourceType ResourceType) error {
 	return fmt.Errorf("unexpected error when deleting resource: %s", resp.Status)
 }
 
-func SendGetRequest(resourceType ResourceType, resourceId string) (interface{}, error) {
+func GetResourceData(resourceType ResourceType, resourceId string) (interface{}, error) {
+
+	body, err := SendGetRequest(resourceType, resourceId)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := Deserialize(body, FormatJSON, resourceType)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing JSON response: %w", err)
+	}
+	return data, nil
+}
+
+func SendGetRequest(resourceType ResourceType, resourceId string) ([]byte, error) {
 
 	reqUrl := buildRequestUrl(GET, resourceType, resourceId)
 	formattedReqUrl := addQueryParams(reqUrl, resourceType, GET)
@@ -330,17 +345,14 @@ func SendGetRequest(resourceType ResourceType, resourceId string) (interface{}, 
 		return nil, fmt.Errorf("error reading response body: %w", err)
 	}
 
-	data, err := Deserialize(body, FormatJSON, resourceType)
-	if err != nil {
-		return nil, fmt.Errorf("error deserializing JSON response: %w", err)
-	}
-
-	return data, nil
+	return body, nil
 }
 
-func SendPostRequest(resourceType ResourceType, requestBody []byte) (*http.Response, error) {
+func SendPostRequest(resourceType ResourceType, requestBody []byte, pathSuffix ...string) (*http.Response, error) {
 
-	reqUrl := buildRequestUrl(POST, resourceType, "")
+	combinedSuffix := path.Join(pathSuffix...)
+	reqUrl := buildRequestUrl(POST, resourceType, combinedSuffix)
+
 	request, err := http.NewRequest("POST", reqUrl, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("error creating POST request: %w", err)
@@ -482,6 +494,8 @@ func getResourcePath(resourceType ResourceType) string {
 		return "oidc/scopes"
 	case CHALLENGE_QUESTIONS:
 		return "challenges"
+	case EMAIL_TEMPLATES:
+		return "email/template-types"
 	}
 	return ""
 }
@@ -522,7 +536,7 @@ func buildRequestUrl(requestType string, resourceType ResourceType, resourceId s
 	case GET:
 		reqUrl = getResourceBaseUrl(resourceType) + resourceId
 	case POST:
-		reqUrl = getResourceBaseUrl(resourceType)
+		reqUrl = getResourceBaseUrl(resourceType) + resourceId
 	case PUT:
 		reqUrl = getResourceBaseUrl(resourceType) + resourceId
 	case PATCH:

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -26,6 +26,7 @@ const USERSTORES_CONFIG = "USERSTORES"
 const OIDC_SCOPES_CONFIG = "OIDC_SCOPES"
 const ROLES_CONFIG = "ROLES"
 const CHALLENGE_QUESTIONS_CONFIG = "CHALLENGE_QUESTIONS"
+const EMAIL_TEMPLATES_CONFIG = "EMAIL_TEMPLATES"
 
 // Tool configs
 const EXCLUDE_CONFIG = "EXCLUDE"
@@ -57,6 +58,7 @@ const (
 	OIDC_SCOPES         ResourceType = "OidcScopes"
 	ROLES               ResourceType = "Roles"
 	CHALLENGE_QUESTIONS ResourceType = "ChallengeQuestions"
+	EMAIL_TEMPLATES     ResourceType = "EmailTemplates"
 )
 
 // Config file names
@@ -184,4 +186,5 @@ const (
 	XML_ROOT_OIDC_SCOPE         = "Scope"
 	XML_ROOT_ROLE               = "Role"
 	XML_ROOT_CHALLENGE_QUESTION = "ChallengeSet"
+	XML_ROOT_EMAIL_TEMPLATE     = "EmailTemplate"
 )

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -36,7 +36,8 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_application_business_api_update internal_application_internal_api_update internal_org_application_business_api_update internal_org_application_internal_api_update " +
 	"internal_oidc_scope_mgt_view internal_oidc_scope_mgt_create internal_oidc_scope_mgt_update internal_oidc_scope_mgt_delete " +
 	"internal_role_mgt_view internal_role_mgt_create internal_role_mgt_update internal_role_mgt_delete " +
-	"internal_identity_mgt_view internal_identity_mgt_create internal_identity_mgt_update internal_identity_mgt_delete"
+	"internal_identity_mgt_view internal_identity_mgt_create internal_identity_mgt_update internal_identity_mgt_delete " +
+	"internal_email_mgt_view internal_email_mgt_create internal_email_mgt_update internal_email_mgt_delete"
 
 const (
 	AppName       = "IAM-CTL"

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -32,4 +32,5 @@ var ResourceOrder = []ResourceType{
 	OIDC_SCOPES,
 	ROLES, // Dependency: Applications
 	CHALLENGE_QUESTIONS,
+	EMAIL_TEMPLATES,
 }

--- a/iamctl/pkg/utils/serializationUtils.go
+++ b/iamctl/pkg/utils/serializationUtils.go
@@ -159,6 +159,7 @@ func GetXMLRootTag(resourceType ResourceType) string {
 		OIDC_SCOPES:         XML_ROOT_OIDC_SCOPE,
 		ROLES:               XML_ROOT_ROLE,
 		CHALLENGE_QUESTIONS: XML_ROOT_CHALLENGE_QUESTION,
+		EMAIL_TEMPLATES:     XML_ROOT_EMAIL_TEMPLATE,
 	}
 	return xmlRootTags[resourceType]
 }

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -60,6 +60,7 @@ type ToolConfigs struct {
 	OidcScopeConfigs         map[string]interface{} `json:"OIDC_SCOPES"`
 	RoleConfigs              map[string]interface{} `json:"ROLES"`
 	ChallengeQuestionConfigs map[string]interface{} `json:"CHALLENGE_QUESTIONS"`
+	EmailTemplateConfigs     map[string]interface{} `json:"EMAIL_TEMPLATES"`
 }
 
 type KeywordConfigs struct {
@@ -71,6 +72,7 @@ type KeywordConfigs struct {
 	OidcScopeConfigs         map[string]interface{} `json:"OIDC_SCOPES"`
 	RoleConfigs              map[string]interface{} `json:"ROLES"`
 	ChallengeQuestionConfigs map[string]interface{} `json:"CHALLENGE_QUESTIONS"`
+	EmailTemplateConfigs     map[string]interface{} `json:"EMAIL_TEMPLATES"`
 }
 
 var SERVER_CONFIGS ServerConfigs


### PR DESCRIPTION
## Purpose                                                                                                                                                  
                                                                                                                                                               
 Add support for email template management in the IAM-CTL tool to enable export and import of email templates between Identity Server environments.  

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662           
   
## Goals                                                                                                                                                    
                                                            
Enable users to:
  - Export/import email templates between IS environments, preserving both template types and their locale specific template content
  - Apply keyword replacement for environment specific variables in template content
  - Filter template types using `EXCLUDE` and `INCLUDE_ONLY` configurations
  - Delete template types and individual templates when `ALLOW_DELETE` is enabled

## Approach

Email templates follow a two-level hierarchy that required handling beyond the standard single resource pattern:
```
EmailTemplates/
|--- AccountConfirmation/
|    |--- en_US.yml
|--- idleAccountReminder/
|    |--- en_US.yml
|    |--- ga-IE.yml
```
  - Created new `pkg/emailTemplates` package following existing resource type patterns
  - Each template type maps to a **subdirectory** named by its `displayName`. Each template inside is a file named `{templateId}.{ext}`
  - Export fetches all types, creates a subdirectory per type, then fetches each template individually via GET and writes as a serialized file
  - Import reads subdirectories, resolves the type ID (creating the type via POST if absent, reusing the existing ID if present), then syncs template files within each type directory
  - Two-layer deletion under `ALLOW_DELETE`:
    - **Type layer**: template types present in the upstream but missing as a local directory are deleted
    - **Template layer**: within each type, locale templates present in the upstream but missing as a local file are deleted
  - On export, stale local type directories are removed using `removeDeletedLocalTypeDirectories`; stale template files within a type directory are removed using the shared `utils.RemoveDeletedLocalResources`
  - Template create/update uses the pathSuffix extension on `SendPostRequest` (typeId suffix routes the POST to `/email/template-types/{typeId}`) and `SendPutRequest` with a composite ID (`typeId/templates/templateId`)
  - `EXCLUDE` / `INCLUDE_ONLY` filtering is applied at the template type level
  - Integrated email template operations into `exportAll` and `importAll` CLI commands
  - Added `EMAIL_TEMPLATES` resource type to the configuration system (constants, tool configs, keyword mapping, resource order)
  - Updated authentication scope to include email template management permissions

## User Stories

As a system administrator, I want to export and import email templates across environments to enable version control and maintain consistent notification configurations in Identity Server deployments.

## Release Note

Added email template management support to the IAM-CTL tool.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.