### PR TITLE
Fix Oauth credential handling and role reference handling in application export/import

### DIFF
--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -213,6 +213,44 @@ func removeAssociatedRoles(fileContent []byte) []byte {
 	return []byte(result)
 }
 
+func injectDeployedOAuthCredentials(appId, fileData string, format utils.Format) (string, error) {
+
+	oidcConfig, err := getDeployedInboundProtocolConfig(appId, "oidc")
+	if err != nil {
+		return fileData, err
+	}
+	if oidcConfig == nil {
+		return fileData, nil
+	}
+	clientSecret, ok := oidcConfig["clientSecret"].(string)
+	if !ok {
+		return fileData, fmt.Errorf("clientSecret not found in deployed oidc config")
+	}
+	clientId, ok := oidcConfig["clientId"].(string)
+	if !ok {
+		return fileData, fmt.Errorf("clientId not found in deployed oidc config")
+	}
+	result := fileData
+
+	switch format {
+	case utils.FormatYAML:
+		re := regexp.MustCompile(`(?m)(^\s*oauthConsumerSecret:\s*)[^\n]*$`)
+		result = re.ReplaceAllString(result, "${1}"+clientSecret)
+		re = regexp.MustCompile(`(?m)(^\s*oauthConsumerKey:\s*)[^\n]*$`)
+		result = re.ReplaceAllString(result, "${1}"+clientId)
+		re = regexp.MustCompile(`(?m)(^\s*inboundAuthKey:\s*)[^\n]*$`)
+		result = re.ReplaceAllString(result, "${1}"+clientId)
+	case utils.FormatJSON:
+		re := regexp.MustCompile(`("oauthConsumerSecret":\s*)(?:null|"[^"]*")`)
+		result = re.ReplaceAllString(result, `${1}"`+clientSecret+`"`)
+		re = regexp.MustCompile(`("oauthConsumerKey":\s*)"[^"]*"`)
+		result = re.ReplaceAllString(result, `${1}"`+clientId+`"`)
+		re = regexp.MustCompile(`("inboundAuthKey":\s*)"[^"]*"`)
+		result = re.ReplaceAllString(result, `${1}"`+clientId+`"`)
+	}
+	return result, nil
+}
+
 func isToolMgtApp(appId string) (bool, error) {
 
 	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols/oidc")
@@ -405,18 +443,30 @@ func processInboundProtocolForUpdate(appId string, protocolMap map[string]interf
 	return protocolPath, nil
 }
 
-func injectDeployedReadOnlyFields(appId, protocolPath string, localConfig map[string]interface{}) error {
+func getDeployedInboundProtocolConfig(appId, protocolPath string) (map[string]interface{}, error) {
 
 	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols/"+protocolPath)
 	if err != nil {
 		if strings.Contains(err.Error(), "Resource not found") {
-			return nil
+			return nil, nil
 		}
-		return fmt.Errorf("error retrieving deployed %s config: %w", protocolPath, err)
+		return nil, fmt.Errorf("error retrieving deployed %s config: %w", protocolPath, err)
 	}
 	var deployedConfig map[string]interface{}
 	if err := json.Unmarshal(body, &deployedConfig); err != nil {
-		return fmt.Errorf("error unmarshalling deployed %s config: %w", protocolPath, err)
+		return nil, fmt.Errorf("error unmarshalling deployed %s config: %w", protocolPath, err)
+	}
+	return deployedConfig, nil
+}
+
+func injectDeployedReadOnlyFields(appId, protocolPath string, localConfig map[string]interface{}) error {
+
+	deployedConfig, err := getDeployedInboundProtocolConfig(appId, protocolPath)
+	if err != nil {
+		return err
+	}
+	if deployedConfig == nil {
+		return nil
 	}
 
 	switch protocolPath {

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -201,6 +201,17 @@ func maskOAuthConsumerSecret(fileContent []byte) []byte {
 	return []byte(maskedContent)
 }
 
+func removeAssociatedRoles(fileContent []byte) []byte {
+
+	yamlPattern := regexp.MustCompile(`(?m)(^\s+roles:)[^\n]*\n(\s+-[^\n]*\n)*`)
+	result := yamlPattern.ReplaceAllString(string(fileContent), "${1} []\n")
+
+	jsonPattern := regexp.MustCompile(`("roles"\s*:\s*)\[(?:\s*\{[^}]*\}\s*,?\s*)*\]`)
+	result = jsonPattern.ReplaceAllString(result, `${1}[]`)
+
+	return []byte(result)
+}
+
 func isToolMgtApp(appId string) (bool, error) {
 
 	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols/oidc")

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -253,24 +253,19 @@ func injectDeployedOAuthCredentials(appId, fileData string, format utils.Format)
 
 func isToolMgtApp(appId string) (bool, error) {
 
-	body, err := utils.SendGetRequest(utils.APPLICATIONS, appId+"/inbound-protocols/oidc")
+	oidcConfig, err := getDeployedInboundProtocolConfig(appId, "oidc")
 	if err != nil {
-		// 404 means no OIDC config — not the tool management app
-		if strings.Contains(err.Error(), "Resource not found") {
-			return false, nil
-		}
 		return false, err
 	}
-	var oidcConfig map[string]interface{}
-	if err := json.Unmarshal(body, &oidcConfig); err != nil {
-		return false, fmt.Errorf("error unmarshalling OIDC config: %w", err)
+	if oidcConfig == nil {
+		return false, nil
 	}
 
-	clientId, _ := oidcConfig["clientId"].(string)
-	if clientId == utils.SERVER_CONFIGS.ClientId {
-		return true, nil
+	clientId, ok := oidcConfig["clientId"].(string)
+	if !ok {
+		return false, fmt.Errorf("clientId not found in deployed oidc config")
 	}
-	return false, nil
+	return clientId == utils.SERVER_CONFIGS.ClientId, nil
 }
 
 func isOauthSecretGiven(modifiedFileData string, format utils.Format) (bool, error) {

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -30,7 +30,6 @@ import (
 	"text/tabwriter"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
-	"gopkg.in/yaml.v3"
 )
 
 type inboundProtocolRef struct {
@@ -63,13 +62,13 @@ var unsupportedInboundProtocols = map[string]struct{}{
 type AuthConfig struct {
 	InboundAuthenticationConfig struct {
 		InboundAuthenticationRequestConfigs []struct {
-			InboundAuthType              string `yaml:"inboundAuthType"`
-			InboundAuthKey               string `yaml:"inboundAuthKey"`
+			InboundAuthType              string `yaml:"inboundAuthType" json:"inboundAuthType"`
+			InboundAuthKey               string `yaml:"inboundAuthKey" json:"inboundAuthKey"`
 			InboundConfigurationProtocol struct {
-				OauthConsumerSecret string `yaml:"oauthConsumerSecret"`
-			} `yaml:"inboundConfigurationProtocol"`
-		} `yaml:"inboundAuthenticationRequestConfigs"`
-	} `yaml:"inboundAuthenticationConfig"`
+				OauthConsumerSecret string `yaml:"oauthConsumerSecret" json:"oauthConsumerSecret"`
+			} `yaml:"inboundConfigurationProtocol" json:"inboundConfigurationProtocol"`
+		} `yaml:"inboundAuthenticationRequestConfigs" json:"inboundAuthenticationRequestConfigs"`
+	} `yaml:"inboundAuthenticationConfig" json:"inboundAuthenticationConfig"`
 }
 
 func getDeployedAppNames() []string {
@@ -167,9 +166,9 @@ func getAppId(appName string, appList []Application) string {
 	return ""
 }
 
-func isOauthApp(fileData string) (bool, error) {
+func isOauthApp(fileData string, format utils.Format) (bool, error) {
 
-	config, err := unmarshalAuthConfig([]byte(fileData))
+	config, err := unmarshalAuthConfig([]byte(fileData), format)
 	if err != nil {
 		return false, err
 	}
@@ -182,10 +181,10 @@ func isOauthApp(fileData string) (bool, error) {
 	return false, nil
 }
 
-func unmarshalAuthConfig(data []byte) (AuthConfig, error) {
+func unmarshalAuthConfig(data []byte, format utils.Format) (AuthConfig, error) {
 
 	var config AuthConfig
-	if err := yaml.Unmarshal(data, &config); err != nil {
+	if _, err := utils.Deserialize(data, format, utils.APPLICATIONS, &config); err != nil {
 		return AuthConfig{}, fmt.Errorf("failed to unmarshal auth config: %s", err.Error())
 	}
 	return config, nil
@@ -236,9 +235,9 @@ func isToolMgtApp(appId string) (bool, error) {
 	return false, nil
 }
 
-func isOauthSecretGiven(modifiedFileData string) (bool, error) {
+func isOauthSecretGiven(modifiedFileData string, format utils.Format) (bool, error) {
 
-	config, err := unmarshalAuthConfig([]byte(modifiedFileData))
+	config, err := unmarshalAuthConfig([]byte(modifiedFileData), format)
 	if err != nil {
 		return false, fmt.Errorf(err.Error())
 	}

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -194,9 +194,11 @@ func unmarshalAuthConfig(data []byte) (AuthConfig, error) {
 func maskOAuthConsumerSecret(fileContent []byte) []byte {
 
 	// Find and replace the value of oauthConsumerSecret with a mask.
-	pattern := "(?m)(^\\s*oauthConsumerSecret:\\s*)null\\s*$"
-	re := regexp.MustCompile(pattern)
-	maskedContent := re.ReplaceAllString(string(fileContent), "${1}"+utils.SENSITIVE_FIELD_MASK)
+	yamlPattern := regexp.MustCompile(`(?m)(^\s*oauthConsumerSecret:\s*)null\s*$`)
+	maskedContent := yamlPattern.ReplaceAllString(string(fileContent), "${1}"+utils.SENSITIVE_FIELD_MASK)
+
+	jsonPattern := regexp.MustCompile(`("oauthConsumerSecret":\s*)null`)
+	maskedContent = jsonPattern.ReplaceAllString(maskedContent, `${1}"`+utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES+`"`)
 
 	return []byte(maskedContent)
 }

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -79,6 +79,10 @@ func ExportAll(exportFilePath string, format string) {
 			log.Println("Resident application exported successfully.")
 		}
 	}
+
+	if utils.IsResourceTypeExcluded(utils.ROLES) && exportAPIExists {
+		log.Println("Warn: Roles are excluded from export. Export Roles to persist Role audiences of applications.")
+	}
 }
 
 func exportApp(appId string, outputDirPath string, format string, excludeSecrets bool) error {

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -68,6 +68,10 @@ func ImportAll(inputDirPath string) {
 			}
 		}
 	}
+
+	if utils.IsResourceTypeExcluded(utils.ROLES) && exportAPIExists {
+		log.Println("Warn: Roles are excluded from import. Import Roles to persist Role audiences of applications.")
+	}
 }
 
 func importApp(appId, appName, importFilePath string, exportAPIExists bool) error {
@@ -87,6 +91,7 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 	modifiedFileData := utils.RemoveSecretMasks(fileDataWithReplacedKeywords)
 
 	if exportAPIExists && appName != utils.RESIDENT_APP {
+		modifiedFileData = string(removeAssociatedRoles([]byte(modifiedFileData)))
 		if appId == "" {
 			return importApplication(appName, importFilePath, modifiedFileData)
 		}

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -90,18 +90,19 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 	fileDataWithReplacedKeywords := utils.ReplaceKeywords(string(fileBytes), appKeywordMapping)
 	modifiedFileData := utils.RemoveSecretMasks(fileDataWithReplacedKeywords)
 
-	if exportAPIExists && appName != utils.RESIDENT_APP {
-		modifiedFileData = string(removeAssociatedRoles([]byte(modifiedFileData)))
-		if appId == "" {
-			return importApplication(appName, importFilePath, modifiedFileData)
-		}
-		return updateApplication(appId, appName, importFilePath, modifiedFileData)
-	}
-
 	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
 	if err != nil {
 		return fmt.Errorf("unsupported file format for application: %w", err)
 	}
+
+	if exportAPIExists && appName != utils.RESIDENT_APP {
+		modifiedFileData = string(removeAssociatedRoles([]byte(modifiedFileData)))
+		if appId == "" {
+			return importApplication(appName, importFilePath, modifiedFileData, format)
+		}
+		return updateApplication(appId, appName, importFilePath, modifiedFileData)
+	}
+
 	appMap, err := utils.DeserializeToMap([]byte(modifiedFileData), format, utils.APPLICATIONS)
 	if err != nil {
 		return fmt.Errorf("error deserializing application: %w", err)
@@ -118,7 +119,7 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 	return updateAppWithCRUD(appId, appName, appMap)
 }
 
-func importApplication(appName, importFilePath, modifiedFileData string) error {
+func importApplication(appName, importFilePath, modifiedFileData string, format utils.Format) error {
 
 	log.Println("Creating new application: " + appName)
 	resp, err := utils.SendImportRequest(importFilePath, modifiedFileData, utils.APPLICATIONS)
@@ -127,9 +128,9 @@ func importApplication(appName, importFilePath, modifiedFileData string) error {
 	}
 	defer resp.Body.Close()
 
-	if oauthApp, err := isOauthApp(modifiedFileData); err != nil {
+	if oauthApp, err := isOauthApp(modifiedFileData, format); err != nil {
 		fmt.Println("Failed to check if the applications is an OAuth app:", err.Error())
-	} else if oauthSecretGiven, err := isOauthSecretGiven(modifiedFileData); err != nil {
+	} else if oauthSecretGiven, err := isOauthSecretGiven(modifiedFileData, format); err != nil {
 		fmt.Println("Failed to check if oauthConsumerSecret is given:", err.Error())
 	} else if oauthApp && !oauthSecretGiven {
 		// Check if oauthConsumerSecret is given or else add an indicator to the summary informing a new secret is generated.

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -100,7 +100,7 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 		if appId == "" {
 			return importApplication(appName, importFilePath, modifiedFileData, format)
 		}
-		return updateApplication(appId, appName, importFilePath, modifiedFileData)
+		return updateApplication(appId, appName, importFilePath, modifiedFileData, format)
 	}
 
 	appMap, err := utils.DeserializeToMap([]byte(modifiedFileData), format, utils.APPLICATIONS)
@@ -149,10 +149,15 @@ func importApplication(appName, importFilePath, modifiedFileData string, format 
 	return nil
 }
 
-func updateApplication(appId, appName, importFilePath, modifiedFileData string) error {
+func updateApplication(appId, appName, importFilePath, modifiedFileData string, format utils.Format) error {
 
 	log.Println("Updating application: " + appName)
-	err := utils.SendUpdateRequest(appId, importFilePath, modifiedFileData, utils.APPLICATIONS)
+	fileData, err := injectDeployedOAuthCredentials(appId, modifiedFileData, format)
+	if err != nil {
+		return fmt.Errorf("error injecting deployed OAuth credentials: %w", err)
+	}
+
+	err = utils.SendUpdateRequest(appId, importFilePath, fileData, utils.APPLICATIONS)
 	if err != nil {
 		return fmt.Errorf("error when updating application: %s", err)
 	}

--- a/iamctl/pkg/utils/resourceReferenceUtils.go
+++ b/iamctl/pkg/utils/resourceReferenceUtils.go
@@ -32,7 +32,7 @@ func ExtractAndRegisterIdentifier(resourceType ResourceType, resourceData interf
 
 	resourceMeta, exists := RESOURCE_IDENTIFIER_METADATA[resourceType]
 	if !exists {
-		log.Println("Warning: No identifier metadata found for resource type. Skipping resource identifier map entry.")
+		log.Println("Warn: No identifier metadata found for resource type. Skipping resource identifier map entry.")
 		return
 	}
 
@@ -40,7 +40,7 @@ func ExtractAndRegisterIdentifier(resourceType ResourceType, resourceData interf
 	uniqueValue := GetValue(resourceData, resourceMeta.UniqueValuePath)
 
 	if idValue == "" || uniqueValue == "" {
-		log.Println("Warning: Could not extract identifier or unique value. Skipping resource identifier map entry.")
+		log.Println("Warn: Could not extract identifier or unique value. Skipping resource identifier map entry.")
 		return
 	}
 


### PR DESCRIPTION
## Purpose

  The Application export/import pipeline had several correctness gaps specific to how IS serializes and validates application configuration:

  - `maskOAuthConsumerSecret` only handled YAML. The IS export API returns compact JSON, so the original YAML-only regex with a line-end anchor `\s*$` never matched JSON output, leaving `oauthConsumerSecret` unmasked in JSON exports.
  - `AuthConfig` struct had only `yaml:` struct tags. When an application file in JSON format was processed, `unmarshalAuthConfig` always used `yaml.Unmarshal`, causing silent deserialization failure and incorrect new-secret detection for JSON files.
  - On update, the local file contains either a secret mask (`********`) or a stale secret value from the source environment. Sending either value to the target environment causes the server to reject the update, as OIDC credentials are environment-specific and read-only from the server's perspective.
  - `roles` embedded in the application body carry environment-specific UUIDs. Sending these on import overwrites the role audience assignments in the target, causing cross-environment data corruption.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Fixes: https://github.com/wso2/product-is/issues/27647
Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/68

  ## Goals

  - Mask `oauthConsumerSecret` correctly in both YAML and JSON exported files
  - Fix OAuth app detection and new-secret indicator logic to work correctly with JSON files
  - Inject deployed OIDC credentials (`clientSecret`, `clientId`) from the target environment before sending update requests, replacing any stale or masked values in the local file
  - Strip `roles` from the application body before import, as role audience linking is managed separately by the Roles resource
  - Warn when Roles are excluded from export/import while using the export API, since role audiences won't be created

  ## Approach

  - **JSON masking**: Extended `maskOAuthConsumerSecret` with a second regex pattern for JSON (`"oauthConsumerSecret": null → "oauthConsumerSecret": "********"`). The JSON pattern has no line-end anchor since compact JSON places the next field immediately after the value.
  - **Format-aware deserialization**: Added `json:` struct tags to `AuthConfig` and changed `unmarshalAuthConfig` to accept an explicit `utils.Format` parameter, delegating to `utils.Deserialize`. Format is detected once from the file extension at the top of `importApp` and propagated to `importApplication`, `updateApplication`, `isOauthApp`, and `isOauthSecretGiven`.
  - **Credential injection on update**: Added `injectDeployedOAuthCredentials(appId, fileData, format)` which fetches the deployed OIDC config via a new shared helper `getDeployedInboundProtocolConfig`, then overwrites `oauthConsumerSecret`, `oauthConsumerKey`, and `inboundAuthKey` in the local file before the update request.
  Format-specific regex patterns handle both YAML (multiline, `[^\n]*` to match any existing value) and compact JSON (`(?:null|"[^"]*")` to match null or any quoted string).
  - **Extracted helper**: `getDeployedInboundProtocolConfig(appId, protocolPath)` is extracted as a shared helper returning `(map[string]interface{}, error)`, used by `injectDeployedOAuthCredentials`, `injectDeployedReadOnlyFields`, and `isToolMgtApp`. Returns `nil, nil` on 404 to let callers skip gracefully.
  - **Role stripping**: Added `removeAssociatedRoles` which clears the `roles` array in the application body using format-specific regex patterns before the import/update call. This prevents the import from overwriting role audience assignments managed by the Roles resource.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced support for parsing and handling auth configuration in both YAML and JSON formats.
  * Added automatic injection of deployed OAuth credentials during application updates.

* **Bug Fixes**
  * Improved credential masking to work correctly across both YAML and JSON format types.
  * Added warnings when roles are excluded from import/export operations with API exports.

* **Chores**
  * Updated log message formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/72)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->