### PR TITLE
Add support for Email providers and Sms provider resource types

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -21,6 +21,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
+	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
 	certificates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/certificates"
 	challengeQuestions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/challengeQuestions"
@@ -28,13 +29,13 @@ import (
 	emailTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/emailTemplates"
 	governanceConnectors "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/governanceConnectors"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
-	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
+	notificationProviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationProviders"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
-	validationRules "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/validationRules"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
 	userstores "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/userStores"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+	validationRules "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/validationRules"
 	workflows "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/workflows"
 )
 
@@ -67,6 +68,8 @@ var exportAllCmd = &cobra.Command{
 			utils.WORKFLOWS:             workflows.ExportAll,
 			utils.API_RESOURCES:         apiResources.ExportAll,
 			utils.VALIDATION_RULES:      validationRules.ExportAll,
+			utils.EMAIL_PROVIDERS:       notificationProviders.ExportAllEmailProviders,
+			utils.SMS_PROVIDERS:         notificationProviders.ExportAllSmsProviders,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -21,6 +21,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
+	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
 	certificates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/certificates"
 	challengeQuestions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/challengeQuestions"
@@ -28,13 +29,13 @@ import (
 	emailTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/emailTemplates"
 	governanceConnectors "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/governanceConnectors"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
-	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
+	notificationProviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationProviders"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
-	validationRules "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/validationRules"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
 	userstores "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/userStores"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+	validationRules "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/validationRules"
 	workflows "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/workflows"
 )
 
@@ -66,6 +67,8 @@ var importAllCmd = &cobra.Command{
 			utils.WORKFLOWS:             workflows.ImportAll,
 			utils.API_RESOURCES:         apiResources.ImportAll,
 			utils.VALIDATION_RULES:      validationRules.ImportAll,
+			utils.EMAIL_PROVIDERS:       notificationProviders.ImportAllEmailProviders,
+			utils.SMS_PROVIDERS:         notificationProviders.ImportAllSmsProviders,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/pkg/notificationProviders/emailProvider.go
+++ b/iamctl/pkg/notificationProviders/emailProvider.go
@@ -1,0 +1,31 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package notificationProviders
+
+import "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+
+func ExportAllEmailProviders(exportFilePath, format string) {
+
+	exportAll(utils.EMAIL_PROVIDERS, exportFilePath, format)
+}
+
+func ImportAllEmailProviders(inputDirPath string) {
+
+	importAll(utils.EMAIL_PROVIDERS, inputDirPath)
+}

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -52,6 +52,17 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 		}
 	}
 
+	var secretExclusionDisabled bool
+	switch resType {
+	case utils.EMAIL_PROVIDERS:
+		secretExclusionDisabled = !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.EmailProviderConfigs)
+	case utils.SMS_PROVIDERS:
+		secretExclusionDisabled = !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.SmsProviderConfigs)
+	}
+	if secretExclusionDisabled {
+		log.Printf("Warn: Secrets exclusion cannot be disabled for %s. All secrets will be masked.", logName)
+	}
+
 	for _, provider := range providers {
 		if !utils.IsResourceExcluded(provider.Name, getProviderResourceConfig(resType)) {
 			log.Printf("Exporting %s: %s", logName, provider.Name)
@@ -73,6 +84,11 @@ func exportProvider(resType utils.ResourceType, logName string, name string, out
 	data, err := utils.GetResourceData(resType, name)
 	if err != nil {
 		return fmt.Errorf("error while getting %s: %w", logName, err)
+	}
+
+	data, err = processAuthSecrets(resType, data)
+	if err != nil {
+		return fmt.Errorf("error while processing auth secrets: %w", err)
 	}
 
 	format := utils.FormatFromString(formatString)

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -1,0 +1,98 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package notificationProviders
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func exportAll(resType utils.ResourceType, exportFilePath string, format string) {
+
+	logName := getProviderLogName(resType)
+	log.Printf("Exporting %s...", logName)
+	exportFilePath = filepath.Join(exportFilePath, resType.String())
+
+	if !utils.IsEntitySupportedInVersion(resType) || utils.IsResourceTypeExcluded(resType) {
+		return
+	}
+
+	providers, err := getProviderList(resType)
+	if err != nil {
+		log.Printf("Error while retrieving the %s list: %s", logName, err)
+		return
+	}
+
+	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
+		os.MkdirAll(exportFilePath, 0700)
+	} else {
+		if utils.TOOL_CONFIGS.AllowDelete {
+			utils.RemoveDeletedLocalResources(exportFilePath, getDeployedProviderNames(providers))
+		}
+	}
+
+	for _, provider := range providers {
+		if !utils.IsResourceExcluded(provider.Name, getProviderResourceConfig(resType)) {
+			log.Printf("Exporting %s: %s", logName, provider.Name)
+
+			err := exportProvider(resType, logName, provider.Name, exportFilePath, format)
+			if err != nil {
+				utils.UpdateFailureSummary(resType, provider.Name)
+				log.Printf("Error while exporting %s: %s. %s", logName, provider.Name, err)
+			} else {
+				utils.UpdateSuccessSummary(resType, utils.EXPORT)
+				log.Printf("%s exported successfully: %s", logName, provider.Name)
+			}
+		}
+	}
+}
+
+func exportProvider(resType utils.ResourceType, logName string, name string, outputDirPath string, formatString string) error {
+
+	data, err := utils.GetResourceData(resType, name)
+	if err != nil {
+		return fmt.Errorf("error while getting %s: %w", logName, err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, name, format)
+
+	keywordMapping := getProviderKeywordMapping(resType, name)
+	modifiedData, err := utils.ProcessExportedData(data, exportedFileName, format, keywordMapping, resType)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedData, format, resType)
+	if err != nil {
+		return fmt.Errorf("error while serializing %s: %w", logName, err)
+	}
+
+	err = ioutil.WriteFile(exportedFileName, modifiedFile, 0644)
+	if err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -55,17 +55,6 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 		}
 	}
 
-	var secretExclusionDisabled bool
-	switch resType {
-	case utils.EMAIL_PROVIDERS:
-		secretExclusionDisabled = !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.EmailProviderConfigs)
-	case utils.SMS_PROVIDERS:
-		secretExclusionDisabled = !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.SmsProviderConfigs)
-	}
-	if secretExclusionDisabled {
-		log.Printf("Warn: Secrets exclusion cannot be disabled for %s. All secrets will be masked.", logName)
-	}
-
 	for _, provider := range providers {
 		if !utils.IsResourceExcluded(provider.Name, getProviderResourceConfig(resType)) {
 			log.Printf("Exporting %s: %s", logName, provider.Name)

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -36,6 +36,7 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 
 	if resType == utils.EMAIL_PROVIDERS && utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
 		log.Println("Exporting email providers for super tenant not supported.")
+		return
 	}
 	if !utils.IsEntitySupportedInVersion(resType) || utils.IsResourceTypeExcluded(resType) {
 		return

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -34,6 +34,9 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 	log.Printf("Exporting %s...", logName)
 	exportFilePath = filepath.Join(exportFilePath, resType.String())
 
+	if resType == utils.EMAIL_PROVIDERS && utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
+		log.Println("Exporting email providers for super tenant not supported.")
+	}
 	if !utils.IsEntitySupportedInVersion(resType) || utils.IsResourceTypeExcluded(resType) {
 		return
 	}

--- a/iamctl/pkg/notificationProviders/import.go
+++ b/iamctl/pkg/notificationProviders/import.go
@@ -1,0 +1,166 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package notificationProviders
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func importAll(resType utils.ResourceType, inputDirPath string) {
+
+	logName := getProviderLogName(resType)
+	log.Printf("Importing %s...", logName)
+	importFilePath := filepath.Join(inputDirPath, resType.String())
+
+	if !utils.IsEntitySupportedInVersion(resType) || utils.IsResourceTypeExcluded(resType) {
+		return
+	}
+	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
+		log.Printf("No %s to import.", logName)
+		return
+	}
+
+	existingProviderList, err := getProviderList(resType)
+	if err != nil {
+		log.Printf("Error retrieving the deployed %s list: %s", logName, err)
+		return
+	}
+	files, err := ioutil.ReadDir(importFilePath)
+	if err != nil {
+		log.Printf("Error importing %s: %s", logName, err)
+		return
+	}
+
+	if utils.TOOL_CONFIGS.AllowDelete {
+		removeDeletedDeployedProviders(resType, files, existingProviderList, logName)
+	}
+
+	for _, file := range files {
+		providerFilePath := filepath.Join(importFilePath, file.Name())
+		fileInfo := utils.GetFileInfo(providerFilePath)
+		providerName := fileInfo.ResourceName
+
+		if !utils.IsResourceExcluded(providerName, getProviderResourceConfig(resType)) {
+			providerExists := isProviderExists(providerName, existingProviderList)
+			err := importProvider(resType, logName, providerName, providerExists, providerFilePath)
+			if err != nil {
+				log.Printf("Error importing %s: %s", logName, err)
+				utils.UpdateFailureSummary(resType, providerName)
+			}
+		}
+	}
+}
+
+func importProvider(resType utils.ResourceType, logName string, name string, exists bool, importFilePath string) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format for %s: %w", logName, err)
+	}
+
+	fileBytes, err := ioutil.ReadFile(importFilePath)
+	if err != nil {
+		return fmt.Errorf("error when reading the file for %s: %w", logName, err)
+	}
+
+	keywordMapping := getProviderKeywordMapping(resType, name)
+	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), keywordMapping)
+
+	if !exists {
+		return createProvider(resType, []byte(modifiedFileData), format, name, logName)
+	}
+	return updateProvider(resType, name, []byte(modifiedFileData), format, logName)
+}
+
+func createProvider(resType utils.ResourceType, requestBody []byte, format utils.Format, name string, logName string) error {
+
+	log.Printf("Creating new %s: %s", logName, name)
+
+	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, resType)
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPostRequest(resType, jsonBody)
+	if err != nil {
+		return fmt.Errorf("error when creating %s: %w", logName, err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(resType, utils.IMPORT)
+	log.Printf("%s created successfully: %s", logName, name)
+	return nil
+}
+
+func updateProvider(resType utils.ResourceType, name string, requestBody []byte, format utils.Format, logName string) error {
+
+	log.Printf("Updating %s: %s", logName, name)
+
+	updateBody, err := utils.PrepareJSONRequestBody(requestBody, format, resType, "name")
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPutRequest(resType, name, updateBody)
+	if err != nil {
+		return fmt.Errorf("error when updating %s: %w", logName, err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(resType, utils.UPDATE)
+	log.Printf("%s updated successfully: %s", logName, name)
+	return nil
+}
+
+func removeDeletedDeployedProviders(resType utils.ResourceType, localFiles []os.FileInfo, deployedProviders []notificationProvider, logName string) {
+
+	if len(deployedProviders) == 0 {
+		return
+	}
+
+	localResourceNames := make(map[string]struct{})
+	for _, file := range localFiles {
+		resourceName := utils.GetFileInfo(file.Name()).ResourceName
+		localResourceNames[resourceName] = struct{}{}
+	}
+
+	for _, provider := range deployedProviders {
+		if _, existsLocally := localResourceNames[provider.Name]; existsLocally {
+			continue
+		}
+		if utils.IsResourceExcluded(provider.Name, getProviderResourceConfig(resType)) {
+			log.Printf("%s is excluded from deletion: %s", logName, provider.Name)
+			continue
+		}
+
+		log.Printf("%s: %s not found locally. Deleting.\n", logName, provider.Name)
+		if err := utils.SendDeleteRequest(provider.Name, resType); err != nil {
+			utils.UpdateFailureSummary(resType, provider.Name)
+			log.Printf("Error deleting %s: %s. %s", logName, provider.Name, err)
+		} else {
+			utils.UpdateSuccessSummary(resType, utils.DELETE)
+		}
+	}
+}

--- a/iamctl/pkg/notificationProviders/import.go
+++ b/iamctl/pkg/notificationProviders/import.go
@@ -36,6 +36,7 @@ func importAll(resType utils.ResourceType, inputDirPath string) {
 
 	if resType == utils.EMAIL_PROVIDERS && utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
 		log.Println("Importing email providers for super tenant not supported.")
+		return
 	}
 	if !utils.IsEntitySupportedInVersion(resType) || utils.IsResourceTypeExcluded(resType) {
 		return

--- a/iamctl/pkg/notificationProviders/import.go
+++ b/iamctl/pkg/notificationProviders/import.go
@@ -34,6 +34,9 @@ func importAll(resType utils.ResourceType, inputDirPath string) {
 	log.Printf("Importing %s...", logName)
 	importFilePath := filepath.Join(inputDirPath, resType.String())
 
+	if resType == utils.EMAIL_PROVIDERS && utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
+		log.Println("Importing email providers for super tenant not supported.")
+	}
 	if !utils.IsEntitySupportedInVersion(resType) || utils.IsResourceTypeExcluded(resType) {
 		return
 	}

--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -116,3 +116,112 @@ func isProviderExists(name string, exisitingProviderList []notificationProvider)
 	}
 	return false
 }
+
+func processAuthSecrets(resType utils.ResourceType, data interface{}) (interface{}, error) {
+
+	providerMap, ok := data.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected format for provider data")
+	}
+	provider, ok := providerMap["provider"].(string)
+	if !ok {
+		return nil, fmt.Errorf("unexpected format for provider")
+	}
+
+	if provider != "Custom" && resType == utils.SMS_PROVIDERS {
+		delete(providerMap, "authentication")
+		return providerMap, nil
+	}
+
+	var authType string
+	var authentication map[string]interface{}
+	var properties interface{}
+
+	switch resType {
+	case utils.EMAIL_PROVIDERS:
+		authType, ok = providerMap["authType"].(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected format for authType")
+		}
+		emailProps, ok := providerMap["properties"].([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected format for properties")
+		}
+		properties = emailProps
+
+	case utils.SMS_PROVIDERS:
+		authentication, ok = providerMap["authentication"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected format for authentication")
+		}
+		authType, ok = authentication["type"].(string)
+		if !ok {
+			return nil, fmt.Errorf("unexpected format for authentication type")
+		}
+		smsProps, ok := authentication["properties"].(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected format for authentication properties")
+		}
+		properties = smsProps
+	}
+
+	maskedProps, err := maskAuthSecrets(resType, authType, properties)
+	if err != nil {
+		return nil, fmt.Errorf("error masking auth secrets: %w", err)
+	}
+
+	switch resType {
+	case utils.EMAIL_PROVIDERS:
+		providerMap["properties"] = maskedProps
+	case utils.SMS_PROVIDERS:
+		authentication["properties"] = maskedProps
+	}
+
+	return providerMap, nil
+}
+
+func maskAuthSecrets(resType utils.ResourceType, authType string, properties interface{}) (interface{}, error) {
+
+	switch authType {
+	case "NONE":
+		return properties, nil
+	case "BASIC":
+		return addSecretWithMask(resType, properties, "password")
+	case "CLIENT_CREDENTIAL":
+		return addSecretWithMask(resType, properties, "clientSecret")
+	case "BEARER":
+		return addSecretWithMask(resType, properties, "accessToken")
+	case "API_KEY":
+		switch resType {
+		case utils.SMS_PROVIDERS:
+			return addSecretWithMask(resType, properties, "value")
+		case utils.EMAIL_PROVIDERS:
+			return addSecretWithMask(resType, properties, "apiKeyValue")
+		}
+	}
+	return properties, nil
+}
+
+func addSecretWithMask(resType utils.ResourceType, properties interface{}, key string) (interface{}, error) {
+
+	switch resType {
+	case utils.EMAIL_PROVIDERS:
+		emailProps, ok := properties.([]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected format for email provider properties")
+		}
+		return append(emailProps, map[string]interface{}{
+			"key":   key,
+			"value": utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES,
+		}), nil
+
+	case utils.SMS_PROVIDERS:
+		smsProps, ok := properties.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("unexpected format for SMS provider properties")
+		}
+		smsProps[key] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+		return smsProps, nil
+	}
+	return properties, nil
+}

--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -22,6 +22,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"log"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -128,17 +129,16 @@ func processAuthSecrets(resType utils.ResourceType, data interface{}) (interface
 		return nil, fmt.Errorf("unexpected format for provider")
 	}
 
-	if provider != "Custom" && resType == utils.SMS_PROVIDERS {
-		delete(providerMap, "authentication")
-		return providerMap, nil
-	}
-
 	var authType string
 	var authentication map[string]interface{}
 	var properties interface{}
 
 	switch resType {
 	case utils.EMAIL_PROVIDERS:
+		if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.EmailProviderConfigs) {
+			log.Printf("Warn: Secrets exclusion cannot be disabled for Email Providers. All secrets will be masked.")
+		}
+
 		authType, ok = providerMap["authType"].(string)
 		if !ok {
 			return nil, fmt.Errorf("unexpected format for authType")
@@ -150,6 +150,19 @@ func processAuthSecrets(resType utils.ResourceType, data interface{}) (interface
 		properties = emailProps
 
 	case utils.SMS_PROVIDERS:
+		if provider != "Custom" {
+			delete(providerMap, "authentication")
+			if utils.AreSecretsExcluded(utils.TOOL_CONFIGS.SmsProviderConfigs) {
+				providerMap["secret"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+			}
+			return providerMap, nil
+		}
+
+		if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.SmsProviderConfigs) {
+			log.Printf("Warn: Secrets exclusion cannot be disabled for Custom SMS Providers. All secrets will be masked.")
+		}
+		delete(providerMap, "secret")
+
 		authentication, ok = providerMap["authentication"].(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("unexpected format for authentication")

--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -1,0 +1,118 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package notificationProviders
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+type notificationProvider struct {
+	Name string `json:"name"`
+}
+
+func getProviderResourceConfig(resType utils.ResourceType) map[string]interface{} {
+
+	switch resType {
+	case utils.EMAIL_PROVIDERS:
+		return utils.TOOL_CONFIGS.EmailProviderConfigs
+	case utils.SMS_PROVIDERS:
+		return utils.TOOL_CONFIGS.SmsProviderConfigs
+	}
+	return nil
+}
+
+func getProviderKeywordConfig(resType utils.ResourceType) map[string]interface{} {
+
+	switch resType {
+	case utils.EMAIL_PROVIDERS:
+		return utils.KEYWORD_CONFIGS.EmailProviderConfigs
+	case utils.SMS_PROVIDERS:
+		return utils.KEYWORD_CONFIGS.SmsProviderConfigs
+	}
+	return nil
+}
+
+func getProviderLogName(resType utils.ResourceType) string {
+
+	switch resType {
+	case utils.EMAIL_PROVIDERS:
+		return "Email Providers"
+	case utils.SMS_PROVIDERS:
+		return "SMS Providers"
+	}
+	return string(resType)
+}
+
+func getProviderList(resType utils.ResourceType) ([]notificationProvider, error) {
+
+	var list []notificationProvider
+	resp, err := utils.SendGetListRequest(resType, -1)
+	if err != nil {
+		return nil, fmt.Errorf("error while getting the list: %w", err)
+	}
+	defer resp.Body.Close()
+
+	statusCode := resp.StatusCode
+	if statusCode == 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error when reading the list: %w", err)
+		}
+		err = json.Unmarshal(body, &list)
+		if err != nil {
+			return nil, fmt.Errorf("error when unmarshalling the list: %w", err)
+		}
+		return list, nil
+	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
+		return nil, fmt.Errorf("Status code: %d, Error: %s", statusCode, error)
+	}
+	return nil, fmt.Errorf("unknown error while getting the list")
+}
+
+func getDeployedProviderNames(providers []notificationProvider) []string {
+
+	var names []string
+	for _, provider := range providers {
+		names = append(names, provider.Name)
+	}
+	return names
+}
+
+func getProviderKeywordMapping(resType utils.ResourceType, name string) map[string]interface{} {
+
+	kwConfig := getProviderKeywordConfig(resType)
+	if kwConfig != nil {
+		return utils.ResolveAdvancedKeywordMapping(name, kwConfig)
+	}
+	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func isProviderExists(name string, exisitingProviderList []notificationProvider) bool {
+
+	for _, provider := range exisitingProviderList {
+		if provider.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -57,9 +57,9 @@ func getProviderLogName(resType utils.ResourceType) string {
 
 	switch resType {
 	case utils.EMAIL_PROVIDERS:
-		return "Email Providers"
+		return "email providers"
 	case utils.SMS_PROVIDERS:
-		return "SMS Providers"
+		return "sms providers"
 	}
 	return string(resType)
 }

--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -212,7 +212,7 @@ func maskAuthSecrets(resType utils.ResourceType, authType string, properties int
 			return addSecretWithMask(resType, properties, "apiKeyValue")
 		}
 	}
-	return properties, nil
+	return nil, fmt.Errorf("unknown authentication type %s", authType)
 }
 
 func addSecretWithMask(resType utils.ResourceType, properties interface{}, key string) (interface{}, error) {

--- a/iamctl/pkg/notificationProviders/smsProvider.go
+++ b/iamctl/pkg/notificationProviders/smsProvider.go
@@ -1,0 +1,31 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package notificationProviders
+
+import "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+
+func ExportAllSmsProviders(exportFilePath, format string) {
+
+	exportAll(utils.SMS_PROVIDERS, exportFilePath, format)
+}
+
+func ImportAllSmsProviders(inputDirPath string) {
+
+	importAll(utils.SMS_PROVIDERS, inputDirPath)
+}

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -596,13 +596,17 @@ func getResourceBaseUrl(resourceType ResourceType) string {
 	if IsSubOrganization() {
 		basePath += "/o"
 	}
-	if resourceType == ROLES {
+
+	switch resourceType {
+	case ROLES:
 		if RolesV2ApiExists {
 			basePath += "/scim2/v2/Roles/"
 		} else {
 			basePath += "/scim2/Roles/"
 		}
-	} else {
+	case EMAIL_PROVIDERS, SMS_PROVIDERS:
+		basePath += "/api/server/v2/" + getResourcePath(resourceType) + "/"
+	default:
 		basePath += "/api/server/v1/" + getResourcePath(resourceType) + "/"
 	}
 	return SERVER_CONFIGS.ServerUrl + basePath

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -582,6 +582,10 @@ func getResourcePath(resourceType ResourceType) string {
 		return "validation-rules"
 	case ORGANIZATIONS:
 		return "organizations"
+	case EMAIL_PROVIDERS:
+		return "notification-senders/email"
+	case SMS_PROVIDERS:
+		return "notification-senders/sms"
 	}
 	return ""
 }

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -33,6 +33,8 @@ const CERTIFICATES_CONFIG = "CERTIFICATES"
 const WORKFLOWS_CONFIG = "WORKFLOWS"
 const API_RESOURCES_CONFIG = "API_RESOURCES"
 const VALIDATION_RULES_CONFIG = "VALIDATION_RULES"
+const EMAIL_PROVIDERS_CONFIG = "EMAIL_PROVIDERS"
+const SMS_PROVIDERS_CONFIG = "SMS_PROVIDERS"
 
 // Tool configs
 const EXCLUDE_CONFIG = "EXCLUDE"
@@ -74,6 +76,8 @@ const (
 	API_RESOURCES         ResourceType = "ApiResources"
 	VALIDATION_RULES      ResourceType = "ValidationRules"
 	ORGANIZATIONS         ResourceType = "Organizations"
+	EMAIL_PROVIDERS       ResourceType = "EmailProviders"
+	SMS_PROVIDERS         ResourceType = "SmsProviders"
 )
 
 // Sub resource types
@@ -230,6 +234,11 @@ var validationRuleArrayIdentifiers = map[string]string{
 	"ValidationRules": "field",
 	"rules":           "validator",
 	"properties":      "key",
+}
+
+var notificationProviderArrayIdentifiers = map[string]string{
+
+	"properties": "key",
 }
 
 type ResourceIdentifierMeta struct {

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -238,7 +238,9 @@ var validationRuleArrayIdentifiers = map[string]string{
 
 var notificationProviderArrayIdentifiers = map[string]string{
 
-	"properties": "key",
+	"properties":     "key",
+	"EmailProviders": "name",
+	"SmsProviders":   "name",
 }
 
 type ResourceIdentifierMeta struct {

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -44,7 +44,8 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_workflow_association_view internal_workflow_association_create internal_workflow_association_update internal_workflow_association_delete " +
 	"internal_api_resource_view internal_api_resource_create internal_api_resource_update internal_api_resource_delete " +
 	"internal_validation_rule_mgt_update internal_governance_view internal_governance_update " +
-	"internal_organization_view"
+	"internal_organization_view " +
+	"internal_config_mgt_view internal_config_mgt_add internal_config_mgt_update internal_config_mgt_delete"
 
 const (
 	AppName       = "IAM-CTL"

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -45,7 +45,7 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_api_resource_view internal_api_resource_create internal_api_resource_update internal_api_resource_delete " +
 	"internal_validation_rule_mgt_update internal_governance_view internal_governance_update " +
 	"internal_organization_view " +
-	"internal_config_mgt_view internal_config_mgt_add internal_config_mgt_update internal_config_mgt_delete"
+	"internal_notification_senders_view internal_notification_senders_create internal_notification_senders_update internal_notification_senders_delete"
 
 const (
 	AppName       = "IAM-CTL"

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -204,6 +204,8 @@ func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 		return validationRuleArrayIdentifiers
 	case APPLICATION_AUTHORIZED_APIS:
 		return applicationAuthorizedApiArrayIdentifiers
+	case EMAIL_PROVIDERS, SMS_PROVIDERS:
+		return notificationProviderArrayIdentifiers
 	default:
 		return make(map[string]string)
 	}

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -34,6 +34,8 @@ var ResourceOrder = []ResourceType{
 	ROLES, // Dependency: Applications
 	CHALLENGE_QUESTIONS,
 	EMAIL_TEMPLATES,
+	EMAIL_PROVIDERS,
+	SMS_PROVIDERS,
 	SCRIPT_LIBRARIES,
 	GOVERNANCE_CONNECTORS, // Dependency: Roles
 	CERTIFICATES,

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -68,6 +68,8 @@ type ToolConfigs struct {
 	WorkflowConfigs            map[string]interface{} `json:"WORKFLOWS"`
 	ApiResourceConfigs         map[string]interface{} `json:"API_RESOURCES"`
 	ValidationRuleConfigs      map[string]interface{} `json:"VALIDATION_RULES"`
+	EmailProviderConfigs       map[string]interface{} `json:"EMAIL_PROVIDERS"`
+	SmsProviderConfigs         map[string]interface{} `json:"SMS_PROVIDERS"`
 }
 
 type KeywordConfigs struct {
@@ -86,6 +88,8 @@ type KeywordConfigs struct {
 	WorkflowConfigs            map[string]interface{} `json:"WORKFLOWS"`
 	ApiResourceConfigs         map[string]interface{} `json:"API_RESOURCES"`
 	ValidationRuleConfigs      map[string]interface{} `json:"VALIDATION_RULES"`
+	EmailProviderConfigs       map[string]interface{} `json:"EMAIL_PROVIDERS"`
+	SmsProviderConfigs         map[string]interface{} `json:"SMS_PROVIDERS"`
 }
 
 var SERVER_CONFIGS ServerConfigs

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -25,6 +25,8 @@ const (
 	MIN_VERSION_API_RESOURCES               = "7.0.0"
 	MIN_VERSION_VALIDATION_RULES            = "7.0.0"
 	MIN_VERSION_APPLICATION_AUTHORIZED_APIS = "7.0.0"
+	MIN_VERSION_EMAIL_PROVIDERS             = "7.2.0"
+	MIN_VERSION_SMS_PROVIDERS               = "7.2.0"
 )
 
 var EntityMinVersionRequirements = map[ResourceType]string{
@@ -32,6 +34,8 @@ var EntityMinVersionRequirements = map[ResourceType]string{
 	API_RESOURCES:               MIN_VERSION_API_RESOURCES,
 	VALIDATION_RULES:            MIN_VERSION_VALIDATION_RULES,
 	APPLICATION_AUTHORIZED_APIS: MIN_VERSION_APPLICATION_AUTHORIZED_APIS,
+	EMAIL_PROVIDERS:             MIN_VERSION_EMAIL_PROVIDERS,
+	SMS_PROVIDERS:               MIN_VERSION_SMS_PROVIDERS,
 }
 
 // Maximum supported WSO2 Identity Server version for each resource type.


### PR DESCRIPTION
  ## Purpose                                                                                                                                                      
                                                                                                                                                                  
  Add export/import support for Email and SMS notification providers via the IS notification-sender REST APIs. Introduces a single shared package parameterised by resource type to avoid duplicating logic, and adds auth secret masking that accounts for the structurally different property shapes between email and SMS providers.  

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/73                                                                                                                                      
                                                            
  ## Goals

  - Export and import email notification providers                                                                       
  - Export and import SMS notification providers
  - Mask auth secret fields unconditionally on export for Email and Custom SMS providers, since the IS API never returns secret values in GET responses for these types
  - Respect `EXCLUDE_SECRETS` for non-Custom SMS providers, where the IS API does return the `secret` field value                                              
  - Strip the `authentication` block entirely for non-Custom SMS providers                                             
  - Gate both resource types behind IS version 7.2.0                                                                                                              
  - Surface both types as fully independent resources (`EmailProviders/`, `SmsProviders/`) with separate config keys, exclusion rules, and keyword mappings       
                                                                                                                                                                  
  ## Approach                                               
                                                                                                                                                                  
  ### One package, two resource types                                                                                                                             
  
  Email and SMS providers share identical lifecycle operations (list, get, create, update, delete) and differ only in their API path and property shape. Rather than duplicating `export.go` / `import.go` for each type, a single `pkg/notificationProviders/` package implements all logic parameterised by `ResourceType`.
  
Thin adapter files (`emailProvider.go`, `smsProvider.go`) expose the public entry points (`ExportAllEmailProviders`, `ImportAllEmailProviders`, etc.) and bind each to the correct constant. From the CLI and config perspective, the two types are fully independent: separate `EmailProviderConfigs` / `SmsProviderConfigs` fields in both `ToolConfigs` and `KeywordConfigs`, separate entries in `ResourceOrder`, separate version-gate constants, and separate `exportFunctions` / `importFunctions` map entries.

  ### Auth secret masking: two different property shapes                                                                                                                                                   
   
  For Email and Custom SMS providers, the IS API never returns the values of secret fields in GET responses. To produce usable exported files, `processAuthSecrets` appends a masked placeholder for every secret the provider's auth type requires, unconditionally, and warns if the user attempts to disable secret exclusion.
                                                                                                                                                                                                           
  Email and SMS encode properties differently:              

  - **Email** `properties`: a `[]interface{}` of `{"key": "…", "value": "…"}` objects — the standard key/value array pattern used across IAM-CTL.                                                          
  - **SMS** `authentication.properties`: a flat `map[string]interface{}` where each field name is the property key directly (e.g. `{"tokenEndpoint": "…"}`).
                                                                                                                                                                                                           
  `addSecretWithMask` branches on `resType` to handle both shapes. `maskAuthSecrets` maps each `authType` value (`NONE`, `BASIC`, `CLIENT_CREDENTIAL`, `BEARER`, `API_KEY`) to the correct secret key name, noting that `API_KEY` uses different key names per type (`apiKeyValue` for email, `value` for SMS).                                                                                                     
                                                                                                                                                                                                           
  ### Non-Custom SMS provider early return                  

  For SMS providers where `provider != "Custom"`, the IS API returns an `authentication` block that is not required for the create/update path. `processAuthSecrets` detects this case and deletes the `authentication` key from the exported data entirely before returning, rather than attempting to mask fields.
                                                                                                                                                                                                           
  Unlike Email and Custom SMS providers, the IS API does return the `secret` field value for non-Custom SMS providers. This means `EXCLUDE_SECRETS` is respected: when enabled (the default), the `secret` field is masked with `********` in the exported file; when disabled, the real value is exported and can be used as a keyword mapping.                                                      

 ### Super tenant restriction for email providers                                                                                                   
   
  The IS API does not support email provider management at the super tenant level. Email provider export and import are skipped when running against the super tenant, while SMS providers remain unaffected.

  ### API server v2                                                                                                                                  
   
  Unlike all other resource types which use the API server v1, notification providers are served under `/api/server/v2`. The base URL is set accordingly so requests are routed to the correct endpoint.
                                                                                                                                                 
  ### Top-level array serialisation                                                                                                                  
   
  The IS API returns email and SMS providers as top-level arrays, which requires the outermost list itself to be treated as an array-identified resource rather than just the nested properties entries. `notificationProviderArrayIdentifiers` is extended to include `EmailProviders` and `SmsProviders` keyed by name, ensuring the keyword management correctly handles the list-of-providers structure during both export and import. 

  ## User Stories                                                                                                                                                 
  
  As a system administrator, I want to export and import Email and SMS notification provider configurations using IAM-CTL to enable version control and maintain consistent IAM configurations.
                                                                                                                                                                  
  ## Release Note                                           

  Added Email and SMS notification provider management support to the IAM-CTL tool. 

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for exporting and importing email notification providers through the command-line interface.
  * Added support for exporting and importing SMS notification providers through the command-line interface.
  * Notification provider management now integrated into the export and import workflows (requires WSO2 Identity Server 7.2.0 or later).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->