### PR TITLE
Add support for Validation rules resource type

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -30,6 +30,7 @@ import (
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
+	validationRules "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/validationRules"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
 	userstores "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/userStores"
@@ -65,6 +66,7 @@ var exportAllCmd = &cobra.Command{
 			utils.CERTIFICATES:          certificates.ExportAll,
 			utils.WORKFLOWS:             workflows.ExportAll,
 			utils.API_RESOURCES:         apiResources.ExportAll,
+			utils.VALIDATION_RULES:      validationRules.ExportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -30,6 +30,7 @@ import (
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
+	validationRules "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/validationRules"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
 	userstores "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/userStores"
@@ -64,6 +65,7 @@ var importAllCmd = &cobra.Command{
 			utils.CERTIFICATES:          certificates.ImportAll,
 			utils.WORKFLOWS:             workflows.ImportAll,
 			utils.API_RESOURCES:         apiResources.ImportAll,
+			utils.VALIDATION_RULES:      validationRules.ImportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -576,6 +576,8 @@ func getResourcePath(resourceType ResourceType) string {
 		return "workflow-associations"
 	case API_RESOURCES:
 		return "api-resources"
+	case VALIDATION_RULES:
+		return "validation-rules"
 	}
 	return ""
 }

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -32,6 +32,7 @@ const GOVERNANCE_CONNECTORS_CONFIG = "GOVERNANCE_CONNECTORS"
 const CERTIFICATES_CONFIG = "CERTIFICATES"
 const WORKFLOWS_CONFIG = "WORKFLOWS"
 const API_RESOURCES_CONFIG = "API_RESOURCES"
+const VALIDATION_RULES_CONFIG = "VALIDATION_RULES"
 
 // Tool configs
 const EXCLUDE_CONFIG = "EXCLUDE"
@@ -71,6 +72,7 @@ const (
 	CERTIFICATES          ResourceType = "Certificates"
 	WORKFLOWS             ResourceType = "Workflows"
 	API_RESOURCES         ResourceType = "ApiResources"
+	VALIDATION_RULES      ResourceType = "ValidationRules"
 )
 
 // Sub resource types
@@ -205,6 +207,13 @@ var apiResourceArrayIdentifiers = map[string]string{
 	"scopes":                    "name",
 	"properties":                "name",
 	"authorizationDetailsTypes": "type",
+}
+
+var validationRuleArrayIdentifiers = map[string]string{
+
+	"ValidationRules": "field",
+	"rules":           "validator",
+	"properties":      "key",
 }
 
 type ResourceIdentifierMeta struct {

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -42,7 +42,8 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_keystore_view internal_keystore_update internal_keystore_create internal_keystore_delete " +
 	"internal_workflow_view internal_workflow_create internal_workflow_update internal_workflow_delete " +
 	"internal_workflow_association_view internal_workflow_association_create internal_workflow_association_update internal_workflow_association_delete " +
-	"internal_api_resource_view internal_api_resource_create internal_api_resource_update internal_api_resource_delete"
+	"internal_api_resource_view internal_api_resource_create internal_api_resource_update internal_api_resource_delete " +
+	"internal_validation_rule_mgt_update"
 
 const (
 	AppName       = "IAM-CTL"

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -151,7 +151,13 @@ func GetKeywordLocations(fileData interface{}, path []string, keywordMapping map
 				break
 			} else {
 				arrayIdentifiers := GetArrayIdentifiers(resourceType)
-				arrayElementPath, err := resolvePathWithIdentifiers(path[len(path)-1], val, arrayIdentifiers)
+				var arrayName string
+				if len(path) > 0 {
+					arrayName = path[len(path)-1]
+				} else {
+					arrayName = resourceType.String()
+				}
+				arrayElementPath, err := resolvePathWithIdentifiers(arrayName, val, arrayIdentifiers)
 				if err != nil {
 					log.Printf("Error: cannot resolve path for the field %s. %s.\n", strings.Join(path, "."), err)
 					break
@@ -192,6 +198,8 @@ func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 		return workflowArrayIdentifiers
 	case API_RESOURCES:
 		return apiResourceArrayIdentifiers
+	case VALIDATION_RULES:
+		return validationRuleArrayIdentifiers
 	default:
 		return make(map[string]string)
 	}

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -38,4 +38,5 @@ var ResourceOrder = []ResourceType{
 	CERTIFICATES,
 	WORKFLOWS, // Dependency: Roles
 	API_RESOURCES,
+	VALIDATION_RULES,
 }

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -67,6 +67,7 @@ type ToolConfigs struct {
 	CertificateConfigs         map[string]interface{} `json:"CERTIFICATES"`
 	WorkflowConfigs            map[string]interface{} `json:"WORKFLOWS"`
 	ApiResourceConfigs         map[string]interface{} `json:"API_RESOURCES"`
+	ValidationRuleConfigs      map[string]interface{} `json:"VALIDATION_RULES"`
 }
 
 type KeywordConfigs struct {
@@ -84,6 +85,7 @@ type KeywordConfigs struct {
 	CertificateConfigs         map[string]interface{} `json:"CERTIFICATES"`
 	WorkflowConfigs            map[string]interface{} `json:"WORKFLOWS"`
 	ApiResourceConfigs         map[string]interface{} `json:"API_RESOURCES"`
+	ValidationRuleConfigs      map[string]interface{} `json:"VALIDATION_RULES"`
 }
 
 var SERVER_CONFIGS ServerConfigs

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -21,13 +21,15 @@ package utils
 // Minimum WSO2 Identity Server version requirements for each resource type.
 // If a resource type is not present in this map, there is no minimum version requirement.
 const (
-	MIN_VERSION_WORKFLOWS     = "7.2.0"
-	MIN_VERSION_API_RESOURCES = "7.0.0"
+	MIN_VERSION_WORKFLOWS        = "7.2.0"
+	MIN_VERSION_API_RESOURCES    = "7.0.0"
+	MIN_VERSION_VALIDATION_RULES = "7.0.0"
 )
 
 var EntityMinVersionRequirements = map[ResourceType]string{
-	WORKFLOWS:     MIN_VERSION_WORKFLOWS,
-	API_RESOURCES: MIN_VERSION_API_RESOURCES,
+	WORKFLOWS:        MIN_VERSION_WORKFLOWS,
+	API_RESOURCES:    MIN_VERSION_API_RESOURCES,
+	VALIDATION_RULES: MIN_VERSION_VALIDATION_RULES,
 }
 
 // Maximum supported WSO2 Identity Server version for each resource type.

--- a/iamctl/pkg/validationRules/export.go
+++ b/iamctl/pkg/validationRules/export.go
@@ -33,7 +33,7 @@ func ExportAll(exportFilePath string, format string) {
 	log.Println("Exporting validation rules...")
 	exportFilePath = filepath.Join(exportFilePath, utils.VALIDATION_RULES.String())
 
-	if utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
+	if !utils.IsEntitySupportedInVersion(utils.VALIDATION_RULES) || utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {

--- a/iamctl/pkg/validationRules/export.go
+++ b/iamctl/pkg/validationRules/export.go
@@ -1,0 +1,79 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package validationRules
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ExportAll(exportFilePath string, format string) {
+
+	log.Println("Exporting validation rules...")
+	exportFilePath = filepath.Join(exportFilePath, utils.VALIDATION_RULES.String())
+
+	if utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
+		return
+	}
+	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
+		os.MkdirAll(exportFilePath, 0700)
+	}
+
+	err := exportValidationRules(exportFilePath, format)
+	if err != nil {
+		utils.UpdateFailureSummary(utils.VALIDATION_RULES, resourceFileName)
+		log.Printf("Error while exporting validation rules: %s", err)
+	} else {
+		utils.UpdateSuccessSummary(utils.VALIDATION_RULES, utils.EXPORT)
+		log.Println("Validation rules exported successfully.")
+	}
+}
+
+func exportValidationRules(outputDirPath string, formatString string) error {
+
+	rules, err := utils.GetResourceData(utils.VALIDATION_RULES, "")
+	if err != nil {
+		return fmt.Errorf("error while getting validation rules: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, resourceFileName, format)
+
+	keywordMapping := getValidationRuleKeywordMapping()
+	modifiedRules, err := utils.ProcessExportedData(rules, exportedFileName, format, keywordMapping, utils.VALIDATION_RULES)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedRules, format, utils.VALIDATION_RULES)
+	if err != nil {
+		return fmt.Errorf("error while serializing validation rules: %w", err)
+	}
+
+	err = os.WriteFile(exportedFileName, modifiedFile, 0644)
+	if err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/validationRules/export.go
+++ b/iamctl/pkg/validationRules/export.go
@@ -20,6 +20,7 @@ package validationRules
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -70,7 +71,7 @@ func exportValidationRules(outputDirPath string, formatString string) error {
 		return fmt.Errorf("error while serializing validation rules: %w", err)
 	}
 
-	err = os.WriteFile(exportedFileName, modifiedFile, 0644)
+	err = ioutil.WriteFile(exportedFileName, modifiedFile, 0644)
 	if err != nil {
 		return fmt.Errorf("error when writing exported content to file: %w", err)
 	}

--- a/iamctl/pkg/validationRules/import.go
+++ b/iamctl/pkg/validationRules/import.go
@@ -1,0 +1,89 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package validationRules
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ImportAll(inputDirPath string) {
+
+	log.Println("Importing validation rules...")
+	importFilePath := filepath.Join(inputDirPath, utils.VALIDATION_RULES.String())
+
+	if utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
+		return
+	}
+	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
+		log.Println("No validation rules to import.")
+		return
+	}
+	filePath, err := getValidationRulesFilePath(importFilePath)
+
+	if err == nil {
+		err = importValidationRules(filePath)
+	}
+	if err != nil {
+		utils.UpdateFailureSummary(utils.VALIDATION_RULES, resourceFileName)
+		log.Println("Error importing validation rules:", err)
+	}
+}
+
+func importValidationRules(filePath string) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(filePath))
+	if err != nil {
+		return fmt.Errorf("unsupported format for validation rules file: %w", err)
+	}
+	fileBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("error reading validation rules file: %w", err)
+	}
+
+	keywordMapping := getValidationRuleKeywordMapping()
+	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), keywordMapping)
+
+	return updateValidationRules([]byte(modifiedFileData), format)
+}
+
+func updateValidationRules(requestBody []byte, format utils.Format) error {
+
+	log.Println("Updating validation rules.")
+
+	jsonBody, err := prepareValidationRulesRequestBody(requestBody, format)
+	if err != nil {
+		return fmt.Errorf("error preparing update request body: %w", err)
+	}
+
+	resp, err := utils.SendPutRequest(utils.VALIDATION_RULES, "", jsonBody)
+	if err != nil {
+		return fmt.Errorf("error when updating validation rules: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.VALIDATION_RULES, utils.UPDATE)
+	log.Println("Validation rules updated successfully.")
+	return nil
+}

--- a/iamctl/pkg/validationRules/import.go
+++ b/iamctl/pkg/validationRules/import.go
@@ -33,7 +33,7 @@ func ImportAll(inputDirPath string) {
 	log.Println("Importing validation rules...")
 	importFilePath := filepath.Join(inputDirPath, utils.VALIDATION_RULES.String())
 
-	if utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
+	if !utils.IsEntitySupportedInVersion(utils.VALIDATION_RULES) || utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {

--- a/iamctl/pkg/validationRules/validationRuleUtils.go
+++ b/iamctl/pkg/validationRules/validationRuleUtils.go
@@ -1,0 +1,63 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package validationRules
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+const resourceFileName = "validationRules"
+
+func getValidationRuleKeywordMapping() map[string]interface{} {
+
+	if utils.KEYWORD_CONFIGS.ValidationRuleConfigs != nil {
+		return utils.ResolveAdvancedKeywordMapping(resourceFileName, utils.KEYWORD_CONFIGS.ValidationRuleConfigs)
+	}
+	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func getValidationRulesFilePath(importDirPath string) (string, error) {
+
+	matches, err := filepath.Glob(filepath.Join(importDirPath, resourceFileName+".*"))
+	if err != nil {
+		return "", fmt.Errorf("error searching for validation rules file: %w", err)
+	}
+	if len(matches) == 0 {
+		return "", fmt.Errorf("validation rules file not found in %s", importDirPath)
+	}
+	return matches[0], nil
+}
+
+func prepareValidationRulesRequestBody(data []byte, format utils.Format) ([]byte, error) {
+
+	parsed, err := utils.Deserialize(data, format, utils.VALIDATION_RULES)
+	if err != nil {
+		return nil, fmt.Errorf("error deserializing file: %w", err)
+	}
+	parsed = utils.ConvertToStringKeyMap(parsed)
+
+	jsonBody, err := utils.Serialize(parsed, utils.FormatJSON, utils.VALIDATION_RULES)
+	if err != nil {
+		return nil, fmt.Errorf("error serializing to JSON: %w", err)
+	}
+	return jsonBody, nil
+}


### PR DESCRIPTION
  ## Purpose
            
  Add export/import support for the Validation Rules resource type. This resource exposes a single GET/PUT endpoint that manages the full ruleset as one document, which required a different approach compared to individually addressable resources.  Also adds missing scopes for Governance Connectors.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/69                                                                                                                                                                    
                                         
  ## Goals
          
  - Export validation rules via to a single `validationRules.*` file
  - Import by reading that file and issuing an update request with the full ruleset 
  - Support keyword replacement and format selection (YAML/JSON) consistent with other resource types    
  - Add missing scopes required for Governance Connector export/import 
                                                                                                     
  ## Approach
             
  ### Singleton resource model
                              
  Validation rules are not individually addressable. The API exposes the entire ruleset as one document. Rather than iterating resources, export writes a single fixed-name file (`validationRules.*`) and import reads it back with a single PUT. `filepath.Glob` is used to locate the file regardless of extension, erroring out if it is absent.                                                                
                                                                                                                                           
  ### Custom JSON serialization for array body
                                              
  The PUT body is a JSON array, not an object. The shared `PrepareJSONRequestBody` utility assumes a map at the top level and would fail here. A dedicated `prepareValidationRulesRequestBody` function deserializes the file, runs `ConvertToStringKeyMap` to normalize YAML's `map[interface{}]interface{}` types, then serializes to JSON, keeping the same steps without the map-type assumption.       
                                                                                                                                                                                                
  ### Fix for top-level array in keyword traversal
                                                  
  `GetKeywordLocations` accessed `path[len(path)-1]` unconditionally when resolving array element identifiers, which panics when called on a top-level array with an empty path. The fix guards the access and falls back to `resourceType.String()` as the array name, allowing the identifier lookup to work correctly for root-level arrays. `validationRuleArrayIdentifiers` uses `"ValidationRules"` as the root key mapping to `"field"`, with `"rules"` → `"validator"` and `"properties"` → `"key"` for nested arrays.                                                                                                      
         
  ## User Stories
 
  As a system administrator, I want to export and import validation rule configurations using IAM-CTL to enable version control and maintain consistent IAM configurations.
                                                                                                                                                                                                     
  ## Release Note                                           
                                                                                                                                                                                                               
 Added Validation Rules management support to IAM-CTL tool.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Validation rules can now be exported and imported through the CLI.
  * Validation rules are fully integrated into resource export/import workflows.
  * Validation rules support requires version 7.0.0 or later.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/70)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->