### PR TITLE
Add support for API resources resource type

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -28,6 +28,7 @@ import (
 	emailTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/emailTemplates"
 	governanceConnectors "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/governanceConnectors"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
+	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
@@ -63,6 +64,7 @@ var exportAllCmd = &cobra.Command{
 			utils.GOVERNANCE_CONNECTORS: governanceConnectors.ExportAll,
 			utils.CERTIFICATES:          certificates.ExportAll,
 			utils.WORKFLOWS:             workflows.ExportAll,
+			utils.API_RESOURCES:         apiResources.ExportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -28,6 +28,7 @@ import (
 	emailTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/emailTemplates"
 	governanceConnectors "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/governanceConnectors"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
+	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
@@ -62,6 +63,7 @@ var importAllCmd = &cobra.Command{
 			utils.GOVERNANCE_CONNECTORS: governanceConnectors.ImportAll,
 			utils.CERTIFICATES:          certificates.ImportAll,
 			utils.WORKFLOWS:             workflows.ImportAll,
+			utils.API_RESOURCES:         apiResources.ImportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/pkg/apiResources/apiResourceUtils.go
+++ b/iamctl/pkg/apiResources/apiResourceUtils.go
@@ -1,0 +1,190 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package apiResources
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+type apiScope struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type apiResource struct {
+	ID         string        `json:"id"`
+	Identifier string        `json:"identifier"`
+	Scopes     []interface{} `json:"scopes"`
+}
+
+type apiResourceListResponse struct {
+	APIResources []apiResource `json:"apiResources"`
+}
+
+var exportedScopesMap map[string]string
+
+func getApiResourceList() ([]apiResource, error) {
+
+	var listResponse apiResourceListResponse
+	resp, err := utils.SendGetListRequest(utils.API_RESOURCES, -1)
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving API resource list. %w", err)
+	}
+	defer resp.Body.Close()
+
+	statusCode := resp.StatusCode
+	if statusCode == 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error when reading the retrieved API resource list. %w", err)
+		}
+
+		err = json.Unmarshal(body, &listResponse)
+		if err != nil {
+			return nil, fmt.Errorf("error when unmarshalling the retrieved API resource list. %w", err)
+		}
+
+		return listResponse.APIResources, nil
+	} else if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
+		return nil, fmt.Errorf("error while retrieving API resource list. Status code: %d, Error: %s", statusCode, errMsg)
+	}
+	return nil, fmt.Errorf("error while retrieving API resource list")
+}
+
+func getDeployedApiResourceIdentifiers(resources []apiResource) []string {
+
+	var identifiers []string
+	for _, r := range resources {
+		identifiers = append(identifiers, r.Identifier)
+	}
+	return identifiers
+}
+
+func getApiResourceId(identifier string, list []apiResource) string {
+
+	for _, r := range list {
+		if r.Identifier == identifier {
+			return r.ID
+		}
+	}
+	return ""
+}
+
+func getApiResourceKeywordMapping(resourceIdentifer string) map[string]interface{} {
+
+	if utils.KEYWORD_CONFIGS.ApiResourceConfigs != nil {
+		return utils.ResolveAdvancedKeywordMapping(resourceIdentifer, utils.KEYWORD_CONFIGS.ApiResourceConfigs)
+	}
+	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func processScopes(resourceMap map[string]interface{}, resourceIdentifier string) error {
+
+	scopeList, ok := resourceMap["scopes"].([]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for scopes in API resource data")
+	}
+
+	for _, scopeRaw := range scopeList {
+		scopeEntry, ok := scopeRaw.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected format for scope in API resource data")
+		}
+		delete(scopeEntry, "id")
+
+		scopeName, ok := scopeEntry["name"].(string)
+		if !ok {
+			return fmt.Errorf("unexpected format for scope name")
+		}
+		exportedScopesMap[scopeName] = resourceIdentifier
+	}
+
+	return nil
+}
+
+func getApiResourceScopes(resourceId string) ([]apiScope, error) {
+
+	var scopes []apiScope
+	body, err := utils.SendGetRequest(utils.API_RESOURCES, resourceId+"/scopes")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(body, &scopes); err != nil {
+		return nil, fmt.Errorf("error unmarshalling scopes: %w", err)
+	}
+	return scopes, nil
+}
+
+func readLocalScopesMap(importDirPath string) (map[string]string, error) {
+
+	matches, err := filepath.Glob(filepath.Join(importDirPath, "ApiResourceScopes.*"))
+	if err != nil {
+		return nil, fmt.Errorf("error searching for file: %w", err)
+	}
+	if len(matches) == 0 {
+		return map[string]string{}, nil
+	}
+
+	fileBytes, err := ioutil.ReadFile(matches[0])
+	if err != nil {
+		return nil, fmt.Errorf("error reading file: %w", err)
+	}
+
+	format, err := utils.FormatFromExtension(filepath.Ext(matches[0]))
+	if err != nil {
+		return nil, fmt.Errorf("unsupported format for file: %w", err)
+	}
+	var scopeMap map[string]string
+	if _, err := utils.Deserialize(fileBytes, format, utils.API_RESOURCES, &scopeMap); err != nil {
+		return nil, fmt.Errorf("error deserializing file: %w", err)
+	}
+	return scopeMap, nil
+}
+
+func writeScopesMap(outputDirPath string, scopeMap map[string]string, formatString string) error {
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, utils.API_RESOURCE_SCOPES.String(), format)
+
+	data, err := utils.Serialize(scopeMap, format, utils.API_RESOURCES)
+	if err != nil {
+		return fmt.Errorf("error serializing scope name map: %w", err)
+	}
+	if err := ioutil.WriteFile(exportedFileName, data, 0644); err != nil {
+		return fmt.Errorf("error writing scope name map: %w", err)
+	}
+	return nil
+}
+
+func updateApiResourceExportSummary(success bool, successCount int) {
+
+	if !success {
+		utils.UpdateFailureSummary(utils.API_RESOURCES, utils.API_RESOURCE_SCOPES.String())
+		return
+	}
+	for i := 0; i < successCount; i++ {
+		utils.UpdateSuccessSummary(utils.API_RESOURCES, utils.EXPORT)
+	}
+}

--- a/iamctl/pkg/apiResources/apiResourceUtils.go
+++ b/iamctl/pkg/apiResources/apiResourceUtils.go
@@ -33,9 +33,8 @@ type apiScope struct {
 }
 
 type apiResource struct {
-	ID         string        `json:"id"`
-	Identifier string        `json:"identifier"`
-	Scopes     []interface{} `json:"scopes"`
+	ID         string `json:"id"`
+	Identifier string `json:"identifier"`
 }
 
 type apiResourceListResponse struct {
@@ -91,10 +90,10 @@ func getApiResourceId(identifier string, list []apiResource) string {
 	return ""
 }
 
-func getApiResourceKeywordMapping(resourceIdentifer string) map[string]interface{} {
+func getApiResourceKeywordMapping(resourceIdentifier string) map[string]interface{} {
 
 	if utils.KEYWORD_CONFIGS.ApiResourceConfigs != nil {
-		return utils.ResolveAdvancedKeywordMapping(resourceIdentifer, utils.KEYWORD_CONFIGS.ApiResourceConfigs)
+		return utils.ResolveAdvancedKeywordMapping(resourceIdentifier, utils.KEYWORD_CONFIGS.ApiResourceConfigs)
 	}
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }

--- a/iamctl/pkg/apiResources/apiResourceUtils.go
+++ b/iamctl/pkg/apiResources/apiResourceUtils.go
@@ -98,28 +98,28 @@ func getApiResourceKeywordMapping(resourceIdentifier string) map[string]interfac
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }
 
-func processScopes(resourceMap map[string]interface{}, resourceIdentifier string) error {
+func processScopes(resourceMap map[string]interface{}) (scopeNames []string, err error) {
 
 	scopeList, ok := resourceMap["scopes"].([]interface{})
 	if !ok {
-		return fmt.Errorf("unexpected format for scopes in API resource data")
+		return nil, fmt.Errorf("unexpected format for scopes in API resource data")
 	}
 
 	for _, scopeRaw := range scopeList {
 		scopeEntry, ok := scopeRaw.(map[string]interface{})
 		if !ok {
-			return fmt.Errorf("unexpected format for scope in API resource data")
+			return nil, fmt.Errorf("unexpected format for scope in API resource data")
 		}
 		delete(scopeEntry, "id")
 
 		scopeName, ok := scopeEntry["name"].(string)
 		if !ok {
-			return fmt.Errorf("unexpected format for scope name")
+			return nil, fmt.Errorf("unexpected format for scope name")
 		}
-		exportedScopesMap[scopeName] = resourceIdentifier
+		scopeNames = append(scopeNames, scopeName)
 	}
 
-	return nil
+	return scopeNames, nil
 }
 
 func getApiResourceScopes(resourceId string) ([]apiScope, error) {
@@ -143,7 +143,7 @@ func readLocalScopesMap(importDirPath string) (map[string]string, error) {
 		return nil, fmt.Errorf("error searching for file: %w", err)
 	}
 	if len(matches) == 0 {
-		return map[string]string{}, nil
+		return nil, fmt.Errorf("ApiResourceScopes file not found")
 	}
 
 	fileBytes, err := ioutil.ReadFile(matches[0])

--- a/iamctl/pkg/apiResources/export.go
+++ b/iamctl/pkg/apiResources/export.go
@@ -1,0 +1,112 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package apiResources
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ExportAll(exportFilePath string, format string) {
+
+	log.Println("Exporting API resources...")
+	exportFilePath = filepath.Join(exportFilePath, utils.API_RESOURCES.String())
+
+	if utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
+		return
+	}
+	resources, err := getApiResourceList()
+	if err != nil {
+		log.Println("Error: when retrieving API resource list.", err)
+		return
+	}
+
+	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
+		os.MkdirAll(exportFilePath, 0700)
+	} else {
+		if utils.TOOL_CONFIGS.AllowDelete {
+			deployedIdentifiers := getDeployedApiResourceIdentifiers(resources)
+			utils.RemoveDeletedLocalResources(exportFilePath, deployedIdentifiers)
+		}
+	}
+
+	exportedScopesMap = map[string]string{}
+	successCount := 0
+
+	for _, resource := range resources {
+		if !utils.IsResourceExcluded(resource.Identifier, utils.TOOL_CONFIGS.ApiResourceConfigs) {
+			log.Println("Exporting API resource:", resource.Identifier)
+			err := exportApiResource(resource.ID, resource.Identifier, exportFilePath, format)
+			if err != nil {
+				utils.UpdateFailureSummary(utils.API_RESOURCES, resource.Identifier)
+				log.Printf("Error while exporting API resource: %s. %s", resource.Identifier, err)
+			} else {
+				successCount++
+				log.Println("API resource exported successfully:", resource.Identifier)
+			}
+		}
+	}
+
+	err = writeScopesMap(exportFilePath, exportedScopesMap, format)
+	updateApiResourceExportSummary(err == nil, successCount)
+	if err != nil {
+		log.Println("Error writing scope name map:", err)
+	}
+}
+
+func exportApiResource(resourceId string, resourceIdentifier string, outputDirPath string, formatString string) error {
+
+	resourceData, err := utils.GetResourceData(utils.API_RESOURCES, resourceId)
+	if err != nil {
+		return fmt.Errorf("error while getting API resource: %w", err)
+	}
+	resourceMap, ok := resourceData.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for API resource data")
+	}
+
+	if err := processScopes(resourceMap, resourceIdentifier); err != nil {
+		return fmt.Errorf("error while processing scopes: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, resourceIdentifier, format)
+
+	keywordMapping := getApiResourceKeywordMapping(resourceIdentifier)
+	modifiedResource, err := utils.ProcessExportedData(resourceMap, exportedFileName, format, keywordMapping, utils.API_RESOURCES)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedResource, format, utils.API_RESOURCES)
+	if err != nil {
+		return fmt.Errorf("error while serializing API resource: %w", err)
+	}
+
+	if err := ioutil.WriteFile(exportedFileName, modifiedFile, 0644); err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/apiResources/export.go
+++ b/iamctl/pkg/apiResources/export.go
@@ -33,7 +33,7 @@ func ExportAll(exportFilePath string, format string) {
 	log.Println("Exporting API resources...")
 	exportFilePath = filepath.Join(exportFilePath, utils.API_RESOURCES.String())
 
-	if utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
+	if !utils.IsEntitySupportedInVersion(utils.API_RESOURCES) || utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
 		return
 	}
 	resources, err := getApiResourceList()

--- a/iamctl/pkg/apiResources/export.go
+++ b/iamctl/pkg/apiResources/export.go
@@ -86,7 +86,8 @@ func exportApiResource(resourceId string, resourceIdentifier string, outputDirPa
 		return fmt.Errorf("unexpected format for API resource data")
 	}
 
-	if err := processScopes(resourceMap, resourceIdentifier); err != nil {
+	scopeNames, err := processScopes(resourceMap)
+	if err != nil {
 		return fmt.Errorf("error while processing scopes: %w", err)
 	}
 
@@ -106,6 +107,10 @@ func exportApiResource(resourceId string, resourceIdentifier string, outputDirPa
 
 	if err := ioutil.WriteFile(exportedFileName, modifiedFile, 0644); err != nil {
 		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	for _, scopeName := range scopeNames {
+		exportedScopesMap[scopeName] = resourceIdentifier
 	}
 
 	return nil

--- a/iamctl/pkg/apiResources/import.go
+++ b/iamctl/pkg/apiResources/import.go
@@ -133,11 +133,16 @@ func updateApiResource(resourceId, resourceIdentifier string, requestBody []byte
 
 	log.Println("Updating API resource:", resourceIdentifier)
 
-	var resource apiResource
-	if _, err := utils.Deserialize(requestBody, format, utils.API_RESOURCES, &resource); err != nil {
+	dataMap, err := utils.DeserializeToMap(requestBody, format, utils.API_RESOURCES)
+	if err != nil {
 		return fmt.Errorf("error deserializing file: %w", err)
 	}
-	jsonBody, err := json.Marshal(resource.Scopes)
+	scopes, ok := dataMap["scopes"]
+	if !ok {
+		return fmt.Errorf("scopes array not found in API resource data")
+	}
+
+	jsonBody, err := json.Marshal(scopes)
 	if err != nil {
 		return fmt.Errorf("error serializing update scopes request body: %w", err)
 	}

--- a/iamctl/pkg/apiResources/import.go
+++ b/iamctl/pkg/apiResources/import.go
@@ -34,7 +34,7 @@ func ImportAll(inputDirPath string) {
 	log.Println("Importing API resources...")
 	importFilePath := filepath.Join(inputDirPath, utils.API_RESOURCES.String())
 
-	if utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
+	if !utils.IsEntitySupportedInVersion(utils.API_RESOURCES) || utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {

--- a/iamctl/pkg/apiResources/import.go
+++ b/iamctl/pkg/apiResources/import.go
@@ -1,0 +1,224 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package apiResources
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ImportAll(inputDirPath string) {
+
+	log.Println("Importing API resources...")
+	importFilePath := filepath.Join(inputDirPath, utils.API_RESOURCES.String())
+
+	if utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
+		return
+	}
+	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
+		log.Println("No API resources to import.")
+		return
+	}
+
+	deployedResources, err := getApiResourceList()
+	if err != nil {
+		log.Println("Error retrieving the deployed API resource list:", err)
+		return
+	}
+	files, err := ioutil.ReadDir(importFilePath)
+	if err != nil {
+		log.Println("Error importing API resources:", err)
+		return
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		deployedResources = removeDeletedDeployedApiResources(files, deployedResources)
+	}
+
+	localScopeMap, err := readLocalScopesMap(importFilePath)
+	if err != nil {
+		log.Println("Error reading local scope name map:", err)
+		utils.UpdateFailureSummary(utils.API_RESOURCES, utils.API_RESOURCE_SCOPES.String())
+		return
+	}
+	failedResources := removeDeletedDeployedScopes(localScopeMap, deployedResources)
+
+	for _, file := range files {
+		apiResFilePath := filepath.Join(importFilePath, file.Name())
+		fileInfo := utils.GetFileInfo(apiResFilePath)
+		resourceName := fileInfo.ResourceName
+
+		if resourceName == utils.API_RESOURCE_SCOPES.String() {
+			continue
+		}
+		if _, failed := failedResources[resourceName]; failed {
+			log.Printf("Skipping API resource %s: deleting stale scopes failed", resourceName)
+			utils.UpdateFailureSummary(utils.API_RESOURCES, resourceName)
+			continue
+		}
+		if !utils.IsResourceExcluded(resourceName, utils.TOOL_CONFIGS.ApiResourceConfigs) {
+			resourceId := getApiResourceId(resourceName, deployedResources)
+			if err := importApiResource(resourceId, resourceName, apiResFilePath); err != nil {
+				log.Println("Error importing API resource:", err)
+				utils.UpdateFailureSummary(utils.API_RESOURCES, resourceName)
+			}
+		}
+	}
+}
+
+func importApiResource(resourceId, resourceIdentifier, importFilePath string) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format for API resource: %w", err)
+	}
+
+	fileBytes, err := ioutil.ReadFile(importFilePath)
+	if err != nil {
+		return fmt.Errorf("error when reading the file for API resource: %w", err)
+	}
+
+	keywordMapping := getApiResourceKeywordMapping(resourceIdentifier)
+	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), keywordMapping)
+
+	if resourceId == "" {
+		return createApiResource(resourceIdentifier, []byte(modifiedFileData), format)
+	}
+	return updateApiResource(resourceId, resourceIdentifier, []byte(modifiedFileData), format)
+}
+
+func createApiResource(resourceIdentifier string, requestBody []byte, format utils.Format) error {
+
+	log.Println("Creating new API resource:", resourceIdentifier)
+
+	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.API_RESOURCES,
+		"id", "type", "properties", "authorizationDetailsTypes")
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPostRequest(utils.API_RESOURCES, jsonBody)
+	if err != nil {
+		return fmt.Errorf("error when creating API resource: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.API_RESOURCES, utils.IMPORT)
+	log.Println("API resource created successfully.")
+	return nil
+}
+
+func updateApiResource(resourceId, resourceIdentifier string, requestBody []byte, format utils.Format) error {
+
+	log.Println("Updating API resource:", resourceIdentifier)
+
+	var resource apiResource
+	if _, err := utils.Deserialize(requestBody, format, utils.API_RESOURCES, &resource); err != nil {
+		return fmt.Errorf("error deserializing file: %w", err)
+	}
+	jsonBody, err := json.Marshal(resource.Scopes)
+	if err != nil {
+		return fmt.Errorf("error serializing update scopes request body: %w", err)
+	}
+
+	resp, err := utils.SendPutRequest(utils.API_RESOURCES, resourceId+"/scopes", jsonBody)
+	if err != nil {
+		return fmt.Errorf("error when updating API resource scopes: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.API_RESOURCES, utils.UPDATE)
+	log.Println("API resource updated successfully.")
+	return nil
+}
+
+func removeDeletedDeployedApiResources(localFiles []os.FileInfo, deployedResources []apiResource) (remainingResources []apiResource) {
+
+	if len(deployedResources) == 0 {
+		return deployedResources
+	}
+
+	localResourceNames := make(map[string]struct{})
+	for _, file := range localFiles {
+		resourceName := utils.GetFileInfo(file.Name()).ResourceName
+		localResourceNames[resourceName] = struct{}{}
+	}
+
+	for _, resource := range deployedResources {
+		if _, existsLocally := localResourceNames[resource.Identifier]; existsLocally {
+			remainingResources = append(remainingResources, resource)
+			continue
+		}
+		if utils.IsResourceExcluded(resource.Identifier, utils.TOOL_CONFIGS.ApiResourceConfigs) {
+			log.Println("API resource is excluded from deletion:", resource.Identifier)
+			remainingResources = append(remainingResources, resource)
+			continue
+		}
+
+		log.Printf("API resource: %s not found locally. Deleting.\n", resource.Identifier)
+		if err := utils.SendDeleteRequest(resource.ID, utils.API_RESOURCES); err != nil {
+			utils.UpdateFailureSummary(utils.API_RESOURCES, resource.Identifier)
+			log.Println("Error deleting API resource:", resource.Identifier, err)
+			remainingResources = append(remainingResources, resource)
+		} else {
+			utils.UpdateSuccessSummary(utils.API_RESOURCES, utils.DELETE)
+		}
+	}
+	return remainingResources
+}
+
+func removeDeletedDeployedScopes(localScopeMap map[string]string, deployedResources []apiResource) (failedResources map[string]struct{}) {
+
+	failedResources = make(map[string]struct{})
+
+	for _, resource := range deployedResources {
+		scopes, err := getApiResourceScopes(resource.ID)
+		if err != nil {
+			log.Printf("Error retrieving scopes for API resource %s: %v", resource.Identifier, err)
+			failedResources[resource.Identifier] = struct{}{}
+			continue
+		}
+
+		for _, scope := range scopes {
+			localApiResName, scopeInLocalMap := localScopeMap[scope.Name]
+
+			shouldDelete := false
+			if !scopeInLocalMap && utils.TOOL_CONFIGS.AllowDelete {
+				shouldDelete = true
+			} else if scopeInLocalMap && localApiResName != resource.Identifier {
+				shouldDelete = true
+			}
+			if !shouldDelete {
+				continue
+			}
+
+			if err := utils.SendDeleteRequest(resource.ID+"/scopes/id/"+scope.ID, utils.API_RESOURCES); err != nil {
+				log.Printf("Error deleting scope %s from API resource %s: %v", scope.Name, resource.Identifier, err)
+				failedResources[resource.Identifier] = struct{}{}
+			}
+		}
+	}
+
+	return failedResources
+}

--- a/iamctl/pkg/apiResources/import.go
+++ b/iamctl/pkg/apiResources/import.go
@@ -198,6 +198,9 @@ func removeDeletedDeployedScopes(localScopeMap map[string]string, deployedResour
 	failedResources = make(map[string]struct{})
 
 	for _, resource := range deployedResources {
+		if utils.IsResourceExcluded(resource.Identifier, utils.TOOL_CONFIGS.ApiResourceConfigs) {
+			continue
+		}
 		scopes, err := getApiResourceScopes(resource.ID)
 		if err != nil {
 			log.Printf("Error retrieving scopes for API resource %s: %v", resource.Identifier, err)

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -469,7 +469,7 @@ func SendPutRequest(resourceType ResourceType, resourceId string, requestBody []
 		return nil, fmt.Errorf("error sending PUT request: %w", err)
 	}
 
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
 		resp.Body.Close()
 		if errMsg, ok := ErrorCodes[resp.StatusCode]; ok {
 			return nil, fmt.Errorf("error response for the PUT request: %s", errMsg)
@@ -519,6 +519,7 @@ func SendGetListRequest(resourceType ResourceType, resourceLimit int, opts ...Se
 
 	cfg := applySendOptions(opts)
 	var reqUrl = buildRequestUrl(LIST, resourceType, "")
+	reqUrl = addQueryParams(reqUrl, resourceType, LIST)
 	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	req, err := http.NewRequest("GET", reqUrl, bytes.NewBuffer(nil))
@@ -573,6 +574,8 @@ func getResourcePath(resourceType ResourceType) string {
 		return "workflows"
 	case WORKFLOW_ASSOCIATIONS:
 		return "workflow-associations"
+	case API_RESOURCES:
+		return "api-resources"
 	}
 	return ""
 }
@@ -646,6 +649,10 @@ func addQueryParams(reqURL string, resourceType ResourceType, operation string) 
 	case CERTIFICATES:
 		if operation == GET {
 			queryParams.Set("encode-cert", "true")
+		}
+	case API_RESOURCES:
+		if operation == LIST {
+			queryParams.Set("filter", "type eq BUSINESS")
 		}
 	}
 

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -31,6 +31,7 @@ const SCRIPT_LIBRARIES_CONFIG = "SCRIPT_LIBRARIES"
 const GOVERNANCE_CONNECTORS_CONFIG = "GOVERNANCE_CONNECTORS"
 const CERTIFICATES_CONFIG = "CERTIFICATES"
 const WORKFLOWS_CONFIG = "WORKFLOWS"
+const API_RESOURCES_CONFIG = "API_RESOURCES"
 
 // Tool configs
 const EXCLUDE_CONFIG = "EXCLUDE"
@@ -69,10 +70,12 @@ const (
 	GOVERNANCE_CONNECTORS ResourceType = "GovernanceConnectors"
 	CERTIFICATES          ResourceType = "Certificates"
 	WORKFLOWS             ResourceType = "Workflows"
+	API_RESOURCES         ResourceType = "ApiResources"
 )
 
 // Sub resource types
 const WORKFLOW_ASSOCIATIONS ResourceType = "WorkflowAssociations"
+const API_RESOURCE_SCOPES ResourceType = "ApiResourceScopes"
 
 // Config file names
 const SERVER_CONFIG_FILE = "serverConfig.json"
@@ -195,6 +198,13 @@ var workflowArrayIdentifiers = map[string]string{
 	"steps":        "step",
 	"options":      "entity",
 	"associations": "id",
+}
+
+var apiResourceArrayIdentifiers = map[string]string{
+
+	"scopes":                    "name",
+	"properties":                "name",
+	"authorizationDetailsTypes": "type",
 }
 
 type ResourceIdentifierMeta struct {

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -41,7 +41,8 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_functional_lib_view internal_functional_lib_create internal_functional_lib_update internal_functional_lib_delete " +
 	"internal_keystore_view internal_keystore_update internal_keystore_create internal_keystore_delete " +
 	"internal_workflow_view internal_workflow_create internal_workflow_update internal_workflow_delete " +
-	"internal_workflow_association_view internal_workflow_association_create internal_workflow_association_update internal_workflow_association_delete"
+	"internal_workflow_association_view internal_workflow_association_create internal_workflow_association_update internal_workflow_association_delete " +
+	"internal_api_resource_view internal_api_resource_create internal_api_resource_update internal_api_resource_delete"
 
 const (
 	AppName       = "IAM-CTL"

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -190,6 +190,8 @@ func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 		return challengeQuestionsArrayIdentifiers
 	case WORKFLOWS:
 		return workflowArrayIdentifiers
+	case API_RESOURCES:
+		return apiResourceArrayIdentifiers
 	default:
 		return make(map[string]string)
 	}

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -37,4 +37,5 @@ var ResourceOrder = []ResourceType{
 	GOVERNANCE_CONNECTORS,
 	CERTIFICATES,
 	WORKFLOWS, // Dependency: Roles
+	API_RESOURCES,
 }

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -66,6 +66,7 @@ type ToolConfigs struct {
 	GovernanceConnectorConfigs map[string]interface{} `json:"GOVERNANCE_CONNECTORS"`
 	CertificateConfigs         map[string]interface{} `json:"CERTIFICATES"`
 	WorkflowConfigs            map[string]interface{} `json:"WORKFLOWS"`
+	ApiResourceConfigs         map[string]interface{} `json:"API_RESOURCES"`
 }
 
 type KeywordConfigs struct {
@@ -82,6 +83,7 @@ type KeywordConfigs struct {
 	GovernanceConnectorConfigs map[string]interface{} `json:"GOVERNANCE_CONNECTORS"`
 	CertificateConfigs         map[string]interface{} `json:"CERTIFICATES"`
 	WorkflowConfigs            map[string]interface{} `json:"WORKFLOWS"`
+	ApiResourceConfigs         map[string]interface{} `json:"API_RESOURCES"`
 }
 
 var SERVER_CONFIGS ServerConfigs

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -21,11 +21,13 @@ package utils
 // Minimum WSO2 Identity Server version requirements for each resource type.
 // If a resource type is not present in this map, there is no minimum version requirement.
 const (
-	MIN_VERSION_WORKFLOWS = "7.2.0"
+	MIN_VERSION_WORKFLOWS     = "7.2.0"
+	MIN_VERSION_API_RESOURCES = "7.0.0"
 )
 
 var EntityMinVersionRequirements = map[ResourceType]string{
-	WORKFLOWS: MIN_VERSION_WORKFLOWS,
+	WORKFLOWS:     MIN_VERSION_WORKFLOWS,
+	API_RESOURCES: MIN_VERSION_API_RESOURCES,
 }
 
 // Maximum supported WSO2 Identity Server version for each resource type.


### PR DESCRIPTION
## Purpose

  Add export/import support for the API Resources resource type, including API Resource Scopes as a dependent sub-resource. Introduces scope ownership tracking across resources and handles scope-level lifecycle operations required to safely reconcile scope assignments between environments.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/66

  ## Goals

  - Export and import business API resources via the IS API resource management REST APIs
  - Track scope-to-resource ownership in a dedicated `ApiResourceScopes.*` file to drive stale and moved scope cleanup on import
  - Detect and delete scopes that have moved between API resources before import to prevent name-conflict failures on update
  - Filter exported resources to `BUSINESS` type only, excluding system-managed API resources
  - Fetch per-resource scopes via a dedicated endpoint on import since the list API does not return full scope data
  - Accept `204 No Content` as a success response for scope update calls alongside `200 OK`
  - Defer export success summary until after the scope map file is successfully written

  ## Approach

  ### Two resource types: API_RESOURCES and API_RESOURCE_SCOPES

  API Resources introduce two resource types: `API_RESOURCES` as the primary resource and `API_RESOURCE_SCOPES` as a sub-resource. A separate flat `ApiResourceScopes.*` file records a `scopeName → apiResourceIdentifier` mapping, used purely as an ownership manifest on import. Failures on scope map write are surfaced under `API_RESOURCES` in the summary.

  ### Scope ownership tracking for moved scopes

  Scopes are uniquely named across the server. A scope can only belong to one API resource at a time. When a scope moves from one API resource to another between environments, the import must delete it from the old owner before the update call on the new owner, otherwise the PUT fails with a name conflict.

  `removeDeletedDeployedScopes` handles this by comparing each deployed scope against the local `ApiResourceScopes.*` map:

  - Scope not in local map + `AllowDelete` enabled → delete (removed entirely)
  - Scope in local map but mapped to a different resource → always delete from current owner regardless of `AllowDelete`, since this is a move not a deletion

  The second case is intentionally not gated on `AllowDelete` because without it the subsequent update call will fail with a server-side conflict error.

  ### Scope fetch via dedicated endpoint

  The list API does not return full scope data for each resource. During import, `getApiResourceScopes` fetches scopes per resource to get the current deployed scope list with IDs needed for targeted deletion. This means scope cleanup always makes N calls; unavoidable since moved-scope detection must run in all cases.

  ### Deleted resource list pruned before scope cleanup

  `removeDeletedDeployedApiResources` now returns the surviving resource list (resources that were not successfully deleted). This pruned list is passed to `removeDeletedDeployedScopes` so that scope deletion is never attempted against already-deleted resources, avoiding spurious 404 failures that would otherwise block the import of remaining resources.

  ### Filtering to BUSINESS type only

  The IS API resource list endpoint returns both system-managed and user-defined resources. A static `filter=type eq BUSINESS` query parameter is wired into `addQueryParams` for the `LIST` operation on `API_RESOURCES`, keeping system resources out of export entirely without requiring per-resource exclusion rules.

  ### Scopes-only update path

In existing API resource update only the related scopes are updated. The scopes array is extracted from the deserialized file and marshalled to JSON. The scopes endpoint returns `204 No Content` on success; `SendPutRequest` was updated to accept both `200` and `204` across all resource types. 

  ## User Stories

  As a system administrator, I want to export and import API resource definitions using IAM-CTL to enable version control and maintain consistent IAM configurations.

  ## Release Note

  Added API Resource management support to IAM-CTL tool.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API resources export functionality to the `exportAll` command, including associated scopes.
  * Added API resources import functionality to the `importAll` command with scope management.
  * API resources now included in the ordered resource processing workflow.

* **Chores**
  * Updated minimum version requirement to 7.0.0 for API resources support.
  * Extended configuration structures to support API resources.
  * Added necessary scopes for API resource operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/69)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->