### PR TITLE
Extend Claim management to support IS versions below 6.1 and fix related bugs

### DIFF
--- a/iamctl/pkg/claims/claimUtils.go
+++ b/iamctl/pkg/claims/claimUtils.go
@@ -22,10 +22,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
 	"regexp"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
-	"gopkg.in/yaml.v3"
 )
 
 type claimDialect struct {
@@ -67,6 +69,20 @@ func getClaimDialectsList() ([]claimDialect, error) {
 	return nil, fmt.Errorf("unexpected error while retrieving claim dialect list")
 }
 
+func getClaimsList(dialectId string) ([]map[string]interface{}, error) {
+
+	body, err := utils.SendGetRequest(utils.CLAIMS, dialectId+"/claims")
+	if err != nil {
+		return nil, fmt.Errorf("error while getting claims for dialect. %w", err)
+	}
+
+	var list []map[string]interface{}
+	if err := json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling claims list. %w", err)
+	}
+	return list, nil
+}
+
 func getClaimKeywordMapping(claimDialectName string) map[string]interface{} {
 
 	if utils.KEYWORD_CONFIGS.ClaimConfigs != nil {
@@ -75,12 +91,7 @@ func getClaimKeywordMapping(claimDialectName string) map[string]interface{} {
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }
 
-func getDeployedClaimDialectNames() []string {
-
-	claimDialects, err := getClaimDialectsList()
-	if err != nil {
-		return []string{}
-	}
+func getDeployedDialectFileNames(claimDialects []claimDialect) []string {
 
 	var claimDialectNames []string
 	for _, claimDialect := range claimDialects {
@@ -88,6 +99,52 @@ func getDeployedClaimDialectNames() []string {
 		claimDialectNames = append(claimDialectNames, formattedName)
 	}
 	return claimDialectNames
+}
+
+func parseClaims(data []byte, format utils.Format) ([]map[string]interface{}, error) {
+
+	result, err := utils.Deserialize(data, format, utils.CLAIMS)
+	if err != nil {
+		return nil, fmt.Errorf("error unmarshalling claim dialect data: %w", err)
+	}
+	dialectMap, ok := utils.ConvertToStringKeyMap(result).(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected format for claim dialect file")
+	}
+	rawClaims, ok := dialectMap["claims"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected format: missing or invalid 'claims' array in claim dialect file")
+	}
+	var claims []map[string]interface{}
+	for _, c := range rawClaims {
+		m, ok := c.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected format: claim entry is not a map")
+		}
+		claims = append(claims, m)
+	}
+	return claims, nil
+}
+
+func getDialectURIFromFile(filePath string) (string, error) {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(filePath))
+	if err != nil {
+		return "", fmt.Errorf("unsupported file format: %w", err)
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", fmt.Errorf("error reading file: %w", err)
+	}
+
+	var dialectConfig ClaimDialectConfigurations
+	if _, err := utils.Deserialize(data, format, utils.CLAIMS, &dialectConfig); err != nil {
+		return "", fmt.Errorf("error deserializing file: %w", err)
+	}
+	if dialectConfig.URI == "" {
+		return "", fmt.Errorf("dialectURI not found in file")
+	}
+	return dialectConfig.URI, nil
 }
 
 func formatFileName(fileName string) string {
@@ -99,29 +156,74 @@ func formatFileName(fileName string) string {
 	return formattedFileName
 }
 
-func getClaimDialectId(claimDialectFilePath string) (string, error) {
-
-	fileContent, err := ioutil.ReadFile(claimDialectFilePath)
-	if err != nil {
-		return "", fmt.Errorf("error when reading the file: %s. %s", claimDialectFilePath, err)
-	}
-
-	var claimDialectConfig ClaimDialectConfigurations
-	err = yaml.Unmarshal(fileContent, &claimDialectConfig)
-	if err != nil {
-		return "", fmt.Errorf("invalid file content at: %s. %s", claimDialectFilePath, err)
-	}
-
-	existingClaimDialectList, err := getClaimDialectsList()
-	if err != nil {
-		return "", fmt.Errorf("error when retrieving the deployed claim dialect list: %s", err)
-	}
+func getClaimDialectId(dialectURI string, existingClaimDialectList []claimDialect) string {
 
 	for _, dialect := range existingClaimDialectList {
-		if dialect.Id == claimDialectConfig.ID {
-			return dialect.Id, nil
+		if dialect.DialectURI == dialectURI {
+			return dialect.Id
 		}
 	}
-	// Claim dialect does not exist, returning an empty user ID
-	return "", nil
+	return ""
+}
+
+func getClaimDialect(dialectId string) (interface{}, error) {
+
+	dialectData, err := utils.GetResourceData(utils.CLAIMS, dialectId)
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving claim dialect. %w", err)
+	}
+	dialectMap, ok := dialectData.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected format for claim dialect response")
+	}
+
+	claims, err := utils.GetResourceData(utils.CLAIMS, dialectId+"/claims")
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving claims for dialect. %w", err)
+	}
+	dialectMap["claims"] = claims
+
+	return dialectMap, nil
+}
+
+func createClaimReqBody(claim map[string]interface{}) ([]byte, error) {
+
+	claimCopy := make(map[string]interface{}, len(claim))
+	for k, v := range claim {
+		if k != "id" && k != "claimDialectURI" {
+			claimCopy[k] = v
+		}
+	}
+	return json.Marshal(claimCopy)
+}
+
+func getClaimID(c map[string]interface{}) string {
+
+	id, _ := c["id"].(string)
+	return id
+}
+
+func getClaimURI(c map[string]interface{}) string {
+
+	uri, _ := c["claimURI"].(string)
+	return uri
+}
+
+func claimChanged(local, deployed map[string]interface{}) bool {
+
+	localJSON, _ := createClaimReqBody(local)
+	deployedJSON, _ := createClaimReqBody(deployed)
+	return string(localJSON) != string(deployedJSON)
+}
+
+func exportAPIExists() bool {
+
+	res, err := utils.CompareVersions(utils.SERVER_CONFIGS.ServerVersion, utils.MIN_VERSION_CLAIMS_EXPORT_API)
+	if err != nil {
+		// Use the export API when the server version is not properly configured for backward compatibility
+		log.Println("Warn: Server version is not properly configured. For IS versions below 6.1, configure the server version properly to avoid failures.")
+		return true
+	}
+
+	return res >= 0
 }

--- a/iamctl/pkg/claims/export.go
+++ b/iamctl/pkg/claims/export.go
@@ -33,9 +33,6 @@ func ExportAll(exportFilePath string, format string) {
 
 	// Export all claim dialects with related claims.
 	log.Println("Exporting claims...")
-	if !utils.IsEntitySupportedInVersion(utils.CLAIMS) {
-		return
-	}
 	if utils.IsSubOrganization() {
 		log.Println("Exporting claims for sub organization not supported.")
 		return
@@ -45,15 +42,17 @@ func ExportAll(exportFilePath string, format string) {
 	if utils.IsResourceTypeExcluded(utils.CLAIMS) {
 		return
 	}
+
+	claimDialects, err := getClaimDialectsList()
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		os.MkdirAll(exportFilePath, 0700)
 	} else {
 		if utils.TOOL_CONFIGS.AllowDelete {
-			utils.RemoveDeletedLocalResources(exportFilePath, getDeployedClaimDialectNames())
+			utils.RemoveDeletedLocalResources(exportFilePath, getDeployedDialectFileNames(claimDialects))
 		}
 	}
 
-	claimDialects, err := getClaimDialectsList()
+	exportAPIExists := exportAPIExists()
 	if err != nil {
 		log.Println("Error while retrieving Claim Dialect list.", err)
 	} else {
@@ -61,12 +60,18 @@ func ExportAll(exportFilePath string, format string) {
 			if !utils.IsResourceExcluded(dialect.DialectURI, utils.TOOL_CONFIGS.ClaimConfigs) {
 				log.Println("Exporting Claim Dialect: ", dialect.DialectURI)
 
-				err := exportClaimDialect(dialect.Id, exportFilePath, format)
+				var err error
+				if exportAPIExists {
+					err = exportClaimDialect(dialect.Id, dialect.DialectURI, exportFilePath, format)
+				} else {
+					err = exportClaimDialectWithCRUD(dialect.Id, dialect.DialectURI, exportFilePath, format)
+				}
+
 				if err != nil {
 					utils.UpdateFailureSummary(utils.CLAIMS, dialect.DialectURI)
 					log.Printf("Error while exporting Claim Dialect: %s. %s", dialect.DialectURI, err)
 				} else {
-					utils.UpdateSuccessSummary(utils.CLAIMS, dialect.DialectURI)
+					utils.UpdateSuccessSummary(utils.CLAIMS, utils.EXPORT)
 					log.Println("Claim Dialect exported successfully: ", dialect.DialectURI)
 				}
 			}
@@ -74,7 +79,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 }
 
-func exportClaimDialect(dialectId string, outputDirPath string, format string) error {
+func exportClaimDialect(dialectId, dialectUri, outputDirPath, format string) error {
 
 	var fileType string
 	// TODO: Extend support for json and xml formats.
@@ -100,14 +105,13 @@ func exportClaimDialect(dialectId string, outputDirPath string, format string) e
 
 	fileName := params["filename"]
 	exportedFileName := filepath.Join(outputDirPath, fileName)
-	fileInfo := utils.GetFileInfo(exportedFileName)
 
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return fmt.Errorf("error while reading the response body when exporting claim dialect: %s. %s", fileName, err)
 	}
 
-	claimDialectKeywordMapping := getClaimKeywordMapping(fileInfo.ResourceName)
+	claimDialectKeywordMapping := getClaimKeywordMapping(dialectUri)
 	modifiedFile, err := utils.ProcessExportedContent(exportedFileName, body, claimDialectKeywordMapping, utils.CLAIMS)
 	if err != nil {
 		return fmt.Errorf("error while processing the exported content: %s", err)
@@ -117,5 +121,35 @@ func exportClaimDialect(dialectId string, outputDirPath string, format string) e
 	if err != nil {
 		return fmt.Errorf("error when writing the exported content to file: %w", err)
 	}
+	return nil
+}
+
+func exportClaimDialectWithCRUD(dialectId, dialectUri, outputDirPath, formatString string) error {
+
+	claimDialect, err := getClaimDialect(dialectId)
+	if err != nil {
+		return fmt.Errorf("error while getting claim dialect: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	fileName := formatFileName(dialectUri)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, fileName, format)
+
+	dialectKeywordMapping := getClaimKeywordMapping(dialectUri)
+	modifiedDialect, err := utils.ProcessExportedData(claimDialect, exportedFileName, format, dialectKeywordMapping, utils.CLAIMS)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedDialect, format, utils.CLAIMS)
+	if err != nil {
+		return fmt.Errorf("error while serializing claim dialect: %w", err)
+	}
+
+	err = os.WriteFile(exportedFileName, modifiedFile, 0644)
+	if err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
 	return nil
 }

--- a/iamctl/pkg/claims/import.go
+++ b/iamctl/pkg/claims/import.go
@@ -19,23 +19,20 @@
 package claims
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
-	"strings"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
-	"gopkg.in/yaml.v3"
 )
 
 func ImportAll(inputDirPath string) {
 
 	log.Println("Importing claims...")
-	if !utils.IsEntitySupportedInVersion(utils.CLAIMS) {
-		return
-	}
 	if utils.IsSubOrganization() {
 		log.Println("Importing claims for sub organization not supported.")
 		return
@@ -45,17 +42,22 @@ func ImportAll(inputDirPath string) {
 	if utils.IsResourceTypeExcluded(utils.CLAIMS) {
 		return
 	}
-	var files []os.FileInfo
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
 		log.Println("No claim dialects to import.")
-	} else {
-		files, err = ioutil.ReadDir(importFilePath)
-		if err != nil {
-			log.Println("Error importing claim dialects: ", err)
-		}
-		if utils.TOOL_CONFIGS.AllowDelete {
-			removeDeletedDeployedClaimdialect(files, importFilePath)
-		}
+		return
+	}
+
+	existingClaimDialectList, err := getClaimDialectsList()
+	if err != nil {
+		log.Printf("error when retrieving the deployed claim dialect list. %s", err)
+	}
+
+	files, err := ioutil.ReadDir(importFilePath)
+	if err != nil {
+		log.Println("Error importing claim dialects: ", err)
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		removeDeletedDeployedClaimdialect(files, existingClaimDialectList)
 	}
 
 	// Move the local claims file to the front of the array to import it first
@@ -68,23 +70,25 @@ func ImportAll(inputDirPath string) {
 
 	for _, file := range files {
 		claimFilePath := filepath.Join(importFilePath, file.Name())
-		dialectName := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
 
-		if !utils.IsResourceExcluded(dialectName, utils.TOOL_CONFIGS.ClaimConfigs) {
-			dialectId, err := getClaimDialectId(claimFilePath)
+		dialectUri, err := getDialectURIFromFile(claimFilePath)
+		if err != nil {
+			log.Println("error reading dialect URI from file:", err)
+			continue
+		}
+		dialectId := getClaimDialectId(dialectUri, existingClaimDialectList)
+
+		if !utils.IsResourceExcluded(dialectUri, utils.TOOL_CONFIGS.ClaimConfigs) {
+			err = importClaimDialect(dialectId, dialectUri, claimFilePath)
 			if err != nil {
-				log.Printf("Invalid file configurations for Claim Dialect: %s. %s", dialectName, err)
-			} else {
-				err := importClaimDialect(dialectId, claimFilePath)
-				if err != nil {
-					log.Println("error importing claim dialect:", err)
-				}
+				log.Println("error importing claim dialect:", err)
+				utils.UpdateFailureSummary(utils.CLAIMS, dialectUri)
 			}
 		}
 	}
 }
 
-func importClaimDialect(dialectId string, importFilePath string) error {
+func importClaimDialect(dialectId, dialectUri, importFilePath string) error {
 
 	fileBytes, err := ioutil.ReadFile(importFilePath)
 	if err != nil {
@@ -92,30 +96,37 @@ func importClaimDialect(dialectId string, importFilePath string) error {
 	}
 
 	// Replace keyword placeholders in the local file according to the keyword mappings added in configs.
-	fileInfo := utils.GetFileInfo(importFilePath)
-	claimKeywordMapping := getClaimKeywordMapping(fileInfo.ResourceName)
+	claimKeywordMapping := getClaimKeywordMapping(dialectUri)
 	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), claimKeywordMapping)
 
-	// Unmarshal the file data to get the dialect URI as the resource name.
-	var claimDialectConfigurations ClaimDialectConfigurations
-	error := yaml.Unmarshal([]byte(modifiedFileData), &claimDialectConfigurations)
-	if error != nil {
-		return fmt.Errorf("error when unmarshalling the file for claim dialect: %s", err)
+	if exportAPIExists() {
+		if dialectId == "" {
+			return importDialect(dialectUri, importFilePath, modifiedFileData)
+		}
+		return updateDialect(dialectId, dialectUri, importFilePath, modifiedFileData)
 	}
-	fileInfo.ResourceName = claimDialectConfigurations.URI
+
+	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format for claim dialect: %w", err)
+	}
+
+	claims, err := parseClaims([]byte(modifiedFileData), format)
+	if err != nil {
+		return fmt.Errorf("error parsing claims from dialect file: %w", err)
+	}
 
 	if dialectId == "" {
-		return importDialect(importFilePath, modifiedFileData, fileInfo)
+		return createClaimDialectWithCRUD(dialectUri, claims)
 	}
-	return updateDialect(dialectId, importFilePath, modifiedFileData, fileInfo)
+	return updateClaimDialectWithCRUD(dialectId, dialectUri, claims)
 }
 
-func importDialect(importFilePath string, modifiedFileData string, fileInfo utils.FileInfo) error {
+func importDialect(dialectUri, importFilePath, modifiedFileData string) error {
 
-	log.Println("Creating new claim dialect: " + fileInfo.ResourceName)
+	log.Println("Creating new claim dialect: " + dialectUri)
 	err := utils.SendImportRequest(importFilePath, modifiedFileData, utils.CLAIMS)
 	if err != nil {
-		utils.UpdateFailureSummary(utils.CLAIMS, fileInfo.ResourceName)
 		return fmt.Errorf("error when importing claim dialect: %s", err)
 	}
 	utils.UpdateSuccessSummary(utils.CLAIMS, utils.IMPORT)
@@ -123,12 +134,11 @@ func importDialect(importFilePath string, modifiedFileData string, fileInfo util
 	return nil
 }
 
-func updateDialect(dialectId string, importFilePath string, modifiedFileData string, fileInfo utils.FileInfo) error {
+func updateDialect(dialectId, dialectUri, importFilePath, modifiedFileData string) error {
 
-	log.Println("Updating claim dialect: " + fileInfo.ResourceName)
+	log.Println("Updating claim dialect: " + dialectUri)
 	err := utils.SendUpdateRequest(dialectId, importFilePath, modifiedFileData, utils.CLAIMS)
 	if err != nil {
-		utils.UpdateFailureSummary(utils.CLAIMS, fileInfo.ResourceName)
 		return fmt.Errorf("error when updating claim dialect: %s", err)
 	}
 	utils.UpdateSuccessSummary(utils.CLAIMS, utils.UPDATE)
@@ -136,59 +146,170 @@ func updateDialect(dialectId string, importFilePath string, modifiedFileData str
 	return nil
 }
 
-func removeDeletedDeployedClaimdialect(localFiles []os.FileInfo, importFilePath string) {
+func createClaimDialectWithCRUD(dialectURI string, claims []map[string]interface{}) error {
 
-	// Remove deployed claim dialects that do not exist locally.
-	deployedClaimDialects, err := getClaimDialectsList()
+	log.Println("Creating new claim dialect: " + dialectURI)
+
+	newDialectId, err := createDialect(dialectURI)
 	if err != nil {
-		log.Println("Error retrieving deployed claim dialects: ", err)
+		return fmt.Errorf("error when creating claim dialect: %w", err)
+	}
+	for _, claim := range claims {
+		if err := createClaim(newDialectId, claim); err != nil {
+			return fmt.Errorf("error when creating claims of dialect %s: %w", dialectURI, err)
+		}
+	}
+
+	utils.UpdateSuccessSummary(utils.CLAIMS, utils.IMPORT)
+	log.Println("Claim dialect imported successfully.")
+	return nil
+}
+
+func updateClaimDialectWithCRUD(dialectId, dialectURI string, localClaims []map[string]interface{}) error {
+
+	log.Println("Updating claim dialect: " + dialectURI)
+
+	deployedClaims, err := getClaimsList(dialectId)
+	if err != nil {
+		return fmt.Errorf("error retrieving deployed claims for dialect: %w", err)
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		if err := removeDeletedDeployedClaims(dialectId, deployedClaims, localClaims); err != nil {
+			return fmt.Errorf("error removing deleted claims of dialect: %w", err)
+		}
+	}
+
+	if err := updateChangedClaims(dialectId, localClaims, deployedClaims); err != nil {
+		return fmt.Errorf("error updating changed claims of dialect: %w", err)
+	}
+
+	utils.UpdateSuccessSummary(utils.CLAIMS, utils.UPDATE)
+	log.Println("Claim dialect updated successfully.")
+	return nil
+}
+
+func createDialect(dialectURI string) (dialectId string, err error) {
+
+	dialectJSON, err := json.Marshal(map[string]string{"dialectURI": dialectURI})
+	if err != nil {
+		return "", fmt.Errorf("error serializing claim dialect: %w", err)
+	}
+
+	resp, err := utils.SendPostRequest(utils.CLAIMS, dialectJSON)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	location := resp.Header.Get("Location")
+	if location == "" {
+		return "", fmt.Errorf("no Location header in create dialect response")
+	}
+	return path.Base(location), nil
+}
+
+func updateChangedClaims(dialectId string, localClaims, deployedClaims []map[string]interface{}) error {
+
+	deployedByURI := make(map[string]map[string]interface{})
+	for _, c := range deployedClaims {
+		deployedByURI[getClaimURI(c)] = c
+	}
+
+	for _, claim := range localClaims {
+		uri := getClaimURI(claim)
+		if deployed, exists := deployedByURI[uri]; exists {
+			if !claimChanged(claim, deployed) {
+				continue
+			}
+			if err := updateClaim(dialectId, getClaimID(deployed), claim); err != nil {
+				return err
+			}
+		} else {
+			if err := createClaim(dialectId, claim); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func createClaim(dialectId string, claim map[string]interface{}) error {
+
+	claimJSON, err := createClaimReqBody(claim)
+	if err != nil {
+		return fmt.Errorf("error when marshalling claim %s: %w", getClaimURI(claim), err)
+	}
+
+	resp, err := utils.SendPostRequest(utils.CLAIMS, claimJSON, utils.WithPathSuffix(dialectId+"/claims"))
+	if err != nil {
+		return fmt.Errorf("error when creating claim %s: %w", getClaimURI(claim), err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+func updateClaim(dialectId, claimId string, claim map[string]interface{}) error {
+
+	claimJSON, err := createClaimReqBody(claim)
+	if err != nil {
+		return fmt.Errorf("error when marshalling claim %s: %w", getClaimURI(claim), err)
+	}
+
+	resp, err := utils.SendPutRequest(utils.CLAIMS, dialectId+"/claims/"+claimId, claimJSON)
+	if err != nil {
+		return fmt.Errorf("error when updating claim %s: %w", getClaimURI(claim), err)
+	}
+	resp.Body.Close()
+	return nil
+}
+
+func removeDeletedDeployedClaimdialect(localFiles []os.FileInfo, deployedClaimDialects []claimDialect) {
+
+	if len(deployedClaimDialects) == 0 {
 		return
 	}
-deployedResourcess:
+
+	localDialectNames := make(map[string]struct{})
+	for _, file := range localFiles {
+		localDialectNames[utils.GetFileInfo(file.Name()).ResourceName] = struct{}{}
+	}
+
 	for _, claimDialect := range deployedClaimDialects {
-		for _, file := range localFiles {
-
-			var claimDialectConfigurations ClaimDialectConfigurations
-			claimFilePath := filepath.Join(importFilePath, file.Name())
-
-			content, err := readFileContent(claimFilePath)
-			if err != nil {
-				log.Println("error when reading file content: ", err)
-			}
-
-			err = yaml.Unmarshal(content, &claimDialectConfigurations)
-			if err != nil {
-				log.Println("error when unmarshalling the file for claim dialect: ", err)
-			}
-
-			localResourceName := claimDialectConfigurations.URI
-			if claimDialect.DialectURI == localResourceName {
-				continue deployedResourcess
-			}
+		if _, existsLocally := localDialectNames[formatFileName(claimDialect.DialectURI)]; existsLocally {
+			continue
 		}
 		if utils.IsResourceExcluded(claimDialect.DialectURI, utils.TOOL_CONFIGS.ClaimConfigs) {
 			log.Printf("Claim dialect: %s is excluded from deletion.\n", claimDialect.DialectURI)
 			continue
 		}
 		log.Println("Claim dialect not found locally. Deleting claim dialect: ", claimDialect.DialectURI)
-		err := utils.SendDeleteRequest(claimDialect.Id, utils.CLAIMS)
-		if err != nil {
+		if err := utils.SendDeleteRequest(claimDialect.Id, utils.CLAIMS); err != nil {
+			utils.UpdateFailureSummary(utils.CLAIMS, claimDialect.DialectURI)
 			log.Println("Error deleting claim dialect: ", err)
+		} else {
+			utils.UpdateSuccessSummary(utils.CLAIMS, utils.DELETE)
 		}
 	}
 }
 
-func readFileContent(filename string) ([]byte, error) {
+func removeDeletedDeployedClaims(dialectId string, deployedClaims, localClaims []map[string]interface{}) error {
 
-	file, err := os.Open(filename)
-	if err != nil {
-		return nil, err
+	if len(deployedClaims) == 0 {
+		return nil
 	}
-	defer file.Close()
 
-	content, err := ioutil.ReadAll(file)
-	if err != nil {
-		return nil, err
+	localByURI := make(map[string]struct{})
+	for _, claim := range localClaims {
+		localByURI[getClaimURI(claim)] = struct{}{}
 	}
-	return content, nil
+
+	for _, deployed := range deployedClaims {
+		if _, existsLocally := localByURI[getClaimURI(deployed)]; existsLocally {
+			continue
+		}
+		if err := utils.SendDeleteRequest(dialectId+"/claims/"+getClaimID(deployed), utils.CLAIMS); err != nil {
+			return fmt.Errorf("error deleting claim %s of dialect: %w", getClaimURI(deployed), err)
+		}
+	}
+	return nil
 }

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -299,7 +299,6 @@ func SendDeleteRequest(resourceId string, resourceType ResourceType) error {
 
 	statusCode := resp.StatusCode
 	if statusCode == 204 {
-		log.Println("Resource deleted successfully.")
 		return nil
 	} else if error, ok := ErrorCodes[statusCode]; ok {
 		return fmt.Errorf("error response for the delete request: %s", error)

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -195,6 +195,10 @@ var userStoreArrayFields = []string{
 	"properties",
 }
 
+var claimArrayFields = []string{
+	"claims",
+}
+
 // XML root element tags for each resource type
 const (
 	XML_ROOT_OIDC_SCOPE           = "Scope"
@@ -204,4 +208,5 @@ const (
 	XML_ROOT_SCRIPT_LIBRARY       = "ScriptLibrary"
 	XML_ROOT_GOVERNANCE_CONNECTOR = "GovernanceConnector"
 	XML_ROOT_USERSTORE            = "UserStore"
+	XML_ROOT_CLAIM                = "DialectConfiguration"
 )

--- a/iamctl/pkg/utils/serializationUtils.go
+++ b/iamctl/pkg/utils/serializationUtils.go
@@ -92,23 +92,21 @@ func Serialize(data interface{}, format Format, resourceType ResourceType) ([]by
 	}
 }
 
-func Deserialize(data []byte, format Format, resourceType ResourceType) (interface{}, error) {
+func Deserialize(data []byte, format Format, resourceType ResourceType, target ...interface{}) (interface{}, error) {
 
 	switch format {
 	case FormatYAML:
 		var result interface{}
-		err := yaml.Unmarshal(data, &result)
-		if err != nil {
-			return nil, fmt.Errorf("error when parsing data to YAML: %w", err)
+		if len(target) > 0 {
+			return target[0], yaml.Unmarshal(data, target[0])
 		}
-		return result, nil
+		return result, yaml.Unmarshal(data, &result)
 	case FormatJSON:
 		var result interface{}
-		err := json.Unmarshal(data, &result)
-		if err != nil {
-			return nil, fmt.Errorf("error when parsing data to JSON: %w", err)
+		if len(target) > 0 {
+			return target[0], json.Unmarshal(data, target[0])
 		}
-		return result, nil
+		return result, json.Unmarshal(data, &result)
 	case FormatXML:
 		xmlMap, err := XMLToMap(data)
 		if err != nil {
@@ -121,6 +119,13 @@ func Deserialize(data []byte, format Format, resourceType ResourceType) (interfa
 		}
 
 		result := FixArrayFields(xmlData, resourceType)
+		if len(target) > 0 {
+			jsonBytes, err := json.Marshal(result)
+			if err != nil {
+				return nil, fmt.Errorf("error when converting XML data to typed struct: %w", err)
+			}
+			return target[0], json.Unmarshal(jsonBytes, target[0])
+		}
 		return result, nil
 	default:
 		return nil, fmt.Errorf("unsupported format: %s", format)
@@ -163,6 +168,7 @@ func GetXMLRootTag(resourceType ResourceType) string {
 		SCRIPT_LIBRARIES:      XML_ROOT_SCRIPT_LIBRARY,
 		GOVERNANCE_CONNECTORS: XML_ROOT_GOVERNANCE_CONNECTOR,
 		USERSTORES:            XML_ROOT_USERSTORE,
+		CLAIMS:                XML_ROOT_CLAIM,
 	}
 	return xmlRootTags[resourceType]
 }
@@ -203,6 +209,8 @@ func GetArrayFieldPaths(resourceType ResourceType) []string {
 		return governanceConnectorArrayFields
 	case USERSTORES:
 		return userStoreArrayFields
+	case CLAIMS:
+		return claimArrayFields
 	default:
 		return []string{}
 	}

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -23,13 +23,11 @@ package utils
 const (
 	MIN_VERSION_APPLICATIONS       = "6.1.0"
 	MIN_VERSION_IDENTITY_PROVIDERS = "6.1.0"
-	MIN_VERSION_CLAIMS             = "6.1.0"
 )
 
 var EntityMinVersionRequirements = map[ResourceType]string{
 	APPLICATIONS:       MIN_VERSION_APPLICATIONS,
 	IDENTITY_PROVIDERS: MIN_VERSION_IDENTITY_PROVIDERS,
-	CLAIMS:             MIN_VERSION_CLAIMS,
 }
 
 // Maximum supported WSO2 Identity Server version for each resource type.
@@ -41,4 +39,5 @@ var EntityMaxSupportedVersion = map[ResourceType]string{}
 // Minimum WSO2 Identity Server version requirements for resource-specific APIs
 const (
 	MIN_VERSION_USERSTORE_EXPORT_API = "6.1.0"
+	MIN_VERSION_CLAIMS_EXPORT_API    = "6.1.0"
 )


### PR DESCRIPTION
## Purpose

  Extend claim dialect export/import support to Identity Server versions below 6.1 by utilizing CRUD APIs when the dedicated export/import API is unavailable. Also fixes an inconsistent UX where import used file names but export used dialect URIs as resource identifiers, and fixes an O(n²) file-read loop in the deployed dialect delete path.                                                                                                                                                                                                      
   
  Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/54                                                                                                                             
                                                                                                                                                                                                            
  ## Goals

  - Export/import claim dialects with their nested claims on IS versions below 6.1 using the Claim CRUD APIs
  - Detect the server version and select the appropriate API path
  - Maintain full feature parity (keyword replacement, EXCLUDE/INCLUDE_ONLY, ALLOW_DELETE) regardless of the API path used
  - Fix inconsistent UX where import used file names but export used dialect URIs as resource identifiers
  - Reduce redundant API calls by skipping updates for claims that have not changed
  - Fix O(n²) file-read loop in the deployed dialect delete path

  ## Approach

  ### CRUD API fallback for older IS versions

  Removed the blanket minimum version gate for `CLAIMS` that previously skipped export/import entirely on IS versions below 6.1. Introduced `exportAPIExists()` which compares the configured server version against `MIN_VERSION_CLAIMS_EXPORT_API` to determine which API path to use at runtime.

  Added `exportClaimDialectWithCRUD()` (export) and `createClaimDialectWithCRUD()` / `updateClaimDialectWithCRUD()` (import) that call the standard GET / POST / PUT claim endpoints and compose the dialect and its claims into a single file, matching the structure produced by the dedicated export API.

  ### Two-layered resource handling

  Claims are a two-level resource: a claim dialect owns a set of individual claims. The CRUD path therefore requires two layers of API interaction. First create or locate the dialect, then create/update/delete individual claims under it.

  ### Reducing redundant API calls

  `updateChangedClaims()` diffs deployed claims against local ones by URI before issuing any write. Claims that are identical between the local file and the deployed state are skipped entirely, avoiding a PUT per claim on every import run even when nothing has changed.

  ### Consistent UX: dialect URI as the canonical identifier

  Previously import used the file name (without extension) as the resource identifier for keyword mappings and exclusion checks, while export used the dialect URI. This meant TOOL_CONFIGS exclusion entries and keyword config keys had to match the formatted file name rather than the human-readable URI: an invisible inconsistency that was easy to misconfigure.

  Both sides now resolve and pass the dialect URI explicitly, reading the file upfront with `getDialectURIFromFile()` before any further processing, so exclusion rules, keyword mappings, and log messages are uniform across export and import.

  ### Bug fixes in existing delete logic

  `removeDeletedDeployedClaimdialect` previously re-read and unmarshalled every local file on each iteration of the outer deployed-dialect loop, performing **O(n²)** file reads and silently skipping deletes on unmarshal failures. It has been rewritten to build a `map[string]struct{}` of local dialect file names upfront and perform a single **O(1)** lookup per deployed dialect.

  Success and failure summary counters were also missing from the delete path entirely and are now correctly recorded.

  ### Extended `Deserialize` to accept a typed target

  `Deserialize` previously always unmarshalled into a generic `interface{}`. To read the dialect URI from a local file without duplicating unmarshal logic per format, `Deserialize` was extended with an optional variadic `target ...interface{}` parameter. When provided, data is decoded directly into that typed struct (YAML/JSON) or round-tripped through JSON after XML-to-map conversion (XML). This allows `getDialectURIFromFile()` to decode into `ClaimDialectConfigurations` in a single call regardless of file format.

  ### Serialization support

  Added `claimArrayFields` and `XML_ROOT_CLAIM` constants, wired into `GetArrayFieldPaths()` and `GetXMLRootTag()` so the existing serialization utilities handle claim dialect files correctly across YAML, JSON, and XML formats.

  ## User Stories

  As a system administrator, I want to export and import claim dialects and their claims using IAM-CTL to enable version control and maintain consistent IAM configurations.

  ## Release Note

Extended claims export/import to support Identity Server versions below 6.1.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.