### PR TITLE
Add support for Application Email templates and Sms templates resource types

### DIFF
--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -108,9 +108,9 @@ func getProviderKeywordMapping(resType utils.ResourceType, name string) map[stri
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }
 
-func isProviderExists(name string, exisitingProviderList []notificationProvider) bool {
+func isProviderExists(name string, existingProviderList []notificationProvider) bool {
 
-	for _, provider := range exisitingProviderList {
+	for _, provider := range existingProviderList {
 		if provider.Name == name {
 			return true
 		}

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/applicationTemplateUtils.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/applicationTemplateUtils.go
@@ -1,0 +1,54 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package applicationNotificationTemplates
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+const ApplicationTemplatesDir = "applicationTemplates"
+
+type appTemplate struct {
+	Locale string `json:"locale"`
+}
+
+func getAppTemplatesList(rt utils.ResourceType, typeId, appId string) ([]appTemplate, error) {
+
+	var list []appTemplate
+	body, err := utils.SendGetRequest(rt, typeId+"/app-templates/"+appId)
+	if err != nil {
+		return nil, err
+	}
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error unmarshalling app templates: %w", err)
+	}
+	return list, nil
+}
+
+func getDeployedAppTemplateLocales(templates []appTemplate) []string {
+
+	var locales []string
+	for _, t := range templates {
+		locales = append(locales, t.Locale)
+	}
+	return locales
+}

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/applicationTemplateUtils.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/applicationTemplateUtils.go
@@ -53,9 +53,9 @@ func getDeployedAppTemplateLocales(templates []appTemplate) []string {
 	return locales
 }
 
-func isAppTemplateExists(locale string, templates []appTemplate) bool {
+func isAppTemplateExists(locale string, existingTemplates []appTemplate) bool {
 
-	for _, t := range templates {
+	for _, t := range existingTemplates {
 		if t.Locale == locale {
 			return true
 		}

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/applicationTemplateUtils.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/applicationTemplateUtils.go
@@ -52,3 +52,13 @@ func getDeployedAppTemplateLocales(templates []appTemplate) []string {
 	}
 	return locales
 }
+
+func isAppTemplateExists(locale string, templates []appTemplate) bool {
+
+	for _, t := range templates {
+		if t.Locale == locale {
+			return true
+		}
+	}
+	return false
+}

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/applicationTemplateUtils.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/applicationTemplateUtils.go
@@ -25,7 +25,7 @@ import (
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
-const ApplicationTemplatesDir = "applicationTemplates"
+const ApplicationTemplatesDir = "ApplicationTemplates"
 
 type appTemplate struct {
 	Locale string `json:"locale"`

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/export.go
@@ -54,6 +54,9 @@ func ExportTemplateType(rt utils.ResourceType, typeId, displayName, typeDir stri
 
 	if utils.TOOL_CONFIGS.AllowDelete && appsDirExistedBefore {
 		utils.RemoveDeletedLocalDirectories(appsDir, appsWithTemplates)
+		if len(appsWithTemplates) == 0 {
+			os.Remove(appsDir)
+		}
 	}
 	return len(appsWithTemplates) > 0, nil
 }

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/export.go
@@ -1,0 +1,112 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package applicationNotificationTemplates
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ExportTemplateType(rt utils.ResourceType, typeId, displayName, typeDir string, format utils.Format, keywordMapping map[string]interface{}) (bool, error) {
+
+	appMap := utils.GetResourceIdentifierMap(utils.APPLICATIONS)
+	if len(appMap) == 0 {
+		return false, nil
+	}
+
+	appsDir := filepath.Join(typeDir, ApplicationTemplatesDir)
+	appsDirExistedBefore := false
+	if _, err := os.Stat(appsDir); err == nil {
+		appsDirExistedBefore = true
+	}
+
+	var appsWithTemplates []string
+	for appId, appName := range appMap {
+		hadAppTemplates, err := exportTemplatesOfApp(rt, typeId, appId, appName, appsDir, format, keywordMapping)
+		if err != nil {
+			return false, fmt.Errorf("error exporting templates of application %s: %w", appName, err)
+		}
+		if hadAppTemplates {
+			appsWithTemplates = append(appsWithTemplates, appName)
+		}
+	}
+
+	if utils.TOOL_CONFIGS.AllowDelete && appsDirExistedBefore {
+		utils.RemoveDeletedLocalDirectories(appsDir, appsWithTemplates)
+	}
+	return len(appsWithTemplates) > 0, nil
+}
+
+func exportTemplatesOfApp(rt utils.ResourceType, typeId, appId, appName, appsDir string, format utils.Format, keywordMapping map[string]interface{}) (bool, error) {
+
+	templates, err := getAppTemplatesList(rt, typeId, appId)
+	if err != nil {
+		log.Printf("Error retrieving templates list: %s", err)
+		return false, nil
+	}
+	if len(templates) == 0 {
+		return false, nil
+	}
+
+	appDir := filepath.Join(appsDir, appName)
+	if _, err := os.Stat(appDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(appDir, 0700); err != nil {
+			return false, fmt.Errorf("error creating template directory: %w", err)
+		}
+	} else if utils.TOOL_CONFIGS.AllowDelete {
+		utils.RemoveDeletedLocalResources(appDir, getDeployedAppTemplateLocales(templates))
+	}
+
+	for _, template := range templates {
+		if err := exportAppTemplate(rt, typeId, appId, template.Locale, appDir, format, keywordMapping); err != nil {
+			return false, fmt.Errorf("error while exporting template %s. %w", template.Locale, err)
+		}
+	}
+	return true, nil
+}
+
+func exportAppTemplate(rt utils.ResourceType, typeId, appId, locale, appDir string, format utils.Format, keywordMapping map[string]interface{}) error {
+
+	templateData, err := utils.GetResourceData(rt, typeId+"/app-templates/"+appId+"/"+locale)
+	if err != nil {
+		return fmt.Errorf("error while getting template: %w", err)
+	}
+
+	exportedFileName := utils.GetExportedFilePath(appDir, locale, format)
+
+	modifiedData, err := utils.ProcessExportedData(templateData, exportedFileName, format, keywordMapping, rt)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedData, format, rt)
+	if err != nil {
+		return fmt.Errorf("error while serializing template: %w", err)
+	}
+	if err = ioutil.WriteFile(exportedFileName, modifiedFile, 0644); err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/export.go
@@ -55,7 +55,11 @@ func ExportTemplateType(rt utils.ResourceType, typeId, displayName, typeDir stri
 	if utils.TOOL_CONFIGS.AllowDelete && appsDirExistedBefore {
 		utils.RemoveDeletedLocalDirectories(appsDir, appsWithTemplates)
 		if len(appsWithTemplates) == 0 {
-			os.Remove(appsDir)
+			if err := os.Remove(appsDir); err != nil {
+				log.Println("Error removing application templates directory:", err)
+			} else {
+				log.Println("Removed the directory:", ApplicationTemplatesDir)
+			}
 		}
 	}
 	return len(appsWithTemplates) > 0, nil

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/import.go
@@ -208,7 +208,7 @@ func removeDeletedDeployedAppTemplates(rt utils.ResourceType, typeId, appId, app
 		}
 		log.Printf("Application template for application %s not found locally. Deleting: %s", appName, template.Locale)
 		if err := utils.SendDeleteRequest(typeId+"/app-templates/"+appId+"/"+template.Locale, rt); err != nil {
-			return fmt.Errorf("error deleting template: %s. %s", template.Locale, err)
+			return fmt.Errorf("error deleting template: %s. %w", template.Locale, err)
 		}
 	}
 	return nil

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/import.go
@@ -1,0 +1,165 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package applicationNotificationTemplates
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ImportTemplateType(rt utils.ResourceType, typeId, localTypePath string, keywordMapping map[string]interface{}, logName string) error {
+
+	appsDir := filepath.Join(localTypePath, ApplicationTemplatesDir)
+	if _, err := os.Stat(appsDir); os.IsNotExist(err) {
+		return nil
+	}
+	appDirEntries, err := ioutil.ReadDir(appsDir)
+	if err != nil {
+		return fmt.Errorf("error reading application templates directory: %w", err)
+	}
+
+	appMap := utils.GetResourceIdentifierMap(utils.APPLICATIONS)
+
+	for _, appDirEntry := range appDirEntries {
+		if !appDirEntry.IsDir() {
+			continue
+		}
+		appName := appDirEntry.Name()
+		appId, ok := appMap[appName]
+		if !ok {
+			return fmt.Errorf("referenced application with identifier '%s' has not been exported", appName)
+		}
+
+		if err := importAppTemplates(rt, typeId, appId, appName, appsDir, keywordMapping, logName); err != nil {
+			return fmt.Errorf("error importing templates of application %s: %w", appName, err)
+		}
+	}
+	return nil
+}
+
+func importAppTemplates(rt utils.ResourceType, typeId, appId, appName, appsDir string, keywordMapping map[string]interface{}, logName string) error {
+
+	deployedTemplates, err := getAppTemplatesList(rt, typeId, appId)
+	if err != nil {
+		return fmt.Errorf("error getting templates list: %w", err)
+	}
+	appLocalDir := filepath.Join(appsDir, appName)
+	localFiles, err := ioutil.ReadDir(appLocalDir)
+	if err != nil {
+		return fmt.Errorf("error reading local template files: %w", err)
+	}
+
+	if utils.TOOL_CONFIGS.AllowDelete {
+		if err := removeDeletedDeployedAppTemplates(rt, typeId, appId, appName, localFiles, deployedTemplates); err != nil {
+			return fmt.Errorf("error removing deleted templates: %w", err)
+		}
+	}
+
+	for _, file := range localFiles {
+		filePath := filepath.Join(appLocalDir, file.Name())
+		fileInfo := utils.GetFileInfo(filePath)
+		locale := fileInfo.ResourceName
+
+		exists := isAppTemplateExists(locale, deployedTemplates)
+		if err := importAppTemplate(rt, typeId, appId, locale, filePath, keywordMapping, exists, logName); err != nil {
+			return fmt.Errorf("error while importing template %s. %w", locale, err)
+		}
+	}
+	return nil
+}
+
+func importAppTemplate(rt utils.ResourceType, typeId, appId, locale, filePath string, keywordMapping map[string]interface{}, exists bool, logName string) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(filePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format: %w", err)
+	}
+	fileBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("error when reading the file: %w", err)
+	}
+
+	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), keywordMapping)
+
+	if !exists {
+		return createAppTemplate(rt, typeId, appId, []byte(modifiedFileData), format, logName)
+	}
+	return updateAppTemplate(rt, typeId, appId, locale, []byte(modifiedFileData), format, logName)
+}
+
+func createAppTemplate(rt utils.ResourceType, typeId, appId string, requestBody []byte, format utils.Format, logName string) error {
+
+	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, rt)
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPostRequest(rt, jsonBody, utils.WithPathSuffix(typeId+"/app-templates/"+appId))
+	if err != nil {
+		return fmt.Errorf("error when creating %s: %w", logName, err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func updateAppTemplate(rt utils.ResourceType, typeId, appId, locale string, requestBody []byte, format utils.Format, logName string) error {
+
+	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, rt, "locale")
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPutRequest(rt, typeId+"/app-templates/"+appId+"/"+locale, jsonBody)
+	if err != nil {
+		return fmt.Errorf("error when updating %s: %w", logName, err)
+	}
+	defer resp.Body.Close()
+
+	return nil
+}
+
+func removeDeletedDeployedAppTemplates(rt utils.ResourceType, typeId, appId, appName string, localFiles []os.FileInfo, deployedTemplates []appTemplate) error {
+
+	if len(deployedTemplates) == 0 {
+		return nil
+	}
+
+	localLocales := make(map[string]struct{})
+	for _, file := range localFiles {
+		resourceName := utils.GetFileInfo(file.Name()).ResourceName
+		localLocales[resourceName] = struct{}{}
+	}
+
+	for _, template := range deployedTemplates {
+		if _, existsLocally := localLocales[template.Locale]; existsLocally {
+			continue
+		}
+		log.Printf("Application template for application %s not found locally. Deleting: %s", appName, template.Locale)
+		if err := utils.SendDeleteRequest(typeId+"/app-templates/"+appId+"/"+template.Locale, rt); err != nil {
+			return fmt.Errorf("error deleting template: %s. %s", template.Locale, err)
+		}
+	}
+	return nil
+}

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/import.go
@@ -32,6 +32,12 @@ func ImportTemplateType(rt utils.ResourceType, typeId, localTypePath string, key
 
 	appsDir := filepath.Join(localTypePath, ApplicationTemplatesDir)
 	if _, err := os.Stat(appsDir); os.IsNotExist(err) {
+		if utils.TOOL_CONFIGS.AllowDelete {
+			err := removeDeployedTemplatesOfAllApps(rt, typeId)
+			if err != nil {
+				return fmt.Errorf("error removing deployed application templates: %w", err)
+			}
+		}
 		return nil
 	}
 	appDirEntries, err := ioutil.ReadDir(appsDir)
@@ -40,6 +46,7 @@ func ImportTemplateType(rt utils.ResourceType, typeId, localTypePath string, key
 	}
 
 	appMap := utils.GetResourceIdentifierMap(utils.APPLICATIONS)
+	localAppDirs := make(map[string]struct{})
 
 	for _, appDirEntry := range appDirEntries {
 		if !appDirEntry.IsDir() {
@@ -50,15 +57,22 @@ func ImportTemplateType(rt utils.ResourceType, typeId, localTypePath string, key
 		if !ok {
 			return fmt.Errorf("referenced application with identifier '%s' has not been exported", appName)
 		}
+		localAppDirs[appName] = struct{}{}
 
-		if err := importAppTemplates(rt, typeId, appId, appName, appsDir, keywordMapping, logName); err != nil {
+		if err := importTemplatesOfApp(rt, typeId, appId, appName, appsDir, keywordMapping, logName); err != nil {
 			return fmt.Errorf("error importing templates of application %s: %w", appName, err)
+		}
+	}
+
+	if utils.TOOL_CONFIGS.AllowDelete {
+		if err := removeDeployedTemplatesOfDeletedApps(rt, typeId, appMap, localAppDirs); err != nil {
+			return fmt.Errorf("error removing templates of deleted applications: %w", err)
 		}
 	}
 	return nil
 }
 
-func importAppTemplates(rt utils.ResourceType, typeId, appId, appName, appsDir string, keywordMapping map[string]interface{}, logName string) error {
+func importTemplatesOfApp(rt utils.ResourceType, typeId, appId, appName, appsDir string, keywordMapping map[string]interface{}, logName string) error {
 
 	deployedTemplates, err := getAppTemplatesList(rt, typeId, appId)
 	if err != nil {
@@ -137,6 +151,42 @@ func updateAppTemplate(rt utils.ResourceType, typeId, appId, locale string, requ
 	}
 	defer resp.Body.Close()
 
+	return nil
+}
+
+func removeDeployedTemplatesOfAllApps(rt utils.ResourceType, typeId string) error {
+
+	appMap := utils.GetResourceIdentifierMap(utils.APPLICATIONS)
+	if len(appMap) == 0 {
+		return nil
+	}
+
+	for appName, appId := range appMap {
+		deployedTemplates, err := getAppTemplatesList(rt, typeId, appId)
+		if err != nil {
+			return fmt.Errorf("error getting templates for application %s: %w", appName, err)
+		}
+		if err := removeDeletedDeployedAppTemplates(rt, typeId, appId, appName, []os.FileInfo{}, deployedTemplates); err != nil {
+			return fmt.Errorf("error removing templates for application %s: %w", appName, err)
+		}
+	}
+	return nil
+}
+
+func removeDeployedTemplatesOfDeletedApps(rt utils.ResourceType, typeId string, appMap map[string]string, localAppDirs map[string]struct{}) error {
+
+	for appName, appId := range appMap {
+		if _, hasLocal := localAppDirs[appName]; hasLocal {
+			continue
+		}
+		deployedTemplates, err := getAppTemplatesList(rt, typeId, appId)
+		if err != nil {
+			return fmt.Errorf("error getting templates for application %s: %w", appName, err)
+		}
+		if err := removeDeletedDeployedAppTemplates(rt, typeId, appId, appName, []os.FileInfo{}, deployedTemplates); err != nil {
+			return fmt.Errorf("error removing templates for application %s: %w", appName, err)
+		}
+	}
 	return nil
 }
 

--- a/iamctl/pkg/notificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/export.go
@@ -112,7 +112,11 @@ func exportTemplateType(rt utils.ResourceType, typeId, displayName, parentDir, f
 		}
 	} else if utils.TOOL_CONFIGS.AllowDelete {
 		if _, err := os.Stat(orgDir); err == nil {
-			os.RemoveAll(orgDir)
+			if err := os.RemoveAll(orgDir); err != nil {
+				log.Println("Error removing organization templates directory:", err)
+			} else {
+				log.Println("Removed the directory:", orgTemplatesDir)
+			}
 		}
 	}
 

--- a/iamctl/pkg/notificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/export.go
@@ -110,6 +110,10 @@ func exportTemplateType(rt utils.ResourceType, typeId, displayName, parentDir, f
 				return false, fmt.Errorf("error while exporting template: %s. %w", template.Locale, err)
 			}
 		}
+	} else if utils.TOOL_CONFIGS.AllowDelete {
+		if _, err := os.Stat(orgDir); err == nil {
+			os.RemoveAll(orgDir)
+		}
 	}
 
 	hadAppTemplates, err := applicationNotificationTemplates.ExportTemplateType(rt, typeId, displayName, typeDir, format, keywordMapping)

--- a/iamctl/pkg/notificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/export.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationTemplates/applicationNotificationTemplates"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
@@ -88,29 +89,35 @@ func exportTemplateType(rt utils.ResourceType, typeId, displayName, parentDir, f
 	if err != nil {
 		return false, fmt.Errorf("error retrieving deployed templates: %w", err)
 	}
-	if len(deployedTemplates) == 0 {
-		return false, nil
-	}
-
-	if _, err := os.Stat(orgDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(orgDir, 0700); err != nil {
-			return false, fmt.Errorf("error creating template type directory: %w", err)
-		}
-	} else {
-		if utils.TOOL_CONFIGS.AllowDelete {
-			utils.RemoveDeletedLocalResources(orgDir, getDeployedTemplateLocales(deployedTemplates))
-		}
-	}
 
 	keywordMapping := getTemplateKeywordMapping(rt, displayName)
-	for _, template := range deployedTemplates {
-		err := exportTemplate(rt, typeId, template.Locale, orgDir, format, keywordMapping)
-		if err != nil {
-			return false, fmt.Errorf("error while exporting template: %s. %w", template.Locale, err)
+	hadOrgTemplates := len(deployedTemplates) > 0
+
+	if hadOrgTemplates {
+		if _, err := os.Stat(orgDir); os.IsNotExist(err) {
+			if err := os.MkdirAll(orgDir, 0700); err != nil {
+				return false, fmt.Errorf("error creating template type directory: %w", err)
+			}
+		} else {
+			if utils.TOOL_CONFIGS.AllowDelete {
+				utils.RemoveDeletedLocalResources(orgDir, getDeployedTemplateLocales(deployedTemplates))
+			}
+		}
+
+		for _, template := range deployedTemplates {
+			err := exportTemplate(rt, typeId, template.Locale, orgDir, format, keywordMapping)
+			if err != nil {
+				return false, fmt.Errorf("error while exporting template: %s. %w", template.Locale, err)
+			}
 		}
 	}
 
-	return true, nil
+	hadAppTemplates, err := applicationNotificationTemplates.ExportTemplateType(rt, typeId, displayName, typeDir, format, keywordMapping)
+	if err != nil {
+		return hadOrgTemplates, fmt.Errorf("error while exporting application templates: %w", err)
+	}
+
+	return hadOrgTemplates || hadAppTemplates, nil
 }
 
 func exportTemplate(rt utils.ResourceType, typeId, locale, typeDir string, format utils.Format, keywordMapping map[string]interface{}) error {

--- a/iamctl/pkg/notificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/export.go
@@ -82,6 +82,7 @@ func exportTemplateType(rt utils.ResourceType, typeId, displayName, parentDir, f
 
 	format := utils.FormatFromString(formatString)
 	typeDir := filepath.Join(parentDir, displayName)
+	orgDir := filepath.Join(typeDir, orgTemplatesDir)
 
 	deployedTemplates, err := getTemplatesList(rt, typeId)
 	if err != nil {
@@ -91,19 +92,19 @@ func exportTemplateType(rt utils.ResourceType, typeId, displayName, parentDir, f
 		return false, nil
 	}
 
-	if _, err := os.Stat(typeDir); os.IsNotExist(err) {
-		if err := os.MkdirAll(typeDir, 0700); err != nil {
+	if _, err := os.Stat(orgDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(orgDir, 0700); err != nil {
 			return false, fmt.Errorf("error creating template type directory: %w", err)
 		}
 	} else {
 		if utils.TOOL_CONFIGS.AllowDelete {
-			utils.RemoveDeletedLocalResources(typeDir, getDeployedTemplateLocales(deployedTemplates))
+			utils.RemoveDeletedLocalResources(orgDir, getDeployedTemplateLocales(deployedTemplates))
 		}
 	}
 
 	keywordMapping := getTemplateKeywordMapping(rt, displayName)
 	for _, template := range deployedTemplates {
-		err := exportTemplate(rt, typeId, template.Locale, typeDir, format, keywordMapping)
+		err := exportTemplate(rt, typeId, template.Locale, orgDir, format, keywordMapping)
 		if err != nil {
 			return false, fmt.Errorf("error while exporting template: %s. %w", template.Locale, err)
 		}

--- a/iamctl/pkg/notificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/import.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"path/filepath"
 
+	applicationNotificationTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationTemplates/applicationNotificationTemplates"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
@@ -131,6 +132,10 @@ func importTemplateType(rt utils.ResourceType, localTypePath, displayName string
 		if err != nil {
 			return fmt.Errorf("error importing template: %s. %w", locale, err)
 		}
+	}
+
+	if err := applicationNotificationTemplates.ImportTemplateType(rt, typeId, localTypePath, keywordMapping, logName); err != nil {
+		return fmt.Errorf("error while importing application templates: %w", err)
 	}
 
 	if existingType != "" {

--- a/iamctl/pkg/notificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/import.go
@@ -100,9 +100,16 @@ func importTemplateType(rt utils.ResourceType, localTypePath, displayName string
 	if err != nil {
 		return fmt.Errorf("error getting deployed templates: %w", err)
 	}
-	localFiles, err := ioutil.ReadDir(localTypePath)
-	if err != nil {
-		return fmt.Errorf("error reading local template files: %w", err)
+
+	orgDir := filepath.Join(localTypePath, orgTemplatesDir)
+	var localFiles []os.FileInfo
+	if _, err := os.Stat(orgDir); os.IsNotExist(err) {
+		localFiles = []os.FileInfo{}
+	} else {
+		localFiles, err = ioutil.ReadDir(orgDir)
+		if err != nil {
+			return fmt.Errorf("error reading local template files: %w", err)
+		}
 	}
 
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -115,7 +122,7 @@ func importTemplateType(rt utils.ResourceType, localTypePath, displayName string
 	keywordMapping := getTemplateKeywordMapping(rt, displayName)
 
 	for _, file := range localFiles {
-		filePath := filepath.Join(localTypePath, file.Name())
+		filePath := filepath.Join(orgDir, file.Name())
 		fileInfo := utils.GetFileInfo(filePath)
 		locale := fileInfo.ResourceName
 

--- a/iamctl/pkg/notificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/import.go
@@ -264,7 +264,7 @@ func removeDeletedDeployedTemplates(rt utils.ResourceType, typeId string, localF
 		}
 		log.Printf("Template not found locally. Deleting: %s", template.Locale)
 		if err := utils.SendDeleteRequest(typeId+"/org-templates/"+template.Locale, rt); err != nil {
-			return fmt.Errorf("error deleting template: %s. %s", template.Locale, err)
+			return fmt.Errorf("error deleting template: %s. %w", template.Locale, err)
 		}
 	}
 	return nil

--- a/iamctl/pkg/notificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/import.go
@@ -228,15 +228,6 @@ func removeDeletedDeployedTypes(rt utils.ResourceType, localDirs []os.FileInfo, 
 		}
 
 		if _, isExported := exportedNames[deployedType.DisplayName]; isExported {
-			templates, err := getTemplatesList(rt, deployedType.ID)
-			if err != nil {
-				log.Printf("Error checking whether templates exist for type: %s", err.Error())
-				log.Printf("%s type: %s is excluded from deletion.", logName, deployedType.DisplayName)
-				continue
-			}
-			if len(templates) == 0 {
-				continue
-			}
 			log.Printf("%s type not found locally. Resetting: %s", logName, deployedType.DisplayName)
 			if err := resetTemplateType(rt, deployedType.ID); err != nil {
 				utils.UpdateFailureSummary(rt, deployedType.DisplayName)

--- a/iamctl/pkg/notificationTemplates/notificationTemplateUtils.go
+++ b/iamctl/pkg/notificationTemplates/notificationTemplateUtils.go
@@ -28,7 +28,7 @@ import (
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
-const orgTemplatesDir = "organizationTemplates"
+const orgTemplatesDir = "OrganizationTemplates"
 
 type notificationTemplateType struct {
 	ID          string `json:"id"`

--- a/iamctl/pkg/notificationTemplates/notificationTemplateUtils.go
+++ b/iamctl/pkg/notificationTemplates/notificationTemplateUtils.go
@@ -140,19 +140,19 @@ func getTemplateKeywordMapping(rt utils.ResourceType, typeName string) map[strin
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }
 
-func getTemplateTypeId(displayName string, types []notificationTemplateType) string {
+func getTemplateTypeId(displayName string, existingTypes []notificationTemplateType) string {
 
-	for i := range types {
-		if types[i].DisplayName == displayName {
-			return types[i].ID
+	for i := range existingTypes {
+		if existingTypes[i].DisplayName == displayName {
+			return existingTypes[i].ID
 		}
 	}
 	return ""
 }
 
-func isTemplateExists(locale string, templates []notificationTemplate) bool {
+func isTemplateExists(locale string, existingTemplates []notificationTemplate) bool {
 
-	for _, t := range templates {
+	for _, t := range existingTemplates {
 		if t.Locale == locale {
 			return true
 		}

--- a/iamctl/pkg/notificationTemplates/notificationTemplateUtils.go
+++ b/iamctl/pkg/notificationTemplates/notificationTemplateUtils.go
@@ -28,6 +28,8 @@ import (
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
+const orgTemplatesDir = "organizationTemplates"
+
 type notificationTemplateType struct {
 	ID          string `json:"id"`
 	DisplayName string `json:"displayName"`


### PR DESCRIPTION
 ## Purpose                                                                                                                                                             
                                          
  The notification template export/import handled only **org-level** templates. The IS notification templates API also exposes **application-level** email and SMS templates per app per locale. Applications with customised per-app templates could not be round-tripped. Those customisations were silently dropped on every export/import cycle.                                     
                                                                                                                                                                         
  Several structural challenges made app-level templates non-trivial to layer on top of the existing org-level implementation:
                                                                                                                                                                         
  - The app templates API identifies applications by **UUID**, but the filesystem layout must use **human-readable names** for the exported directories. Resolving UUID↔name at both export and import time without making additional API calls required a cross-resource dependency.                                                     
  - Org-level and app-level templates for the **same template type** must coexist in the same type directory without colliding. This demanded a layout change that is backwards-compatible with existing org-template exports.                                                                                                               
  - The **delete semantics for app templates are three-tiered**. Per-locale (stale locales within an app), per-app (all locales for an app whose local folder was removed), and all-apps (all app templates when the entire `ApplicationTemplates/` directory is absent), each with distinct code paths.                                
  - Both `OrganizationTemplates/` and `ApplicationTemplates/` **parent directories** can become stale (empty) and must be removed, but only if they existed before the current run, not if they were simply never created.
                        
  Related to https://github.com/wso2-enterprise/iam-product-management/issues/662                                                                                                                                                 
  Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/75
                                                                                                                                                                         
  ## Goals                                                  
                                                                                                                                                                         
  - Restructure the type directory layout to place org templates under `OrganizationTemplates/` and app templates under `ApplicationTemplates/<AppName>/`, so both levels coexist cleanly under the same type folder                                                                                                                            
  - Export per-app templates for every application that has a custom template for a given type, across both `EMAIL_TEMPLATES` and `SMS_TEMPLATES`
  - On import, perform a full sync per app: create missing locales, update changed locales, delete stale locales (gated on `AllowDelete`)                                
  - Delete all deployed app templates when `ApplicationTemplates/` is absent locally and `AllowDelete` is enabled
  - Delete deployed templates for apps whose local folder was removed, while leaving apps not in the current run untouched when `AllowDelete` is disabled                
  - Remove stale `OrganizationTemplates/` and `ApplicationTemplates/` parent directories when they become empty                                                          
                                                                                                                                                                         
  ## Approach                                                                                                                                                            
                                                                                                                                                                         
  ### Layout change: introducing `OrganizationTemplates/` and `ApplicationTemplates/` subfolders                                                                         
                                                                                                                                                                         
  Org templates previously written directly into `<TypeName>/` are now placed `<TypeName>/OrganizationTemplates/`. App templates live in a sibling       `<TypeName>/ApplicationTemplates/<AppName>/`. Both levels use the same locale filename convention.                                                                     
   
  ```                                                                                                                                                                    
  EMAIL_TEMPLATES/                                          
    AccountConfirmation/                                                                                                                                                 
      OrganizationTemplates/                                
        en_US.json                        
        fr_FR.json
      ApplicationTemplates/                                                                                                                                              
        MyTravelApp/                          
          en_US.json                                                                                                                                                     
        Pickup/                                             
          en_US.json                                                                                                                                                     
    TemplateTypes.json
  ```                                                                                                                                                                    
                                                            
  ### UUID↔name resolution via `ResourceIdentifierMap`                                                                                                                   
                                                            
  The app templates API uses app UUIDs in all paths, but the export filesystem uses app names as directory names. Rather than making extra API calls to build a name↔UUID mapping, the implementation reuses `utils.GetResourceIdentifierMap(utils.APPLICATIONS)`, which is already populated by `applications.ExportAll` / `ImportAll` before templates run (Applications precedes EmailTemplates/SmsTemplates in `ResourceOrder`).
                                                                                                                                                                         
  - **Export**: map is keyed `appId → appName`. Iterating it gives every app UUID to query for templates, and the corresponding name for the directory.
  - **Import**: map is keyed `appName → appId`. Each local app folder name is looked up to resolve the UUID needed for API calls.                                        
                                                            
  If a local app folder name does not resolve to a known UUID (i.e. the application was not part of this run), the import fails the template type with a descriptive error rather than silently skipping or using a stale UUID.
                                                                                                                                                                         
  ### Separate sub-package for app template logic                                                                                                                        
                                                                                                                                                                         
  All app-template code lives in `pkg/notificationTemplates/applicationNotificationTemplates/` (`applicationTemplateUtils.go`, `export.go`, `import.go`). The parent package calls into it after completing org-template processing. This keeps the two concerns separated and the parent package readable. No new resource type registration is needed. App templates piggyback on the existing `EMAIL_TEMPLATES` / `SMS_TEMPLATES` types and their REST scopes.
                                                                                                                                                                         
  ### `hadOrgTemplates || hadAppTemplates` return from `exportTemplateType`
                                                                                                                                                                         
  The parent `exportTemplateType` now returns `true` if either level produced output. This prevents `RemoveDeletedLocalDirectories` from treating a type that has only app templates as stale and deleting its directory.                                                                                                                     
   
                                                                                                                                                                         
  | Condition | Behavior (`AllowDelete=true`) |             
  |---|---|                                                                                                                                                              
  | `ApplicationTemplates/` folder absent | Delete all deployed app templates across all apps |
  | App folder absent, other app folders present | Delete all deployed locales for the absent app |
  | App folder present, locale file missing | Delete that locale for that app |                                                                                          
                                                                               
  Each tier is implemented as a named helper (`removeDeployedTemplatesOfAllApps`, `removeDeployedTemplatesOfDeletedApps`, `removeDeletedDeployedAppTemplates`) so the cases remain independently readable.                                                                                                                                   
                                                                                                                                                                         
  The same `AllowDelete` logic applies to the reset/delete of template types: a type is reset when it existed in the last export but has no local directory, regardless of whether it carried org templates or only app-level templates.                                                                                                       
                                                                                                                                                                         
  ### Lazy mkdir for per-app export directories                                                                                                                          
                                                                                                                                                                         
  App directories under `ApplicationTemplates/` are only created when the app actually has templates for the given type. This avoids populating the export with empty stub directories for apps that have no customisations for a particular template type.                                                                                  
                                                                                                                                                                         
  ### Stale parent directory removal
                                                                                                                                                                         
  After `RemoveDeletedLocalDirectories` cleans up stale app subdirectories, if no apps produced output and `AllowDelete` is enabled, the now-empty `ApplicationTemplates/` directory itself is removed. The same applies to `OrganizationTemplates/` when the server reports zero org templates. Both removals are guarded by a pre-run existence check so they only fire when the directory was left over from a previous export, not when it was simply never created.                         
                                                                                                                                                
  ## User Stories                                                                                                                                                        
                 
  As a system administrator, I want to export and import Application level Email and SMS templates across IS environments using IAM-CTL to to enable version control and maintain consistent IAM configurations.                  
                                                                                                                                                                              
  ## Release Note
                                                                                                                                                                         
 Added Apllication level Email and SMS template management support to the IAM-CTL tool.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for application-level notification templates with independent export and import workflows
  * Templates are now organized into separate application and organization categories
  * Supports locale-specific templates for individual applications

* **Chores**
  * Refactored directory structure to better organize template management by type
  * Improved internal helper function parameter naming for clarity

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/76?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->