### PR TITLE
Add support for Script libraries resource type

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -28,6 +28,7 @@ import (
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
+	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
 	userstores "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/userStores"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -55,6 +56,7 @@ var exportAllCmd = &cobra.Command{
 			utils.ROLES:               roles.ExportAll,
 			utils.CHALLENGE_QUESTIONS: challengeQuestions.ExportAll,
 			utils.EMAIL_TEMPLATES:     emailTemplates.ExportAll,
+			utils.SCRIPT_LIBRARIES:    scriptLibraries.ExportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -28,6 +28,7 @@ import (
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
+	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
 	userstores "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/userStores"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -54,6 +55,7 @@ var importAllCmd = &cobra.Command{
 			utils.ROLES:               roles.ImportAll,
 			utils.CHALLENGE_QUESTIONS: challengeQuestions.ImportAll,
 			utils.EMAIL_TEMPLATES:     emailTemplates.ImportAll,
+			utils.SCRIPT_LIBRARIES:    scriptLibraries.ImportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/pkg/emailTemplates/import.go
+++ b/iamctl/pkg/emailTemplates/import.go
@@ -157,7 +157,7 @@ func createTemplate(typeId string, requestBody []byte, format utils.Format) erro
 		return err
 	}
 
-	resp, err := utils.SendPostRequest(utils.EMAIL_TEMPLATES, jsonBody, typeId)
+	resp, err := utils.SendPostRequest(utils.EMAIL_TEMPLATES, jsonBody, utils.WithPathSuffix(typeId))
 	if err != nil {
 		return fmt.Errorf("error when creating email template: %w", err)
 	}

--- a/iamctl/pkg/scriptLibraries/export.go
+++ b/iamctl/pkg/scriptLibraries/export.go
@@ -1,0 +1,95 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package scriptLibraries
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ExportAll(exportFilePath string, format string) {
+
+	log.Println("Exporting script libraries...")
+	exportFilePath = filepath.Join(exportFilePath, utils.SCRIPT_LIBRARIES.String())
+
+	if utils.IsResourceTypeExcluded(utils.SCRIPT_LIBRARIES) {
+		return
+	}
+	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
+		os.MkdirAll(exportFilePath, 0700)
+	} else {
+		if utils.TOOL_CONFIGS.AllowDelete {
+			deployedNames := getDeployedScriptLibraryNames()
+			utils.RemoveDeletedLocalResources(exportFilePath, deployedNames)
+		}
+	}
+
+	libraries, err := getScriptLibraryList()
+	if err != nil {
+		log.Println("Error: when exporting script libraries.", err)
+	} else {
+		for _, library := range libraries {
+			if !utils.IsResourceExcluded(library.Name, utils.TOOL_CONFIGS.ScriptLibraryConfigs) {
+				log.Println("Exporting script library: ", library.Name)
+
+				err := exportScriptLibrary(library.Name, exportFilePath, format)
+				if err != nil {
+					utils.UpdateFailureSummary(utils.SCRIPT_LIBRARIES, library.Name)
+					log.Printf("Error while exporting script library: %s. %s", library.Name, err)
+				} else {
+					utils.UpdateSuccessSummary(utils.SCRIPT_LIBRARIES, utils.EXPORT)
+					log.Println("Script library exported successfully: ", library.Name)
+				}
+			}
+		}
+	}
+}
+
+func exportScriptLibrary(libraryName string, outputDirPath string, formatString string) error {
+
+	libraryData, err := getScriptLibraryData(libraryName)
+	if err != nil {
+		return fmt.Errorf("error while getting script library: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, libraryName, format)
+
+	keywordMapping := getScriptLibraryKeywordMapping(libraryName)
+	modifiedData, err := utils.ProcessExportedData(libraryData, exportedFileName, format, keywordMapping, utils.SCRIPT_LIBRARIES)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedData, format, utils.SCRIPT_LIBRARIES)
+	if err != nil {
+		return fmt.Errorf("error while serializing script library: %w", err)
+	}
+
+	err = os.WriteFile(exportedFileName, modifiedFile, 0644)
+	if err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/scriptLibraries/import.go
+++ b/iamctl/pkg/scriptLibraries/import.go
@@ -1,0 +1,163 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package scriptLibraries
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ImportAll(inputDirPath string) {
+
+	log.Println("Importing script libraries...")
+	importFilePath := filepath.Join(inputDirPath, utils.SCRIPT_LIBRARIES.String())
+
+	if utils.IsResourceTypeExcluded(utils.SCRIPT_LIBRARIES) {
+		return
+	}
+	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
+		log.Println("No script libraries to import.")
+		return
+	}
+
+	existingList, err := getScriptLibraryList()
+	if err != nil {
+		log.Println("Error retrieving the deployed script library list: ", err)
+		return
+	}
+
+	files, err := os.ReadDir(importFilePath)
+	if err != nil {
+		log.Println("Error importing script libraries: ", err)
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		removeDeletedDeployedScriptLibraries(files, existingList)
+	}
+
+	for _, file := range files {
+		libraryFilePath := filepath.Join(importFilePath, file.Name())
+		fileInfo := utils.GetFileInfo(libraryFilePath)
+		libraryName := fileInfo.ResourceName
+
+		if !utils.IsResourceExcluded(libraryName, utils.TOOL_CONFIGS.ScriptLibraryConfigs) {
+			libraryExists := isScriptLibraryExists(libraryName, existingList)
+			err := importScriptLibrary(libraryName, libraryExists, libraryFilePath)
+			if err != nil {
+				log.Println("Error importing script library: ", err)
+				utils.UpdateFailureSummary(utils.SCRIPT_LIBRARIES, libraryName)
+			}
+		}
+	}
+}
+
+func importScriptLibrary(libraryName string, libraryExists bool, importFilePath string) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format for script library: %w", err)
+	}
+
+	fileBytes, err := os.ReadFile(importFilePath)
+	if err != nil {
+		return fmt.Errorf("error when reading the file for script library: %w", err)
+	}
+
+	keywordMapping := getScriptLibraryKeywordMapping(libraryName)
+	modifiedFileData := []byte(utils.ReplaceKeywords(string(fileBytes), keywordMapping))
+
+	if !libraryExists {
+		return createScriptLibrary(libraryName, modifiedFileData, format)
+	}
+	return updateScriptLibrary(libraryName, modifiedFileData, format)
+}
+
+func createScriptLibrary(name string, data []byte, format utils.Format) error {
+
+	log.Println("Creating new script library: " + name)
+
+	body, contentType, err := utils.PrepareMultipartFormBody(data, format, utils.SCRIPT_LIBRARIES)
+	if err != nil {
+		return fmt.Errorf("error building multipart form: %w", err)
+	}
+
+	resp, err := utils.SendPostRequest(utils.SCRIPT_LIBRARIES, body, utils.WithContentType(contentType))
+	if err != nil {
+		return fmt.Errorf("error when creating script library: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.SCRIPT_LIBRARIES, utils.IMPORT)
+	log.Println("Script library created successfully.")
+	return nil
+}
+
+func updateScriptLibrary(name string, data []byte, format utils.Format) error {
+
+	log.Println("Updating script library: " + name)
+
+	body, contentType, err := utils.PrepareMultipartFormBody(data, format, utils.SCRIPT_LIBRARIES, "name")
+	if err != nil {
+		return fmt.Errorf("error building multipart form: %w", err)
+	}
+
+	resp, err := utils.SendPutRequest(utils.SCRIPT_LIBRARIES, name, body, utils.WithContentType(contentType))
+	if err != nil {
+		return fmt.Errorf("error when updating script library: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.SCRIPT_LIBRARIES, utils.UPDATE)
+	log.Println("Script library updated successfully.")
+	return nil
+}
+
+func removeDeletedDeployedScriptLibraries(localFiles []os.DirEntry, deployedLibraries []scriptLibrary) {
+
+	if len(deployedLibraries) == 0 {
+		return
+	}
+
+	localResourceNames := make(map[string]struct{})
+	for _, file := range localFiles {
+		resourceName := utils.GetFileInfo(file.Name()).ResourceName
+		localResourceNames[resourceName] = struct{}{}
+	}
+
+	for _, library := range deployedLibraries {
+		if _, existsLocally := localResourceNames[library.Name]; existsLocally {
+			continue
+		}
+		if utils.IsResourceExcluded(library.Name, utils.TOOL_CONFIGS.ScriptLibraryConfigs) {
+			log.Println("Script library is excluded from deletion:", library.Name)
+			continue
+		}
+
+		log.Printf("Script library: %s not found locally. Deleting library.\n", library.Name)
+		if err := utils.SendDeleteRequest(library.Name, utils.SCRIPT_LIBRARIES); err != nil {
+			utils.UpdateFailureSummary(utils.SCRIPT_LIBRARIES, library.Name)
+			log.Println("Error deleting script library:", library.Name, err)
+		} else {
+			utils.UpdateSuccessSummary(utils.SCRIPT_LIBRARIES, utils.DELETE)
+		}
+	}
+}

--- a/iamctl/pkg/scriptLibraries/scriptLibraryUtils.go
+++ b/iamctl/pkg/scriptLibraries/scriptLibraryUtils.go
@@ -1,0 +1,118 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package scriptLibraries
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+type scriptLibrary struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type scriptLibraryListResponse struct {
+	ScriptLibraries []scriptLibrary `json:"scriptLibraries"`
+}
+
+func getScriptLibraryList() ([]scriptLibrary, error) {
+
+	resp, err := utils.SendGetListRequest(utils.SCRIPT_LIBRARIES, -1)
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving script library list. %w", err)
+	}
+	defer resp.Body.Close()
+
+	statusCode := resp.StatusCode
+	if statusCode == 200 {
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error when reading the retrieved script library list. %w", err)
+		}
+
+		var listResponse scriptLibraryListResponse
+		err = json.Unmarshal(body, &listResponse)
+		if err != nil {
+			return nil, fmt.Errorf("error when unmarshalling the retrieved script library list. %w", err)
+		}
+
+		return listResponse.ScriptLibraries, nil
+	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
+		return nil, fmt.Errorf("error while retrieving script library list. Status code: %d, Error: %s", statusCode, error)
+	}
+	return nil, fmt.Errorf("error while retrieving script library list")
+}
+
+func getDeployedScriptLibraryNames() []string {
+
+	libraries, err := getScriptLibraryList()
+	if err != nil {
+		return []string{}
+	}
+
+	var names []string
+	for _, library := range libraries {
+		names = append(names, library.Name)
+	}
+	return names
+}
+
+func getScriptLibraryKeywordMapping(libraryName string) map[string]interface{} {
+
+	if utils.KEYWORD_CONFIGS.ScriptLibraryConfigs != nil {
+		return utils.ResolveAdvancedKeywordMapping(libraryName, utils.KEYWORD_CONFIGS.ScriptLibraryConfigs)
+	}
+	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func isScriptLibraryExists(libraryName string, existingList []scriptLibrary) bool {
+
+	for _, library := range existingList {
+		if library.Name == libraryName {
+			return true
+		}
+	}
+	return false
+}
+
+func getScriptLibraryData(libraryName string) (map[string]interface{}, error) {
+
+	libraryData, err := utils.GetResourceData(utils.SCRIPT_LIBRARIES, libraryName)
+	if err != nil {
+		return nil, fmt.Errorf("error while getting script library: %w", err)
+	}
+
+	contentBytes, err := utils.SendGetRequest(utils.SCRIPT_LIBRARIES, libraryName+"/content")
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving script library content: %w", err)
+	}
+
+	dataMap, ok := libraryData.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected format for script library response")
+	}
+	delete(dataMap, "content-ref")
+	dataMap["content"] = string(contentBytes)
+	return dataMap, nil
+}
+

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -30,7 +30,6 @@ import (
 	"net/http"
 	"net/textproto"
 	"net/url"
-	"path"
 	"strconv"
 	"strings"
 )
@@ -45,31 +44,46 @@ const POST = "post"
 const PUT = "put"
 const PATCH = "patch"
 
+type sendConfig struct {
+	contentType string
+	pathSuffix  string
+}
+
+type SendOption func(*sendConfig)
+
 func PrepareJSONRequestBody(data []byte, format Format, resourceType ResourceType, excludeFields ...string) ([]byte, error) {
 
-	parsed, err := Deserialize(data, format, resourceType)
+	dataMap, err := deserializeToMap(data, format, resourceType, excludeFields...)
 	if err != nil {
-		return nil, fmt.Errorf("error deserializing data: %w", err)
+		return nil, err
 	}
 
-	if interfaceMap, ok := parsed.(map[interface{}]interface{}); ok {
-		parsed = ConvertToStringKeyMap(interfaceMap)
-	}
-
-	if len(excludeFields) > 0 {
-		if dataMap, ok := parsed.(map[string]interface{}); ok {
-			for _, field := range excludeFields {
-				delete(dataMap, field)
-			}
-			parsed = dataMap
-		}
-	}
-
-	jsonBody, err := Serialize(parsed, FormatJSON, resourceType)
+	jsonBody, err := Serialize(dataMap, FormatJSON, resourceType)
 	if err != nil {
 		return nil, fmt.Errorf("error serializing to JSON for request body: %w", err)
 	}
 	return jsonBody, nil
+}
+
+func PrepareMultipartFormBody(data []byte, format Format, resourceType ResourceType, excludeFields ...string) ([]byte, string, error) {
+
+	dataMap, err := deserializeToMap(data, format, resourceType, excludeFields...)
+	if err != nil {
+		return nil, "", err
+	}
+
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	for key, value := range dataMap {
+		if err := writer.WriteField(key, fmt.Sprintf("%v", value)); err != nil {
+			return nil, "", fmt.Errorf("error writing field %s: %w", key, err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return nil, "", fmt.Errorf("error closing multipart writer: %w", err)
+	}
+
+	return body.Bytes(), writer.FormDataContentType(), nil
 }
 
 func RemoveResponseFields(response interface{}, fieldsToRemove ...string) (interface{}, error) {
@@ -348,10 +362,26 @@ func SendGetRequest(resourceType ResourceType, resourceId string) ([]byte, error
 	return body, nil
 }
 
-func SendPostRequest(resourceType ResourceType, requestBody []byte, pathSuffix ...string) (*http.Response, error) {
+func WithContentType(ct string) SendOption {
+	return func(c *sendConfig) { c.contentType = ct }
+}
 
-	combinedSuffix := path.Join(pathSuffix...)
-	reqUrl := buildRequestUrl(POST, resourceType, combinedSuffix)
+func WithPathSuffix(suffix string) SendOption {
+	return func(c *sendConfig) { c.pathSuffix = suffix }
+}
+
+func applySendOptions(opts []SendOption) *sendConfig {
+	cfg := &sendConfig{contentType: MEDIA_TYPE_JSON}
+	for _, opt := range opts {
+		opt(cfg)
+	}
+	return cfg
+}
+
+func SendPostRequest(resourceType ResourceType, requestBody []byte, opts ...SendOption) (*http.Response, error) {
+
+	cfg := applySendOptions(opts)
+	reqUrl := buildRequestUrl(POST, resourceType, cfg.pathSuffix)
 
 	request, err := http.NewRequest("POST", reqUrl, bytes.NewBuffer(requestBody))
 	if err != nil {
@@ -359,7 +389,7 @@ func SendPostRequest(resourceType ResourceType, requestBody []byte, pathSuffix .
 	}
 
 	request.Header.Set("Authorization", "Bearer "+SERVER_CONFIGS.Token)
-	request.Header.Set("Content-Type", MEDIA_TYPE_JSON)
+	request.Header.Set("Content-Type", cfg.contentType)
 
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -385,16 +415,18 @@ func SendPostRequest(resourceType ResourceType, requestBody []byte, pathSuffix .
 	return resp, nil
 }
 
-func SendPutRequest(resourceType ResourceType, resourceId string, requestBody []byte) (*http.Response, error) {
+func SendPutRequest(resourceType ResourceType, resourceId string, requestBody []byte, opts ...SendOption) (*http.Response, error) {
 
+	cfg := applySendOptions(opts)
 	reqUrl := buildRequestUrl(PUT, resourceType, resourceId)
+
 	request, err := http.NewRequest("PUT", reqUrl, bytes.NewBuffer(requestBody))
 	if err != nil {
 		return nil, fmt.Errorf("error creating PUT request: %w", err)
 	}
 
 	request.Header.Set("Authorization", "Bearer "+SERVER_CONFIGS.Token)
-	request.Header.Set("Content-Type", MEDIA_TYPE_JSON)
+	request.Header.Set("Content-Type", cfg.contentType)
 
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -496,6 +528,8 @@ func getResourcePath(resourceType ResourceType) string {
 		return "challenges"
 	case EMAIL_TEMPLATES:
 		return "email/template-types"
+	case SCRIPT_LIBRARIES:
+		return "script-libraries"
 	}
 	return ""
 }

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -27,6 +27,7 @@ const OIDC_SCOPES_CONFIG = "OIDC_SCOPES"
 const ROLES_CONFIG = "ROLES"
 const CHALLENGE_QUESTIONS_CONFIG = "CHALLENGE_QUESTIONS"
 const EMAIL_TEMPLATES_CONFIG = "EMAIL_TEMPLATES"
+const SCRIPT_LIBRARIES_CONFIG = "SCRIPT_LIBRARIES"
 
 // Tool configs
 const EXCLUDE_CONFIG = "EXCLUDE"
@@ -59,6 +60,7 @@ const (
 	ROLES               ResourceType = "Roles"
 	CHALLENGE_QUESTIONS ResourceType = "ChallengeQuestions"
 	EMAIL_TEMPLATES     ResourceType = "EmailTemplates"
+	SCRIPT_LIBRARIES    ResourceType = "ScriptLibraries"
 )
 
 // Config file names
@@ -187,4 +189,5 @@ const (
 	XML_ROOT_ROLE               = "Role"
 	XML_ROOT_CHALLENGE_QUESTION = "ChallengeSet"
 	XML_ROOT_EMAIL_TEMPLATE     = "EmailTemplate"
+	XML_ROOT_SCRIPT_LIBRARY     = "ScriptLibrary"
 )

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -37,7 +37,8 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_oidc_scope_mgt_view internal_oidc_scope_mgt_create internal_oidc_scope_mgt_update internal_oidc_scope_mgt_delete " +
 	"internal_role_mgt_view internal_role_mgt_create internal_role_mgt_update internal_role_mgt_delete " +
 	"internal_identity_mgt_view internal_identity_mgt_create internal_identity_mgt_update internal_identity_mgt_delete " +
-	"internal_email_mgt_view internal_email_mgt_create internal_email_mgt_update internal_email_mgt_delete"
+	"internal_email_mgt_view internal_email_mgt_create internal_email_mgt_update internal_email_mgt_delete " +
+	"internal_functional_lib_view internal_functional_lib_create internal_functional_lib_update internal_functional_lib_delete"
 
 const (
 	AppName       = "IAM-CTL"

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -33,4 +33,5 @@ var ResourceOrder = []ResourceType{
 	ROLES, // Dependency: Applications
 	CHALLENGE_QUESTIONS,
 	EMAIL_TEMPLATES,
+	SCRIPT_LIBRARIES,
 }

--- a/iamctl/pkg/utils/serializationUtils.go
+++ b/iamctl/pkg/utils/serializationUtils.go
@@ -160,6 +160,7 @@ func GetXMLRootTag(resourceType ResourceType) string {
 		ROLES:               XML_ROOT_ROLE,
 		CHALLENGE_QUESTIONS: XML_ROOT_CHALLENGE_QUESTION,
 		EMAIL_TEMPLATES:     XML_ROOT_EMAIL_TEMPLATE,
+		SCRIPT_LIBRARIES:    XML_ROOT_SCRIPT_LIBRARY,
 	}
 	return xmlRootTags[resourceType]
 }
@@ -219,4 +220,27 @@ func FixArrayFields(data interface{}, resourceType ResourceType) interface{} {
 		}
 	}
 	return data
+}
+
+func deserializeToMap(data []byte, format Format, resourceType ResourceType, excludeFields ...string) (map[string]interface{}, error) {
+
+	parsed, err := Deserialize(data, format, resourceType)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing data: %w", err)
+	}
+
+	if interfaceMap, ok := parsed.(map[interface{}]interface{}); ok {
+		parsed = ConvertToStringKeyMap(interfaceMap)
+	}
+
+	dataMap, ok := parsed.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("data is not in expected map format")
+	}
+
+	for _, field := range excludeFields {
+		delete(dataMap, field)
+	}
+
+	return dataMap, nil
 }

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -61,6 +61,7 @@ type ToolConfigs struct {
 	RoleConfigs              map[string]interface{} `json:"ROLES"`
 	ChallengeQuestionConfigs map[string]interface{} `json:"CHALLENGE_QUESTIONS"`
 	EmailTemplateConfigs     map[string]interface{} `json:"EMAIL_TEMPLATES"`
+	ScriptLibraryConfigs     map[string]interface{} `json:"SCRIPT_LIBRARIES"`
 }
 
 type KeywordConfigs struct {
@@ -73,6 +74,7 @@ type KeywordConfigs struct {
 	RoleConfigs              map[string]interface{} `json:"ROLES"`
 	ChallengeQuestionConfigs map[string]interface{} `json:"CHALLENGE_QUESTIONS"`
 	EmailTemplateConfigs     map[string]interface{} `json:"EMAIL_TEMPLATES"`
+	ScriptLibraryConfigs     map[string]interface{} `json:"SCRIPT_LIBRARIES"`
 }
 
 var SERVER_CONFIGS ServerConfigs


### PR DESCRIPTION
## Purpose                                                                                                                                                                 
                                                                                                                                                                           
  Add support for script library management in the IAM-CTL tool to enable export and import of script libraries between Identity Server environments. 

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662                       
                                                                                                                                                                           
  ## Goals                                                                                                                                                                   
                                                                                                                                                                             
  Enable users to:
  - Export/import script libraries between IS environments
  - Apply keyword replacement for environment-specific variables
  - Filter script libraries using `EXCLUDE` and `INCLUDE_ONLY` configurations
  - Delete script libraries when `ALLOW_DELETE` is enabled

  ## Approach

  #### New `pkg/scriptLibraries` package
  Created export/import/utils files following the existing resource type pattern. Script libraries required two non-standard API interactions.

  #### Separate content fetch on export
  The Script Library Management API returns metadata and content (as raw bytes) via separate endpoints. Both are merged into a single map for serialization, with `content-ref` stripped before export.

  #### Multipart form body on import
 Unlike most resource types that accept `application/json`, the Script Library API requires `multipart/form-data` on POST and PUT. A new shared `PrepareMultipartFormBody` utility was added to `apiUtils.go`. It deserializes the file, excludes specified fields, and builds a multipart body. This is reusable for any future resource types with similar API requirements.

#### Functional options pattern for `SendPostRequest` / `SendPutRequest`                                                                                                    
  Previously `SendPostRequest` accepted a variadic `pathSuffix ...string` and always set `Content-Type: application/json`. To support two independent optional parameters (a custom content type needed for multipart and a path suffix) without a breaking API change, a functional options pattern was introduced. A `SendOption` is a function that mutates an internal `sendConfig` struct, with two options provided: `WithContentType(ct string)` and `WithPathSuffix(suffix string)`. Both `SendPostRequest` and `SendPutRequest` now accept `opts ...SendOption`, defaulting to `Content-Type: application/json` and no path suffix when no options are passed. 

  #### Shared `deserializeToMap` helper extracted
The deserialization + key-type normalization + field exclusion logic that was duplicated inside `PrepareJSONRequestBody` was extracted into a shared `deserializeToMap` helper (in `serializationUtils.go`), now reused by both `PrepareJSONRequestBody` and `PrepareMultipartFormBody`.

  #### Configuration and scope registration
`SCRIPT_LIBRARIES` was registered across all required configuration points: added as a ResourceType constant, added to both `ToolConfigs` and `KeywordConfigs`, appended to the `ResourceOrder` slice in, and added the required OAuth2 management scopes.

  ## User Stories

  As a system administrator, I want to export and import script libraries across environments to enable version control and maintain consistent IAM configurations.

  ## Release Note

  Added script library management support to IAM-CTL tool.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.