### PR TITLE
Fix issues in Application import and inbound protocol handling 

### DIFF
--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -273,7 +273,7 @@ func processInboundProtocolConfigs(appId string, inboundProtocols []inboundProto
 			}
 		}
 
-		protocolConfig["self"] = self
+		protocolConfig["_type"] = protocolPath
 		if key, known := protocolPathToKey[protocolPath]; known {
 			result[key] = protocolConfig
 		} else {
@@ -316,7 +316,7 @@ func processInboundProtocolsForPost(appMap map[string]interface{}) (newSecretCre
 				if !ok {
 					return false, fmt.Errorf("unexpected format for custom inbound protocol")
 				}
-				delete(itemMap, "self")
+				delete(itemMap, "_type")
 			}
 			continue
 		}
@@ -325,7 +325,7 @@ func processInboundProtocolsForPost(appMap map[string]interface{}) (newSecretCre
 		if !ok {
 			return false, fmt.Errorf("unexpected format for inbound protocol: %s", key)
 		}
-		delete(configMap, "self")
+		delete(configMap, "_type")
 
 		if key == "oidc" {
 			secret, _ := configMap["clientSecret"].(string)
@@ -379,12 +379,11 @@ func flattenInboundProtocols(localProtocolConfig map[string]interface{}) ([]map[
 
 func processInboundProtocolForUpdate(appId string, protocolMap map[string]interface{}) (protocolPath string, err error) {
 
-	self, ok := protocolMap["self"].(string)
+	protocolPath, ok := protocolMap["_type"].(string)
 	if !ok {
-		return "", fmt.Errorf("self URL not found")
+		return "", fmt.Errorf("_type not found in inbound protocol")
 	}
-	protocolPath = path.Base(self)
-	delete(protocolMap, "self")
+	delete(protocolMap, "_type")
 
 	if protocolPath == "oidc" || protocolPath == "passive-sts" {
 		if err := injectDeployedReadOnlyFields(appId, protocolPath, protocolMap); err != nil {
@@ -398,6 +397,9 @@ func injectDeployedReadOnlyFields(appId, protocolPath string, localConfig map[st
 
 	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols/"+protocolPath)
 	if err != nil {
+		if strings.Contains(err.Error(), "Resource not found") {
+			return nil
+		}
 		return fmt.Errorf("error retrieving deployed %s config: %w", protocolPath, err)
 	}
 	var deployedConfig map[string]interface{}

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -142,6 +142,10 @@ func updateApplication(appName, importFilePath, modifiedFileData string) error {
 
 func importAppWithCRUD(appName string, appMap map[string]interface{}) error {
 
+	if appName == utils.CONSOLE || appName == utils.MY_ACCOUNT || appName == utils.CARBON_SP {
+		log.Printf("Application: %s is a system application. Skipping import.\n", appName)
+		return nil
+	}
 	log.Println("Creating new application: " + appName)
 
 	newSecretCreated, err := processInboundProtocolsForPost(appMap)
@@ -312,17 +316,17 @@ func removeDeletedDeployedApps(localFiles []os.FileInfo, deployedApps []Applicat
 
 func removeDeletedInboundProtocols(appId string, deployedRefs []inboundProtocolRef, localProtocols []map[string]interface{}) error {
 
-	localSelfURLs := make(map[string]struct{})
+	localTypes := make(map[string]struct{})
 	for _, p := range localProtocols {
-		self, ok := p["self"].(string)
+		t, ok := p["_type"].(string)
 		if !ok {
-			return fmt.Errorf("unexpected format for self URL")
+			return fmt.Errorf("unexpected format for _type in inbound protocol")
 		}
-		localSelfURLs[self] = struct{}{}
+		localTypes[t] = struct{}{}
 	}
 
 	for _, ref := range deployedRefs {
-		if _, existsLocally := localSelfURLs[ref.Self]; existsLocally {
+		if _, existsLocally := localTypes[path.Base(ref.Self)]; existsLocally {
 			continue
 		}
 		protocolPath := path.Base(ref.Self)


### PR DESCRIPTION
## Purpose                                                                                                                                                                   
                  
Application import had three reliability issues: system applications (Console, My Account, Carbon SP) were being processed during import when they should be skipped; inbound protocol identification relied on self URLs which are environment-specific and not stable across IS deployments; and when a new inbound protocol was added locally
   that didn't yet exist in the deployed application, injectDeployedReadOnlyFields threw an error instead of handling it gracefully.                                                
   
Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/55

  ## Goals                                                                                                                                                                     
                  
  - Prevent system applications from being modified during import
  - Make inbound protocol identification stable and environment-independent by using type identifiers instead of self URLs
  - Handle the case where a locally defined protocol does not exist in the deployed application without failing
                                                                                                                                                                            
  ## Approach        
                                                                                                                                                                            
  - Added a guard at the start of application import to detect and skip system applications (Console, My Account, Carbon SP), logging a message instead of attempting to process them
  - Replaced self URL-based protocol identification with a _type field that stores the protocol path type, making lookups consistent regardless of the server environment   
  - Updated processInboundProtocolForUpdate to extract the protocol type directly from _type instead of parsing it out of the self URL                                      
  - Added a nil-safety check in injectDeployedReadOnlyFields so missing protocol configs are handled gracefully rather than causing a failure                               
  - Updated cleanup logic to strip _type alongside self before POST/PUT requests so the field doesn't leak into API payloads 

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.