### PR TITLE
Extend Application management to support IS versions below 6.1 and fix related bugs

### DIFF
--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -48,10 +48,6 @@ type AppList struct {
 	Applications []Application `json:"applications"`
 }
 
-type AppConfig struct {
-	ApplicationName string `yaml:"applicationName"`
-}
-
 var protocolPathToKey = map[string]string{
 	"saml":        "saml",
 	"oidc":        "oidc",
@@ -159,6 +155,16 @@ func getAppKeywordMapping(appName string) map[string]interface{} {
 		return utils.ResolveAdvancedKeywordMapping(appName, utils.KEYWORD_CONFIGS.ApplicationConfigs)
 	}
 	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func getAppId(appName string, appList []Application) string {
+
+	for _, app := range appList {
+		if app.Name == appName {
+			return app.Id
+		}
+	}
+	return ""
 }
 
 func isOauthApp(fileData string) (bool, error) {
@@ -286,4 +292,46 @@ func processInboundProtocolConfigs(appId string, inboundProtocols []inboundProto
 func maskOIDCClientSecret(oidcConfig map[string]interface{}) {
 
 	oidcConfig["clientSecret"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+}
+
+func processInboundProtocolsForPost(appMap map[string]interface{}) (newSecretCreated bool, err error) {
+
+	inboundConfig, ok := appMap["inboundProtocolConfiguration"].(map[string]interface{})
+	if !ok {
+		return false, fmt.Errorf("unexpected format for inboundProtocolConfiguration")
+	}
+
+	for key, config := range inboundConfig {
+		if key == "custom" {
+			customArr, ok := config.([]interface{})
+			if !ok {
+				return false, fmt.Errorf("unexpected format for custom inbound protocols")
+			}
+			for _, item := range customArr {
+				itemMap, ok := item.(map[string]interface{})
+				if !ok {
+					return false, fmt.Errorf("unexpected format for custom inbound protocol")
+				}
+				delete(itemMap, "self")
+			}
+			continue
+		}
+
+		configMap, ok := config.(map[string]interface{})
+		if !ok {
+			return false, fmt.Errorf("unexpected format for inbound protocol: %s", key)
+		}
+		delete(configMap, "self")
+
+		if key == "saml" {
+			inboundConfig[key] = map[string]interface{}{"manualConfiguration": configMap}
+		}
+		if key == "oidc" {
+			secret, _ := configMap["clientSecret"].(string)
+			if secret == "" {
+				newSecretCreated = true
+			}
+		}
+	}
+	return newSecretCreated, nil
 }

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -267,9 +267,13 @@ func processInboundProtocolConfigs(appId string, inboundProtocols []inboundProto
 		if protocolPath == "oidc" && excludeSecrets {
 			maskOIDCClientSecret(protocolConfig)
 		}
+		if protocolPath == "saml" {
+			protocolConfig = map[string]interface{}{
+				"manualConfiguration": protocolConfig,
+			}
+		}
 
 		protocolConfig["self"] = self
-
 		if key, known := protocolPathToKey[protocolPath]; known {
 			result[key] = protocolConfig
 		} else {
@@ -323,9 +327,6 @@ func processInboundProtocolsForPost(appMap map[string]interface{}) (newSecretCre
 		}
 		delete(configMap, "self")
 
-		if key == "saml" {
-			inboundConfig[key] = map[string]interface{}{"manualConfiguration": configMap}
-		}
 		if key == "oidc" {
 			secret, _ := configMap["clientSecret"].(string)
 			if secret == "" {
@@ -334,4 +335,44 @@ func processInboundProtocolsForPost(appMap map[string]interface{}) (newSecretCre
 		}
 	}
 	return newSecretCreated, nil
+}
+
+func getDeployedInboundProtocols(appId string) ([]inboundProtocolRef, error) {
+
+	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols")
+	if err != nil {
+		return nil, err
+	}
+	var deployedRefs []inboundProtocolRef
+	if err := json.Unmarshal(body, &deployedRefs); err != nil {
+		return nil, fmt.Errorf("error unmarshalling deployed inbound protocols: %w", err)
+	}
+	return deployedRefs, nil
+}
+
+func flattenInboundProtocols(localProtocolConfig map[string]interface{}) ([]map[string]interface{}, error) {
+
+	var result []map[string]interface{}
+	for key, config := range localProtocolConfig {
+		if key == "custom" {
+			customArr, ok := config.([]interface{})
+			if !ok {
+				return nil, fmt.Errorf("unexpected format for custom inbound protocols")
+			}
+			for _, item := range customArr {
+				itemMap, ok := item.(map[string]interface{})
+				if !ok {
+					return nil, fmt.Errorf("unexpected format for custom inbound protocol")
+				}
+				result = append(result, itemMap)
+			}
+		} else {
+			configMap, ok := config.(map[string]interface{})
+			if !ok {
+				return nil, fmt.Errorf("unexpected format for inbound protocol: %s", key)
+			}
+			result = append(result, configMap)
+		}
+	}
+	return result, nil
 }

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -25,7 +25,6 @@ import (
 	"log"
 	"os"
 	"path"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"text/tabwriter"
@@ -196,25 +195,24 @@ func maskOAuthConsumerSecret(fileContent []byte) []byte {
 	return []byte(maskedContent)
 }
 
-func isToolMgtApp(file os.FileInfo, importFilePath string) (bool, error) {
+func isToolMgtApp(appId string) (bool, error) {
 
-	appFilePath := filepath.Join(importFilePath, file.Name())
-	fileData, err := ioutil.ReadFile(appFilePath)
+	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols/oidc")
 	if err != nil {
-		return false, fmt.Errorf("failed to read file: %s", err.Error())
-	}
-
-	config, err := unmarshalAuthConfig(fileData)
-	if err != nil {
-		return false, fmt.Errorf(err.Error())
-	}
-
-	for _, requestConfig := range config.InboundAuthenticationConfig.InboundAuthenticationRequestConfigs {
-		if requestConfig.InboundAuthKey == utils.SERVER_CONFIGS.ClientId {
-			appName := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
-			log.Printf("Info: Tool Management App: %s is excluded from deletion.\n", appName)
-			return true, nil
+		// 404 means no OIDC config — not the tool management app
+		if strings.Contains(err.Error(), "Resource not found") {
+			return false, nil
 		}
+		return false, err
+	}
+	var oidcConfig map[string]interface{}
+	if err := json.Unmarshal(body, &oidcConfig); err != nil {
+		return false, fmt.Errorf("error unmarshalling OIDC config: %w", err)
+	}
+
+	clientId, _ := oidcConfig["clientId"].(string)
+	if clientId == utils.SERVER_CONFIGS.ClientId {
+		return true, nil
 	}
 	return false, nil
 }

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -376,3 +376,55 @@ func flattenInboundProtocols(localProtocolConfig map[string]interface{}) ([]map[
 	}
 	return result, nil
 }
+
+func processInboundProtocolForUpdate(appId string, protocolMap map[string]interface{}) (protocolPath string, err error) {
+
+	self, ok := protocolMap["self"].(string)
+	if !ok {
+		return "", fmt.Errorf("self URL not found")
+	}
+	protocolPath = path.Base(self)
+	delete(protocolMap, "self")
+
+	if protocolPath == "oidc" || protocolPath == "passive-sts" {
+		if err := injectDeployedReadOnlyFields(appId, protocolPath, protocolMap); err != nil {
+			return "", err
+		}
+	}
+	return protocolPath, nil
+}
+
+func injectDeployedReadOnlyFields(appId, protocolPath string, localConfig map[string]interface{}) error {
+
+	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols/"+protocolPath)
+	if err != nil {
+		return fmt.Errorf("error retrieving deployed %s config: %w", protocolPath, err)
+	}
+	var deployedConfig map[string]interface{}
+	if err := json.Unmarshal(body, &deployedConfig); err != nil {
+		return fmt.Errorf("error unmarshalling deployed %s config: %w", protocolPath, err)
+	}
+
+	switch protocolPath {
+	case "oidc":
+		clientId, ok := deployedConfig["clientId"].(string)
+		if !ok {
+			return fmt.Errorf("clientId not found in deployed oidc config")
+		}
+		localConfig["clientId"] = clientId
+
+		deployedSecret, ok := deployedConfig["clientSecret"].(string)
+		if !ok {
+			return fmt.Errorf("clientSecret not found in deployed oidc config")
+		}
+		localConfig["clientSecret"] = deployedSecret
+
+	case "passive-sts":
+		realm, ok := deployedConfig["realm"].(string)
+		if !ok {
+			return fmt.Errorf("realm not found in deployed passive-sts config")
+		}
+		localConfig["realm"] = realm
+	}
+	return nil
+}

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -33,9 +34,14 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+type inboundProtocolRef struct {
+	Self string `json:"self"`
+}
+
 type Application struct {
-	Id   string `json:"id"`
-	Name string `json:"name"`
+	Id               string               `json:"id"`
+	Name             string               `json:"name"`
+	InboundProtocols []inboundProtocolRef `json:"inboundProtocols"`
 }
 
 type AppList struct {
@@ -45,6 +51,18 @@ type AppList struct {
 
 type AppConfig struct {
 	ApplicationName string `yaml:"applicationName"`
+}
+
+var protocolPathToKey = map[string]string{
+	"saml":        "saml",
+	"oidc":        "oidc",
+	"passive-sts": "passiveSts",
+	"ws-trust":    "wsTrust",
+}
+
+var unsupportedInboundProtocols = map[string]struct{}{
+	"kerberos": {},
+	"openid":   {},
 }
 
 type AuthConfig struct {
@@ -216,4 +234,58 @@ func isOauthSecretGiven(modifiedFileData string) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func processInboundProtocolConfigs(appId string, inboundProtocols []inboundProtocolRef, appMap map[string]interface{}, excludeSecrets bool) error {
+
+	result := make(map[string]interface{})
+	var customProtocols []interface{}
+	var skippedProtocols []string
+
+	for _, protocol := range inboundProtocols {
+		self := protocol.Self
+		protocolPath := path.Base(self)
+
+		if _, skip := unsupportedInboundProtocols[protocolPath]; skip {
+			skippedProtocols = append(skippedProtocols, protocolPath)
+			continue
+		}
+
+		body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols/"+protocolPath)
+		if err != nil {
+			return fmt.Errorf("error retrieving inbound protocol %s: %w", protocolPath, err)
+		}
+		var protocolConfig map[string]interface{}
+		if err := json.Unmarshal(body, &protocolConfig); err != nil {
+			return fmt.Errorf("error unmarshalling inbound protocol %s: %w", protocolPath, err)
+		}
+
+		if protocolPath == "oidc" && excludeSecrets {
+			maskOIDCClientSecret(protocolConfig)
+		}
+
+		protocolConfig["self"] = self
+
+		if key, known := protocolPathToKey[protocolPath]; known {
+			result[key] = protocolConfig
+		} else {
+			customProtocols = append(customProtocols, protocolConfig)
+		}
+	}
+
+	if len(customProtocols) > 0 {
+		result["custom"] = customProtocols
+	}
+	if len(skippedProtocols) > 0 {
+		log.Printf("Warn: Skipped unsupported inbound protocols: %v", skippedProtocols)
+	}
+
+	delete(appMap, "inboundProtocols")
+	appMap["inboundProtocolConfiguration"] = result
+	return nil
+}
+
+func maskOIDCClientSecret(oidcConfig map[string]interface{}) {
+
+	oidcConfig["clientSecret"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
 }

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -19,6 +19,7 @@
 package applications
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -34,10 +35,8 @@ func ExportAll(exportFilePath string, format string) {
 	// Export all applications to the Applications folder.
 	log.Println("Exporting applications...")
 	exportFilePath = filepath.Join(exportFilePath, utils.APPLICATIONS.String())
+	exportAPIExists := utils.ExportAPIExists(utils.APPLICATIONS)
 
-	if !utils.IsEntitySupportedInVersion(utils.APPLICATIONS) {
-		return
-	}
 	if utils.IsResourceTypeExcluded(utils.APPLICATIONS) {
 		return
 	}
@@ -50,11 +49,16 @@ func ExportAll(exportFilePath string, format string) {
 	}
 
 	apps := getAppList()
+	excludeSecrets := utils.AreSecretsExcluded(utils.TOOL_CONFIGS.ApplicationConfigs)
 	for _, app := range apps {
-		excludeSecrets := utils.AreSecretsExcluded(utils.TOOL_CONFIGS.ApplicationConfigs)
 		if !utils.IsResourceExcluded(app.Name, utils.TOOL_CONFIGS.ApplicationConfigs) {
 			log.Println("Exporting application: ", app.Name)
-			err := exportApp(app.Id, exportFilePath, format, excludeSecrets)
+			var err error
+			if exportAPIExists {
+				err = exportApp(app.Id, exportFilePath, format, excludeSecrets)
+			} else {
+				err = exportAppWithCRUD(app.Id, app.Name, exportFilePath, format, excludeSecrets)
+			}
 			if err != nil {
 				utils.UpdateFailureSummary(utils.APPLICATIONS, app.Name)
 				log.Printf("Error while exporting application: %s. %s", app.Name, err)
@@ -112,4 +116,57 @@ func exportApp(appId string, outputDirPath string, format string, excludeSecrets
 		return fmt.Errorf("error when writing the exported content to file: %w", err)
 	}
 	return nil
+}
+
+func exportAppWithCRUD(appId, appName, outputDirPath, formatString string, excludeSecrets bool) error {
+
+	appMap, err := getApp(appId, excludeSecrets)
+	if err != nil {
+		return fmt.Errorf("error while getting application: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, appName, format)
+
+	appKeywordMapping := getAppKeywordMapping(appName)
+	modifiedApp, err := utils.ProcessExportedData(appMap, exportedFileName, format, appKeywordMapping, utils.APPLICATIONS)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedApp, format, utils.APPLICATIONS)
+	if err != nil {
+		return fmt.Errorf("error while serializing application: %w", err)
+	}
+
+	err = os.WriteFile(exportedFileName, modifiedFile, 0644)
+	if err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}
+
+func getApp(appId string, excludeSecrets bool) (map[string]interface{}, error) {
+
+	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId)
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving application: %w", err)
+	}
+
+	var appStruct Application
+	if err := json.Unmarshal(body, &appStruct); err != nil {
+		return nil, fmt.Errorf("error unmarshalling application response: %w", err)
+	}
+	var appMap map[string]interface{}
+	if err := json.Unmarshal(body, &appMap); err != nil {
+		return nil, fmt.Errorf("error unmarshalling application response to map: %w", err)
+	}
+
+	if err := processInboundProtocolConfigs(appId, appStruct.InboundProtocols, appMap, excludeSecrets); err != nil {
+		return nil, fmt.Errorf("error while processing inbound protocol configs: %w", err)
+	}
+
+	delete(appMap, "access")
+	return appMap, nil
 }

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -44,7 +44,7 @@ func ExportAll(exportFilePath string, format string) {
 		os.MkdirAll(exportFilePath, 0700)
 	} else {
 		if utils.TOOL_CONFIGS.AllowDelete {
-			utils.RemoveDeletedLocalResources(exportFilePath, getDeployedAppNames())
+			utils.RemoveDeletedLocalResources(exportFilePath, append(getDeployedAppNames(), utils.RESIDENT_APP))
 		}
 	}
 
@@ -66,6 +66,16 @@ func ExportAll(exportFilePath string, format string) {
 				utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.EXPORT)
 				log.Println("Application exported successfully: ", app.Name)
 			}
+		}
+	}
+
+	if !utils.IsResourceExcluded(utils.RESIDENT_APP, utils.TOOL_CONFIGS.ApplicationConfigs) {
+		if err := exportResidentApp(exportFilePath, format); err != nil {
+			utils.UpdateFailureSummary(utils.APPLICATIONS, utils.RESIDENT_APP)
+			log.Printf("Error while exporting resident application: %s", err)
+		} else {
+			utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.EXPORT)
+			log.Println("Resident application exported successfully.")
 		}
 	}
 }
@@ -144,6 +154,36 @@ func exportAppWithCRUD(appId, appName, outputDirPath, formatString string, exclu
 		return fmt.Errorf("error when writing exported content to file: %w", err)
 	}
 
+	return nil
+}
+
+func exportResidentApp(outputDirPath, formatString string) error {
+
+	log.Println("Exporting Resident application...")
+
+	appData, err := utils.GetResourceData(utils.APPLICATIONS, "resident")
+	if err != nil {
+		return fmt.Errorf("error retrieving application: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, utils.RESIDENT_APP, format)
+
+	appKeywordMapping := getAppKeywordMapping(utils.RESIDENT_APP)
+	modifiedApp, err := utils.ProcessExportedData(appData, exportedFileName, format, appKeywordMapping, utils.APPLICATIONS)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedApp, format, utils.APPLICATIONS)
+	if err != nil {
+		return fmt.Errorf("error while serializing application: %w", err)
+	}
+
+	err = os.WriteFile(exportedFileName, modifiedFile, 0644)
+	if err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
 	return nil
 }
 

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -19,84 +19,56 @@
 package applications
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
-	"gopkg.in/yaml.v3"
 )
 
 func ImportAll(inputDirPath string) {
 
 	log.Println("Importing applications...")
 	importFilePath := filepath.Join(inputDirPath, utils.APPLICATIONS.String())
-	if !utils.IsEntitySupportedInVersion(utils.APPLICATIONS) {
-		return
-	}
+	exportAPIExists := utils.ExportAPIExists(utils.APPLICATIONS)
 
 	if utils.IsResourceTypeExcluded(utils.APPLICATIONS) {
 		return
 	}
-	var files []os.FileInfo
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
 		log.Println("No applications to import.")
-	} else {
-		files, err = ioutil.ReadDir(importFilePath)
-		if err != nil {
-			log.Println("Error importing applications: ", err)
-		}
-		if utils.TOOL_CONFIGS.AllowDelete {
-			removeDeletedDeployedApps(files)
-		}
+		return
+	}
+
+	deployedApps := getAppList()
+	files, err := ioutil.ReadDir(importFilePath)
+	if err != nil {
+		log.Println("Error importing applications: ", err)
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		removeDeletedDeployedApps(files, deployedApps)
 	}
 
 	for _, file := range files {
 		appFilePath := filepath.Join(importFilePath, file.Name())
-		appName := strings.TrimSuffix(file.Name(), filepath.Ext(file.Name()))
-		appExists, isValidFile := validateFile(appFilePath, appName)
+		fileInfo := utils.GetFileInfo(appFilePath)
+		appName := fileInfo.ResourceName
 
-		if isValidFile && !utils.IsResourceExcluded(appName, utils.TOOL_CONFIGS.ApplicationConfigs) {
-			importApp(appFilePath, appExists)
+		if !utils.IsResourceExcluded(appName, utils.TOOL_CONFIGS.ApplicationConfigs) {
+			appId := getAppId(appName, deployedApps)
+			err := importApp(appId, appName, appFilePath, exportAPIExists)
+			if err != nil {
+				log.Println("Error importing application: ", err)
+				utils.UpdateFailureSummary(utils.APPLICATIONS, appName)
+			}
 		}
 	}
 }
 
-func validateFile(appFilePath string, appName string) (appExists bool, isValid bool) {
-
-	appExists = false
-
-	fileContent, err := ioutil.ReadFile(appFilePath)
-	if err != nil {
-		log.Println("Error when reading the file for app: ", appName, err)
-		return appExists, false
-	}
-
-	// Validate the YAML format.
-	var appConfig AppConfig
-	err = yaml.Unmarshal(fileContent, &appConfig)
-	if err != nil {
-		log.Println("Invalid file content for app: ", appName, err)
-		return appExists, false
-	}
-
-	existingAppList := getDeployedAppNames()
-	for _, app := range existingAppList {
-		if app == appConfig.ApplicationName {
-			appExists = true
-			break
-		}
-	}
-	if appConfig.ApplicationName != appName {
-		log.Println("Warning: Application name in the file " + appFilePath + " is not matching with the file name.")
-	}
-	return appExists, true
-}
-
-func importApp(importFilePath string, isUpdate bool) error {
+func importApp(appId, appName, importFilePath string, exportAPIExists bool) error {
 
 	fileBytes, err := ioutil.ReadFile(importFilePath)
 	if err != nil {
@@ -104,36 +76,39 @@ func importApp(importFilePath string, isUpdate bool) error {
 	}
 
 	// Replace keyword placeholders in the local file according to the keyword mappings added in configs.
-	fileInfo := utils.GetFileInfo(importFilePath)
-	appKeywordMapping := getAppKeywordMapping(fileInfo.ResourceName)
+	appKeywordMapping := getAppKeywordMapping(appName)
 	fileDataWithReplacedKeywords := utils.ReplaceKeywords(string(fileBytes), appKeywordMapping)
 	modifiedFileData := utils.RemoveSecretMasks(fileDataWithReplacedKeywords)
 
-	if isUpdate {
-		return updateApplication(importFilePath, modifiedFileData, fileInfo)
+	if exportAPIExists {
+		if appId == "" {
+			return importApplication(appName, importFilePath, modifiedFileData)
+		}
+		return updateApplication(appName, importFilePath, modifiedFileData)
 	}
-	return importApplication(importFilePath, modifiedFileData, fileInfo)
-}
 
-func updateApplication(importFilePath string, modifiedFileData string, fileInfo utils.FileInfo) error {
-
-	log.Println("Updating application: " + fileInfo.ResourceName)
-	err := utils.SendUpdateRequest("", importFilePath, modifiedFileData, utils.APPLICATIONS)
+	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
 	if err != nil {
-		utils.UpdateFailureSummary(utils.APPLICATIONS, fileInfo.ResourceName)
-		return fmt.Errorf("error when updating application: %s", err)
+		return fmt.Errorf("unsupported file format for application: %w", err)
 	}
-	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.UPDATE)
-	log.Println("Application updated successfully.")
-	return nil
+
+	appMap, err := utils.DeserializeToMap([]byte(modifiedFileData), format, utils.APPLICATIONS)
+	if err != nil {
+		return fmt.Errorf("error deserializing application: %w", err)
+	}
+	delete(appMap, "id")
+
+	if appId == "" {
+		return importAppWithCRUD(appName, appMap)
+	}
+	return updateAppWithCRUD(appId, appName, appMap)
 }
 
-func importApplication(importFilePath string, modifiedFileData string, fileInfo utils.FileInfo) error {
+func importApplication(appName, importFilePath, modifiedFileData string) error {
 
-	log.Println("Creating new application: " + fileInfo.ResourceName)
+	log.Println("Creating new application: " + appName)
 	err := utils.SendImportRequest(importFilePath, modifiedFileData, utils.APPLICATIONS)
 	if err != nil {
-		utils.UpdateFailureSummary(utils.APPLICATIONS, fileInfo.ResourceName)
 		return fmt.Errorf("error when importing application: %s", err)
 	}
 
@@ -143,21 +118,66 @@ func importApplication(importFilePath string, modifiedFileData string, fileInfo 
 		fmt.Println("Failed to check if oauthConsumerSecret is given:", err.Error())
 	} else if oauthApp && !oauthSecretGiven {
 		// Check if oauthConsumerSecret is given or else add an indicator to the summary informing a new secret is generated.
-		utils.AddNewSecretIndicatorToSummary(fileInfo.ResourceName)
+		utils.AddNewSecretIndicatorToSummary(appName)
 	}
 	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.IMPORT)
 	log.Println("Application imported successfully.")
 	return nil
 }
 
-func removeDeletedDeployedApps(localFiles []os.FileInfo) {
+func updateApplication(appName, importFilePath, modifiedFileData string) error {
+
+	log.Println("Updating application: " + appName)
+	err := utils.SendUpdateRequest("", importFilePath, modifiedFileData, utils.APPLICATIONS)
+	if err != nil {
+		return fmt.Errorf("error when updating application: %s", err)
+	}
+	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.UPDATE)
+	log.Println("Application updated successfully.")
+	return nil
+}
+
+func importAppWithCRUD(appName string, appMap map[string]interface{}) error {
+
+	log.Println("Creating new application: " + appName)
+
+	newSecretCreated, err := processInboundProtocolsForPost(appMap)
+	if err != nil {
+		return fmt.Errorf("error processing inbound protocols: %w", err)
+	}
+
+	body, err := json.Marshal(appMap)
+	if err != nil {
+		return fmt.Errorf("error marshalling application: %w", err)
+	}
+
+	resp, err := utils.SendPostRequest(utils.APPLICATIONS, body)
+	if err != nil {
+		return fmt.Errorf("error creating application: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if newSecretCreated {
+		utils.AddNewSecretIndicatorToSummary(appName)
+	}
+	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.IMPORT)
+	log.Println("Application imported successfully.")
+	return nil
+}
+
+func updateAppWithCRUD(appId, appName string, appMap map[string]interface{}) error {
+
+	// Implemented in commit 4.
+	return fmt.Errorf("updateAppWithCRUD not yet implemented")
+}
+
+func removeDeletedDeployedApps(localFiles []os.FileInfo, deployedApps []Application) {
 
 	localAppNames := make(map[string]struct{})
 	for _, file := range localFiles {
 		localAppNames[utils.GetFileInfo(file.Name()).ResourceName] = struct{}{}
 	}
 
-	deployedApps := getAppList()
 	for _, app := range deployedApps {
 		if _, existsLocally := localAppNames[app.Name]; existsLocally {
 			continue

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -168,6 +168,10 @@ func importAppWithCRUD(appName string, appMap map[string]interface{}) error {
 
 func updateAppWithCRUD(appId, appName string, appMap map[string]interface{}) error {
 
+	if appName == utils.CONSOLE || appName == utils.MY_ACCOUNT {
+		log.Printf("Application: %s is a system application. Skipping update.\n", appName)
+		return nil
+	}
 	log.Println("Updating application: " + appName)
 
 	localProtocolConfig, ok := appMap["inboundProtocolConfiguration"].(map[string]interface{})

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
@@ -167,8 +168,77 @@ func importAppWithCRUD(appName string, appMap map[string]interface{}) error {
 
 func updateAppWithCRUD(appId, appName string, appMap map[string]interface{}) error {
 
-	// Implemented in commit 4.
-	return fmt.Errorf("updateAppWithCRUD not yet implemented")
+	log.Println("Updating application: " + appName)
+
+	localProtocolConfig, ok := appMap["inboundProtocolConfiguration"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for inboundProtocolConfiguration")
+	}
+	localProtocols, err := flattenInboundProtocols(localProtocolConfig)
+	if err != nil {
+		return fmt.Errorf("error processing inbound protocols: %w", err)
+	}
+
+	if err := patchApplication(appId, appMap); err != nil {
+		return fmt.Errorf("error updating application: %w", err)
+	}
+
+	if utils.TOOL_CONFIGS.AllowDelete {
+		deployedRefs, err := getDeployedInboundProtocols(appId)
+		if err != nil {
+			return fmt.Errorf("error retrieving deployed inbound protocols: %w", err)
+		}
+		if err := removeDeletedInboundProtocols(appId, deployedRefs, localProtocols); err != nil {
+			return fmt.Errorf("error removing deleted inbound protocols: %w", err)
+		}
+	}
+	if err := updateInboundProtocols(appId, localProtocols); err != nil {
+		return fmt.Errorf("error updating inbound protocols: %w", err)
+	}
+
+	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.UPDATE)
+	log.Println("Application updated successfully.")
+	return nil
+}
+
+func patchApplication(appId string, appMap map[string]interface{}) error {
+
+	delete(appMap, "inboundProtocolConfiguration")
+
+	body, err := json.Marshal(appMap)
+	if err != nil {
+		return fmt.Errorf("error marshalling application: %w", err)
+	}
+	resp, err := utils.SendPatchRequest(utils.APPLICATIONS, appId, body)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	return nil
+}
+
+func updateInboundProtocols(appId string, localProtocols []map[string]interface{}) error {
+
+	for _, protocolMap := range localProtocols {
+		self, ok := protocolMap["self"].(string)
+		if !ok {
+			return fmt.Errorf("unexpected format for self URL")
+		}
+		protocolPath := path.Base(self)
+		delete(protocolMap, "self")
+
+		protocolBody, err := json.Marshal(protocolMap)
+		if err != nil {
+			return fmt.Errorf("error marshalling protocol %s: %w", protocolPath, err)
+		}
+		resp, err := utils.SendPutRequest(utils.APPLICATIONS, appId+"/inbound-protocols/"+protocolPath, protocolBody)
+		if err != nil {
+			return fmt.Errorf("error updating protocol %s: %w", protocolPath, err)
+		}
+		resp.Body.Close()
+	}
+	return nil
 }
 
 func removeDeletedDeployedApps(localFiles []os.FileInfo, deployedApps []Application) {
@@ -205,4 +275,27 @@ func removeDeletedDeployedApps(localFiles []os.FileInfo, deployedApps []Applicat
 		}
 		utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.DELETE)
 	}
+}
+
+func removeDeletedInboundProtocols(appId string, deployedRefs []inboundProtocolRef, localProtocols []map[string]interface{}) error {
+
+	localSelfURLs := make(map[string]struct{})
+	for _, p := range localProtocols {
+		self, ok := p["self"].(string)
+		if !ok {
+			return fmt.Errorf("unexpected format for self URL")
+		}
+		localSelfURLs[self] = struct{}{}
+	}
+
+	for _, ref := range deployedRefs {
+		if _, existsLocally := localSelfURLs[ref.Self]; existsLocally {
+			continue
+		}
+		protocolPath := path.Base(ref.Self)
+		if err := utils.SendDeleteRequest(appId+"/inbound-protocols/"+protocolPath, utils.APPLICATIONS); err != nil {
+			return fmt.Errorf("error deleting inbound protocol %s: %w", protocolPath, err)
+		}
+	}
+	return nil
 }

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -225,17 +225,15 @@ func patchApplication(appId string, appMap map[string]interface{}) error {
 func updateInboundProtocols(appId string, localProtocols []map[string]interface{}) error {
 
 	for _, protocolMap := range localProtocols {
-		self, ok := protocolMap["self"].(string)
-		if !ok {
-			return fmt.Errorf("unexpected format for self URL")
+		protocolPath, err := processInboundProtocolForUpdate(appId, protocolMap)
+		if err != nil {
+			return fmt.Errorf("error processing protocol: %w", err)
 		}
-		protocolPath := path.Base(self)
-		delete(protocolMap, "self")
-
 		protocolBody, err := json.Marshal(protocolMap)
 		if err != nil {
 			return fmt.Errorf("error marshalling protocol %s: %w", protocolPath, err)
 		}
+
 		resp, err := utils.SendPutRequest(utils.APPLICATIONS, appId+"/inbound-protocols/"+protocolPath, protocolBody)
 		if err != nil {
 			return fmt.Errorf("error updating protocol %s: %w", protocolPath, err)
@@ -297,6 +295,9 @@ func removeDeletedInboundProtocols(appId string, deployedRefs []inboundProtocolR
 			continue
 		}
 		protocolPath := path.Base(ref.Self)
+		if _, unsupported := unsupportedInboundProtocols[protocolPath]; unsupported {
+			continue
+		}
 		if err := utils.SendDeleteRequest(appId+"/inbound-protocols/"+protocolPath, utils.APPLICATIONS); err != nil {
 			return fmt.Errorf("error deleting inbound protocol %s: %w", protocolPath, err)
 		}

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -76,12 +76,11 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 		return fmt.Errorf("error when reading the file for application: %s", err)
 	}
 
-	// Replace keyword placeholders in the local file according to the keyword mappings added in configs.
 	appKeywordMapping := getAppKeywordMapping(appName)
 	fileDataWithReplacedKeywords := utils.ReplaceKeywords(string(fileBytes), appKeywordMapping)
 	modifiedFileData := utils.RemoveSecretMasks(fileDataWithReplacedKeywords)
 
-	if exportAPIExists {
+	if exportAPIExists && appName != utils.RESIDENT_APP {
 		if appId == "" {
 			return importApplication(appName, importFilePath, modifiedFileData)
 		}
@@ -92,13 +91,16 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 	if err != nil {
 		return fmt.Errorf("unsupported file format for application: %w", err)
 	}
-
 	appMap, err := utils.DeserializeToMap([]byte(modifiedFileData), format, utils.APPLICATIONS)
 	if err != nil {
 		return fmt.Errorf("error deserializing application: %w", err)
 	}
-	delete(appMap, "id")
 
+	if appName == utils.RESIDENT_APP {
+		return updateResidentApp(appMap)
+	}
+
+	delete(appMap, "id")
 	if appId == "" {
 		return importAppWithCRUD(appName, appMap)
 	}
@@ -202,6 +204,35 @@ func updateAppWithCRUD(appId, appName string, appMap map[string]interface{}) err
 
 	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.UPDATE)
 	log.Println("Application updated successfully.")
+	return nil
+}
+
+func updateResidentApp(appMap map[string]interface{}) error {
+
+	log.Println("Updating Resident application")
+
+	provConfig, ok := appMap["provisioningConfigurations"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unsupported format for provisioningConfigurations")
+	}
+	if inbound, ok := provConfig["inboundProvisioning"].(map[string]interface{}); ok {
+		if _, exists := inbound["proxyMode"]; !exists {
+			inbound["proxyMode"] = false
+		}
+	}
+
+	reqBody, err := json.Marshal(provConfig)
+	if err != nil {
+		return fmt.Errorf("error marshalling provisioning configurations: %w", err)
+	}
+	resp, err := utils.SendPutRequest(utils.APPLICATIONS, "resident", reqBody)
+	if err != nil {
+		return fmt.Errorf("error updating application: %w", err)
+	}
+	resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.UPDATE)
+	log.Println("Resident application updated successfully.")
 	return nil
 }
 

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -50,7 +50,7 @@ func ImportAll(inputDirPath string) {
 			log.Println("Error importing applications: ", err)
 		}
 		if utils.TOOL_CONFIGS.AllowDelete {
-			removeDeletedDeployedApps(files, importFilePath)
+			removeDeletedDeployedApps(files)
 		}
 	}
 
@@ -150,27 +150,33 @@ func importApplication(importFilePath string, modifiedFileData string, fileInfo 
 	return nil
 }
 
-func removeDeletedDeployedApps(localFiles []os.FileInfo, importFilePath string) {
+func removeDeletedDeployedApps(localFiles []os.FileInfo) {
 
-	// Remove deployed applications that do not exist locally.
+	localAppNames := make(map[string]struct{})
+	for _, file := range localFiles {
+		localAppNames[utils.GetFileInfo(file.Name()).ResourceName] = struct{}{}
+	}
+
 	deployedApps := getAppList()
-deployedResources:
 	for _, app := range deployedApps {
-		for _, file := range localFiles {
-			isToolManagementApp, err := isToolMgtApp(file, importFilePath)
-			if err != nil {
-				log.Printf("Error checking if application is a tool management app: %s\n", err.Error())
-				log.Printf("Application: %s is excluded from deletion.\n", app.Name)
-				continue deployedResources
-			}
-			if app.Name == utils.GetFileInfo(file.Name()).ResourceName || isToolManagementApp {
-				continue deployedResources
-			}
+		if _, existsLocally := localAppNames[app.Name]; existsLocally {
+			continue
 		}
-		if utils.IsResourceExcluded(app.Name, utils.TOOL_CONFIGS.ApplicationConfigs) || app.Name == utils.CONSOLE || app.Name == utils.MY_ACCOUNT {
+
+		if utils.IsResourceExcluded(app.Name, utils.TOOL_CONFIGS.ApplicationConfigs) ||
+			app.Name == utils.CONSOLE || app.Name == utils.MY_ACCOUNT || app.Name == utils.CARBON_SP {
 			log.Printf("Application: %s is excluded from deletion.\n", app.Name)
 			continue
 		}
+		if isToolMgt, err := isToolMgtApp(app.Id); err != nil {
+			log.Printf("Error checking if application is the tool management app: %s\n", err.Error())
+			log.Printf("Application: %s is excluded from deletion.\n", app.Name)
+			continue
+		} else if isToolMgt {
+			log.Printf("Info: Tool Management App: %s is excluded from deletion.\n", app.Name)
+			continue
+		}
+
 		log.Println("Application not found locally. Deleting app: ", app.Name)
 		err := utils.SendDeleteRequest(app.Id, utils.APPLICATIONS)
 		if err != nil {

--- a/iamctl/pkg/claims/import.go
+++ b/iamctl/pkg/claims/import.go
@@ -117,7 +117,7 @@ func importClaimDialect(dialectId, dialectUri, importFilePath string) error {
 	}
 
 	if dialectId == "" {
-		return createClaimDialectWithCRUD(dialectUri, claims)
+		return importClaimDialectWithCRUD(dialectUri, claims)
 	}
 	return updateClaimDialectWithCRUD(dialectId, dialectUri, claims)
 }
@@ -146,7 +146,7 @@ func updateDialect(dialectId, dialectUri, importFilePath, modifiedFileData strin
 	return nil
 }
 
-func createClaimDialectWithCRUD(dialectURI string, claims []map[string]interface{}) error {
+func importClaimDialectWithCRUD(dialectURI string, claims []map[string]interface{}) error {
 
 	log.Println("Creating new claim dialect: " + dialectURI)
 

--- a/iamctl/pkg/identityProviders/import.go
+++ b/iamctl/pkg/identityProviders/import.go
@@ -105,7 +105,7 @@ func importIdp(idpId string, idpName string, importFilePath string, exportAPIExi
 	}
 
 	if idpId == "" {
-		return createIdpWithCRUD(idpName, []byte(modifiedFileData), format)
+		return importIdpWithCRUD(idpName, []byte(modifiedFileData), format)
 	}
 	return updateIdpWithCRUD(idpId, idpName, []byte(modifiedFileData), format)
 }
@@ -134,7 +134,7 @@ func updateIdentityProvider(idpId, idpName, importFilePath, modifiedFileData str
 	return nil
 }
 
-func createIdpWithCRUD(idpName string, requestBody []byte, format utils.Format) error {
+func importIdpWithCRUD(idpName string, requestBody []byte, format utils.Format) error {
 
 	log.Println("Creating new identity provider: " + idpName)
 

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -253,11 +253,11 @@ var appArrayFields = []string{
 	"inboundProtocolConfiguration.oidc.allowedOrigins",
 	"inboundProtocolConfiguration.oidc.scopeValidators",
 	"inboundProtocolConfiguration.oidc.idToken.audience",
-	"inboundProtocolConfiguration.saml.assertionConsumerUrls",
-	"inboundProtocolConfiguration.saml.singleSignOnProfile.bindings",
-	"inboundProtocolConfiguration.saml.singleLogoutProfile.idpInitiatedSingleLogout.returnToUrls",
-	"inboundProtocolConfiguration.saml.singleSignOnProfile.assertion.audiences",
-	"inboundProtocolConfiguration.saml.singleSignOnProfile.assertion.recipients",
+	"inboundProtocolConfiguration.saml.manualConfiguration.assertionConsumerUrls",
+	"inboundProtocolConfiguration.saml.manualConfiguration.singleSignOnProfile.bindings",
+	"inboundProtocolConfiguration.saml.manualConfiguration.singleLogoutProfile.idpInitiatedSingleLogout.returnToUrls",
+	"inboundProtocolConfiguration.saml.manualConfiguration.singleSignOnProfile.assertion.audiences",
+	"inboundProtocolConfiguration.saml.manualConfiguration.singleSignOnProfile.assertion.recipients",
 	"inboundProtocolConfiguration.custom",
 }
 

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -107,7 +107,7 @@ var ErrorCodes = map[int]string{
 }
 
 // Identifiers of array types for each resource type
-var applicationArrayIdentifiers = map[string]string{
+var appExportAPIArrayIdentifiers = map[string]string{
 
 	"inboundAuthenticationRequestConfigs": "inboundAuthKey",
 	"spProperties":                        "name",
@@ -124,6 +124,17 @@ var applicationArrayIdentifiers = map[string]string{
 	"idpClaims":                           "claimId",
 	"provisioningProperties":              "name",
 	"applicationRoleMappingConfig":        "idPName",
+}
+
+var appGetAPIArrayIdentifiers = map[string]string{
+
+	"claimMappings":            "localClaim.uri",
+	"requestedClaims":          "claim.uri",
+	"steps":                    "id",
+	"options":                  "authenticator",
+	"outboundProvisioningIdps": "idp",
+	"mappings":                 "localRole",
+	"properties":               "key",
 }
 
 var idpExportAPIArrayIdentifiers = map[string]string{
@@ -185,31 +196,38 @@ var RESOURCE_REFERENCE_METADATA = map[ResourceType][]ResourceReferenceMeta{}
 
 // Array field paths for each resource type
 var oidcScopeArrayFields = []string{
+
 	"claims",
 }
 
 var rolesArrayFields = []string{
+
 	"permissions",
 	"schemas",
 }
 
 var challengeQuestionsArrayFields = []string{
+
 	"questions",
 }
 
 var governanceConnectorArrayFields = []string{
+
 	"properties",
 }
 
 var userStoreArrayFields = []string{
+
 	"properties",
 }
 
 var claimArrayFields = []string{
+
 	"claims",
 }
 
 var idpArrayFields = []string{
+
 	"federatedAuthenticators.authenticators",
 	"provisioning.outboundConnectors.connectors",
 	"federatedAuthenticators.authenticators.properties",
@@ -218,6 +236,28 @@ var idpArrayFields = []string{
 	"roles.mappings",
 	"claims.provisioningClaims",
 	"certificate.certificates",
+}
+
+var appArrayFields = []string{
+
+	"claimConfiguration.claimMappings",
+	"claimConfiguration.requestedClaims",
+	"claimConfiguration.role.mappings",
+	"authenticationSequence.steps",
+	"authenticationSequence.steps.options",
+	"authenticationSequence.requestPathAuthenticators",
+	"provisioningConfigurations.outboundProvisioningIdps",
+	"inboundProtocolConfiguration.oidc.grantTypes",
+	"inboundProtocolConfiguration.oidc.callbackURLs",
+	"inboundProtocolConfiguration.oidc.allowedOrigins",
+	"inboundProtocolConfiguration.oidc.scopeValidators",
+	"inboundProtocolConfiguration.oidc.idToken.audience",
+	"inboundProtocolConfiguration.saml.assertionConsumerUrls",
+	"inboundProtocolConfiguration.saml.singleSignOnProfile.bindings",
+	"inboundProtocolConfiguration.saml.singleLogoutProfile.idpInitiatedSingleLogout.returnToUrls",
+	"inboundProtocolConfiguration.saml.singleSignOnProfile.assertion.audiences",
+	"inboundProtocolConfiguration.saml.singleSignOnProfile.assertion.recipients",
+	"inboundProtocolConfiguration.custom",
 }
 
 // XML root element tags for each resource type
@@ -231,4 +271,5 @@ const (
 	XML_ROOT_USERSTORE            = "UserStore"
 	XML_ROOT_CLAIM                = "DialectConfiguration"
 	XML_ROOT_IDENTITY_PROVIDER    = "IdentityProvider"
+	XML_ROOT_APPLICATION          = "ServiceProvider"
 )

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -91,6 +91,7 @@ const SENSITIVE_FIELD_MASK_WITHOUT_QUOTES = "********"
 const RESIDENT_IDP_NAME = "LOCAL"
 const CONSOLE = "Console"
 const MY_ACCOUNT = "My Account"
+const CARBON_SP = "wso2carbon-local-sp"
 const ADMIN = "admin"
 const OAUTH2 = "oauth2"
 const ALL_ITEMS = "all_items" // Wildcard to match all elements in an array

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -92,6 +92,7 @@ const RESIDENT_IDP_NAME = "LOCAL"
 const CONSOLE = "Console"
 const MY_ACCOUNT = "My Account"
 const CARBON_SP = "wso2carbon-local-sp"
+const RESIDENT_APP = "Resident"
 const ADMIN = "admin"
 const OAUTH2 = "oauth2"
 const ALL_ITEMS = "all_items" // Wildcard to match all elements in an array

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -173,7 +173,10 @@ func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 
 	switch resourceType {
 	case APPLICATIONS:
-		return applicationArrayIdentifiers
+		if ExportAPIExists(APPLICATIONS) {
+			return appExportAPIArrayIdentifiers
+		}
+		return appGetAPIArrayIdentifiers
 	case IDENTITY_PROVIDERS:
 		if ExportAPIExists(IDENTITY_PROVIDERS) {
 			return idpExportAPIArrayIdentifiers

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -26,9 +26,9 @@ package utils
  */
 var ResourceOrder = []ResourceType{
 	CLAIMS,
-	IDENTITY_PROVIDERS,
 	USERSTORES,
-	APPLICATIONS,
+	IDENTITY_PROVIDERS, // Dependency: Claims, Userstores
+	APPLICATIONS,       // Dependency: Claims, Userstores, Identity Providers
 	OIDC_SCOPES,
 	ROLES, // Dependency: Applications
 	CHALLENGE_QUESTIONS,

--- a/iamctl/pkg/utils/resourceProperties.go
+++ b/iamctl/pkg/utils/resourceProperties.go
@@ -167,5 +167,6 @@ func RemoveDeletedLocalResources(filePath string, deployedResourceNames []string
 func RemoveSecretMasks(modifiedFileData string) string {
 
 	modifiedFileData = strings.ReplaceAll(modifiedFileData, SENSITIVE_FIELD_MASK, "null")
+	modifiedFileData = strings.ReplaceAll(modifiedFileData, `"`+SENSITIVE_FIELD_MASK_WITHOUT_QUOTES+`"`, "null")
 	return modifiedFileData
 }

--- a/iamctl/pkg/utils/serializationUtils.go
+++ b/iamctl/pkg/utils/serializationUtils.go
@@ -170,6 +170,7 @@ func GetXMLRootTag(resourceType ResourceType) string {
 		USERSTORES:            XML_ROOT_USERSTORE,
 		CLAIMS:                XML_ROOT_CLAIM,
 		IDENTITY_PROVIDERS:    XML_ROOT_IDENTITY_PROVIDER,
+		APPLICATIONS:          XML_ROOT_APPLICATION,
 	}
 	return xmlRootTags[resourceType]
 }
@@ -214,6 +215,8 @@ func GetArrayFieldPaths(resourceType ResourceType) []string {
 		return claimArrayFields
 	case IDENTITY_PROVIDERS:
 		return idpArrayFields
+	case APPLICATIONS:
+		return appArrayFields
 	default:
 		return []string{}
 	}

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -20,13 +20,9 @@ package utils
 
 // Minimum WSO2 Identity Server version requirements for each resource type.
 // If a resource type is not present in this map, there is no minimum version requirement.
-const (
-	MIN_VERSION_APPLICATIONS = "6.1.0"
-)
+const ()
 
-var EntityMinVersionRequirements = map[ResourceType]string{
-	APPLICATIONS: MIN_VERSION_APPLICATIONS,
-}
+var EntityMinVersionRequirements = map[ResourceType]string{}
 
 // Maximum supported WSO2 Identity Server version for each resource type.
 // If a resource type is not present in this map, there is no upper version limit.
@@ -39,10 +35,12 @@ const (
 	MIN_VERSION_USERSTORE_EXPORT_API = "6.1.0"
 	MIN_VERSION_CLAIMS_EXPORT_API    = "6.1.0"
 	MIN_VERSION_IDP_EXPORT_API       = "6.1.0"
+	MIN_VERSION_APP_EXPORT_API       = "6.1.0"
 )
 
 var ExportAPIMinVersionRequirements = map[ResourceType]string{
 	USERSTORES:         MIN_VERSION_USERSTORE_EXPORT_API,
 	CLAIMS:             MIN_VERSION_CLAIMS_EXPORT_API,
 	IDENTITY_PROVIDERS: MIN_VERSION_IDP_EXPORT_API,
+	APPLICATIONS:       MIN_VERSION_APP_EXPORT_API,
 }


### PR DESCRIPTION
## Purpose
                                                                                                                                                                                                                            
  Extend application export/import support to Identity Server versions below 6.1 by utilizing CRUD APIs when the dedicated file-based export/import API is unavailable. Also fixes a bug in the tool management app deletion guard where the check was incorrectly performed against local files rather than the deployed application.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/57
                                                                                                                                                                                                                            
## Goals           

  - Export applications on IS versions below 6.1 using the Application CRUD APIs                           
  - Import (create/update) applications on IS versions below 6.1 CRUD APIs
  - Detect the server version and select the appropriate API path
  - Maintain full feature parity (keyword replacement, EXCLUDE/INCLUDE_ONLY, ALLOW_DELETE, secret masking) regardless of the API path used                                                                                  
  - Assemble a complete per-application file during CRUD export, embedding inbound protocol configurations (OIDC, SAML, passive-STS, WS-Trust, custom) fetched via separate sub-resource GETs                               
  - Perform full inbound protocol sync on update: PUT protocols present in the local file, DELETE protocols deployed on the server but absent locally 
  - Preserve read-only fields of deployed inbound protocols on update                                                                      
  - Mask clientSecret of OIDC protocol on export based on EXCLUDE_SECRETS: true
  - Protect the tool management app from deletion in both file-based and CRUD paths    
  - Support Resident application import/export                                                                                                                                     
  - Fix the import/export resource processing order so applications are handled at the correct position relative to other resource types                                                                                    
                                                                                                                                                                                                                            
  ## Approach                                                                                                                                                                                                                  
                                                                                                                                                                                                                            
  ### Dual-API version gate                                                                                                                                                                                                     
   
  versionRequirements.go now defines `MIN_VERSION_APP_EXPORT_API` and maps APPLICATIONS into `ExportAPIMinVersionRequirements`. APPLICATIONS is removed from `EntityMinVersionRequirements` so that older IS versions can fall back to CRUD rather than being blocked entirely. 
                                                                                                                                                                                                                            
  ### CRUD export                                                                                                                                                                                                               
   
  getApp() in applicationUtils.go fetches the top-level application, then calls `getInboundProtocolConfigs()` to fetch each linked protocol. The inboundProtocols link list is replaced in the output map with `inboundProtocolConfiguration` map whose keys are canonical protocol names (oidc, saml, passiveSts, wsTrust). SAML configs are wrapped in `{manualConfiguration: ...}`. Unrecognised protocols (kerberos, openID, and unsupported custom types) are handled gracefully. Each protocol config retains a self field storing the full self URL for later matching during update.

  ### CRUD import — create                                                                                                                                                                                                      
   
  `createAppWithCRUD()` calls `prepareInboundProtocolsForPost()`, which strips self from each protocol config. The prepared map is marshalled and sent. If the app is OAuth and no clientSecret was provided, a new-secret indicator is added to the summary.                                                                                                                                                                                        
                  
  ### CRUD import — update                                                                                                                                                                                                      
   
`updateAppWithCRUD()` extracts the `inboundProtocolConfiguration` and flattens it into a list of individual protocol maps via `flattenInboundProtocols()`. `patchApplication()` then deletes `inboundProtocolConfiguration` from the map and sends the request with the remaining top-level fields.
                                                                                                                                                                  
  If `ALLOW_DELETE` is enabled, `removeDeletedInboundProtocols()` GETs the currently deployed protocol refs, builds a set of local self URLs, and DELETEs any deployed protocol whose self is not present locally (skipping unsupported protocols like Kerberos and OpenID).
                                                                                                                                                                  
 `updateInboundProtocols()` then PUTs each local protocol. Before sending, `processInboundProtocolForUpdate()` extracts the protocolPath from the self URL and strips self from the map. 

### Preserve read-only fields of inbound protocols in update

For OIDC and passive-STS protocols, `injectDeployedReadOnlyFields()` GETs the currently deployed config and copies server-managed read-only fields back into the local map before the PUT; specifically `clientId` and `clientSecret` for OIDC, and `realm` for passive-STS, to avoid the server rejecting the update due to miss match in read-only fields.

  ### Tool management app deletion guard — bug fix                                                                                                                                                                              
   
  Previously `isToolMgtApp()` read local files to decide whether a deployed app should be protected from deletion. The function is rewritten as `isToolMgtApp(appId string)`, which GETs the deployed app's OIDC inbound config and compares clientId to `SERVER_CONFIGS.ClientId`. The outer loop in `removeDeletedDeployedApps()` is also refactored from an `O(n²)` nested loop to a set-based `O(1)` lookup. 

### Resident application import/export  

  `exportResidentApp()` fetches the resident application , applies keyword replacement and writes to  the Applications directory. The file is always written using the CRUD path since there is no file-based export API for the resident app. The resident application name is appended to the deployed app name list passed to `RemoveDeletedLocalResources()` so the file is not deleted during stale file cleanup.                        

  `updateResidentApp()` receives the deserialized app map from `importApp()` extracts the `provisioningConfigurations` field, injects `proxyMode: false` into `inboundProvisioning` if absent, and sends update request. The `importApp()` function short-circuits the export API path for the resident app and routes it directly to the CRUD deserialization and update flow regardless of server version.                                                                                                      
                  
  ### System application protection

  The CRUD update path skips Console and My Account system applications. Also wso2carbon-local-sp app is now preserved in deletion.
   
  ### Serialization support                                                                                                                                                                                                     
                  
Added `appCRUDArrayIdentifiers`, `appCRUDArrayFields`, and `XML_ROOT_APPLICATION`. `GetArrayIdentifiers()` is updated to return the CRUD variants when the file-based export API is unavailable for APPLICATIONS.
                                                                                                                                                                                                                            
  ## User Stories    

As a system administrator, I want to export and import Applications using IAM-CTL to enable version control and maintain consistent IAM configurations.
                                                                                                                                                                                                                            
  ## Release Note                                                                                                                                                                                                              
   
  Extended application export/import to support Identity Server versions below 6.1. 

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.