### PR TITLE
Add support for Actions resource type

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -21,6 +21,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
+	actions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/actions"
 	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
 	certificates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/certificates"
@@ -72,6 +73,7 @@ var exportAllCmd = &cobra.Command{
 			utils.EMAIL_PROVIDERS:       notificationProviders.ExportAllEmailProviders,
 			utils.SMS_PROVIDERS:         notificationProviders.ExportAllSmsProviders,
 			utils.SMS_TEMPLATES:         notificationTemplates.ExportAllSmsTemplates,
+			utils.ACTIONS:               actions.ExportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -21,6 +21,7 @@ package cli
 import (
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
+	actions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/actions"
 	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
 	certificates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/certificates"
@@ -71,6 +72,7 @@ var importAllCmd = &cobra.Command{
 			utils.EMAIL_PROVIDERS:       notificationProviders.ImportAllEmailProviders,
 			utils.SMS_PROVIDERS:         notificationProviders.ImportAllSmsProviders,
 			utils.SMS_TEMPLATES:         notificationTemplates.ImportAllSmsTemplates,
+			utils.ACTIONS:               actions.ImportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/pkg/actions/actionUtils.go
+++ b/iamctl/pkg/actions/actionUtils.go
@@ -91,17 +91,37 @@ func getActionsKeywordMapping(typeName string) map[string]interface{} {
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }
 
-func isActionExists(name string, existingActionList []action) *action {
+func getActionId(name string, existingActionList []action) string {
 
 	for i := range existingActionList {
 		if existingActionList[i].Name == name {
-			return &existingActionList[i]
+			return existingActionList[i].ID
 		}
 	}
-	return nil
+	return ""
 }
 
 func typeIdFromSelf(self string) string {
 
 	return path.Base(self)
+}
+
+func setActionStatus(typePath, actionId, status string) error {
+
+	endpoint := typePath + "/" + actionId + "/"
+	switch status {
+	case "ACTIVE":
+		endpoint += "activate"
+	case "INACTIVE":
+		endpoint += "deactivate"
+	default:
+		return fmt.Errorf("unexpected value for status: %s", status)
+	}
+
+	resp, err := utils.SendPostRequest(utils.ACTIONS, nil, utils.WithPathSuffix(endpoint))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	return nil
 }

--- a/iamctl/pkg/actions/actionUtils.go
+++ b/iamctl/pkg/actions/actionUtils.go
@@ -65,15 +65,6 @@ func getActionsList(actionType string) ([]action, error) {
 	return summaries, nil
 }
 
-func getDeployedActionTypeIds(types []actionType) []string {
-
-	var ids []string
-	for _, at := range types {
-		ids = append(ids, at.ID)
-	}
-	return ids
-}
-
 func getDeployedActionNames(summaries []action) []string {
 
 	var names []string

--- a/iamctl/pkg/actions/actionUtils.go
+++ b/iamctl/pkg/actions/actionUtils.go
@@ -145,6 +145,56 @@ func processAuthProperties(actionMap map[string]interface{}) error {
 	return nil
 }
 
+func replaceRuleReferences(actionMap map[string]interface{}) error {
+
+	ruleRaw, exists := actionMap["rule"]
+	if !exists {
+		return nil
+	}
+	appMap := utils.GetResourceIdentifierMap(utils.APPLICATIONS)
+
+	ruleArr, ok := ruleRaw.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for rule field")
+	}
+	rules, ok := ruleArr["rules"].([]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for rules array")
+	}
+
+	for _, rule := range rules {
+		ruleMap, ok := rule.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected format for rule element")
+		}
+		exprs, ok := ruleMap["expressions"].([]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected format for rule expressions")
+		}
+
+		for _, expr := range exprs {
+			exprMap, ok := expr.(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("unexpected format for expression element")
+			}
+			if exprMap["field"] != "application" {
+				continue
+			}
+
+			oldVal, ok := exprMap["value"].(string)
+			if !ok {
+				return fmt.Errorf("unexpected format for value in expression")
+			}
+			newVal, found := appMap[oldVal]
+			if !found {
+				return fmt.Errorf("referenced application '%s' has not been exported", oldVal)
+			}
+			exprMap["value"] = newVal
+		}
+	}
+	return nil
+}
+
 func setActionStatus(typePath, actionId, status string) error {
 
 	endpoint := typePath + "/" + actionId + "/"

--- a/iamctl/pkg/actions/actionUtils.go
+++ b/iamctl/pkg/actions/actionUtils.go
@@ -1,0 +1,97 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package actions
+
+import (
+	"encoding/json"
+	"fmt"
+	"path"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+type actionType struct {
+	ID   string
+	Self string `json:"self"`
+}
+
+type actionSummary struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+func getActionTypesList() ([]actionType, error) {
+
+	body, err := utils.SendGetRequest(utils.ACTIONS, "types")
+	if err != nil {
+		return nil, fmt.Errorf("error when getting the list: %w", err)
+	}
+	var types []actionType
+	if err := json.Unmarshal(body, &types); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the list: %w", err)
+	}
+	for i := range types {
+		types[i].ID = typeIdFromSelf(types[i].Self)
+	}
+	return types, nil
+}
+
+func getActionsList(actionType string) ([]actionSummary, error) {
+
+	body, err := utils.SendGetRequest(utils.ACTIONS, actionType)
+	if err != nil {
+		return nil, err
+	}
+	var summaries []actionSummary
+	if err := json.Unmarshal(body, &summaries); err != nil {
+		return nil, fmt.Errorf("error unmarshalling actions list: %w", err)
+	}
+	return summaries, nil
+}
+
+func getDeployedActionTypeIds(types []actionType) []string {
+
+	var ids []string
+	for _, at := range types {
+		ids = append(ids, at.ID)
+	}
+	return ids
+}
+
+func getDeployedActionNames(summaries []actionSummary) []string {
+
+	var names []string
+	for _, s := range summaries {
+		names = append(names, s.Name)
+	}
+	return names
+}
+
+func getActionsKeywordMapping(typeName string) map[string]interface{} {
+
+	if utils.KEYWORD_CONFIGS.ActionConfigs != nil {
+		return utils.ResolveAdvancedKeywordMapping(typeName, utils.KEYWORD_CONFIGS.ActionConfigs)
+	}
+	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func typeIdFromSelf(self string) string {
+
+	return path.Base(self)
+}

--- a/iamctl/pkg/actions/actionUtils.go
+++ b/iamctl/pkg/actions/actionUtils.go
@@ -140,18 +140,23 @@ func replaceRuleReferences(actionMap map[string]interface{}) error {
 
 	ruleRaw, exists := actionMap["rule"]
 	if !exists {
+		actionMap["rule"] = map[string]interface{}{}
 		return nil
 	}
-	appMap := utils.GetResourceIdentifierMap(utils.APPLICATIONS)
-
-	ruleArr, ok := ruleRaw.(map[string]interface{})
+	ruleMap, ok := ruleRaw.(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("unexpected format for rule field")
 	}
-	rules, ok := ruleArr["rules"].([]interface{})
+
+	rulesRaw, exists := ruleMap["rules"]
+	if !exists {
+		return nil
+	}
+	rules, ok := rulesRaw.([]interface{})
 	if !ok {
 		return fmt.Errorf("unexpected format for rules array")
 	}
+	appMap := utils.GetResourceIdentifierMap(utils.APPLICATIONS)
 
 	for _, rule := range rules {
 		ruleMap, ok := rule.(map[string]interface{})

--- a/iamctl/pkg/actions/actionUtils.go
+++ b/iamctl/pkg/actions/actionUtils.go
@@ -31,7 +31,7 @@ type actionType struct {
 	Self string `json:"self"`
 }
 
-type actionSummary struct {
+type action struct {
 	ID   string `json:"id"`
 	Name string `json:"name"`
 }
@@ -52,13 +52,13 @@ func getActionTypesList() ([]actionType, error) {
 	return types, nil
 }
 
-func getActionsList(actionType string) ([]actionSummary, error) {
+func getActionsList(actionType string) ([]action, error) {
 
 	body, err := utils.SendGetRequest(utils.ACTIONS, actionType)
 	if err != nil {
 		return nil, err
 	}
-	var summaries []actionSummary
+	var summaries []action
 	if err := json.Unmarshal(body, &summaries); err != nil {
 		return nil, fmt.Errorf("error unmarshalling actions list: %w", err)
 	}
@@ -74,7 +74,7 @@ func getDeployedActionTypeIds(types []actionType) []string {
 	return ids
 }
 
-func getDeployedActionNames(summaries []actionSummary) []string {
+func getDeployedActionNames(summaries []action) []string {
 
 	var names []string
 	for _, s := range summaries {
@@ -89,6 +89,16 @@ func getActionsKeywordMapping(typeName string) map[string]interface{} {
 		return utils.ResolveAdvancedKeywordMapping(typeName, utils.KEYWORD_CONFIGS.ActionConfigs)
 	}
 	return utils.KEYWORD_CONFIGS.KeywordMappings
+}
+
+func isActionExists(name string, existingActionList []action) *action {
+
+	for i := range existingActionList {
+		if existingActionList[i].Name == name {
+			return &existingActionList[i]
+		}
+	}
+	return nil
 }
 
 func typeIdFromSelf(self string) string {

--- a/iamctl/pkg/actions/actionUtils.go
+++ b/iamctl/pkg/actions/actionUtils.go
@@ -106,6 +106,45 @@ func typeIdFromSelf(self string) string {
 	return path.Base(self)
 }
 
+func processAuthProperties(actionMap map[string]interface{}) error {
+
+	endpoint, ok := actionMap["endpoint"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for endpoint")
+	}
+	auth, ok := endpoint["authentication"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for authentication")
+	}
+
+	authType, ok := auth["type"].(string)
+	if !ok {
+		return fmt.Errorf("unexpected format for authentication type")
+	}
+
+	switch authType {
+	case "NONE":
+		auth["properties"] = map[string]interface{}{}
+	case "BASIC":
+		auth["properties"] = map[string]interface{}{
+			"username": utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES,
+			"password": utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES,
+		}
+	case "BEARER":
+		auth["properties"] = map[string]interface{}{
+			"accessToken": utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES,
+		}
+	case "API_KEY":
+		auth["properties"] = map[string]interface{}{
+			"header": utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES,
+			"value":  utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES,
+		}
+	default:
+		return fmt.Errorf("unknown authentication type %s", authType)
+	}
+	return nil
+}
+
 func setActionStatus(typePath, actionId, status string) error {
 
 	endpoint := typePath + "/" + actionId + "/"

--- a/iamctl/pkg/actions/export.go
+++ b/iamctl/pkg/actions/export.go
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package actions
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ExportAll(outputDirPath, format string) {
+
+	log.Println("Exporting actions...")
+	actionsDir := filepath.Join(outputDirPath, utils.ACTIONS.String())
+
+	if utils.IsResourceTypeExcluded(utils.ACTIONS) {
+		return
+	}
+	types, err := getActionTypesList()
+	if err != nil {
+		log.Println("Error retrieving action types list:", err)
+		return
+	}
+
+	if _, err := os.Stat(actionsDir); os.IsNotExist(err) {
+		os.MkdirAll(actionsDir, 0700)
+	} else if utils.TOOL_CONFIGS.AllowDelete {
+		utils.RemoveDeletedLocalDirectories(actionsDir, getDeployedActionTypeIds(types))
+	}
+
+	for _, at := range types {
+		if utils.IsResourceExcluded(at.ID, utils.TOOL_CONFIGS.ActionConfigs) {
+			continue
+		}
+		log.Println("Exporting action type:", at.ID)
+		if err := exportActionType(at, actionsDir, format); err != nil {
+			utils.UpdateFailureSummary(utils.ACTIONS, at.ID)
+			log.Printf("Error exporting action type %s: %s", at.ID, err)
+		} else {
+			utils.UpdateSuccessSummary(utils.ACTIONS, utils.EXPORT)
+			log.Println("Action type exported successfully:", at.ID)
+		}
+	}
+}
+
+func exportActionType(actionType actionType, parentDir, format string) error {
+
+	actions, err := getActionsList(actionType.ID)
+	if err != nil {
+		return fmt.Errorf("error retrieving actions list: %w", err)
+	}
+
+	typeDir := filepath.Join(parentDir, actionType.ID)
+	if _, err := os.Stat(typeDir); os.IsNotExist(err) {
+		if err := os.MkdirAll(typeDir, 0700); err != nil {
+			return fmt.Errorf("error creating action type directory: %w", err)
+		}
+	} else if utils.TOOL_CONFIGS.AllowDelete {
+		utils.RemoveDeletedLocalResources(typeDir, getDeployedActionNames(actions))
+	}
+
+	for _, action := range actions {
+		if err := exportAction(actionType.ID, action.ID, action.Name, typeDir, format); err != nil {
+			return fmt.Errorf("error exporting action %s: %w", action.Name, err)
+		}
+	}
+	return nil
+}
+
+func exportAction(typeId, actionId, actionName, outputDir, formatStr string) error {
+
+	action, err := utils.GetResourceData(utils.ACTIONS, typeId+"/"+actionId)
+	if err != nil {
+		return fmt.Errorf("error getting action data: %w", err)
+	}
+
+	format := utils.FormatFromString(formatStr)
+	exportedFileName := utils.GetExportedFilePath(outputDir, actionName, format)
+
+	keywordMapping := getActionsKeywordMapping(typeId)
+	modifiedData, err := utils.ProcessExportedData(action, exportedFileName, format, keywordMapping, utils.ACTIONS)
+	if err != nil {
+		return fmt.Errorf("error processing exported data: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedData, format, utils.ACTIONS)
+	if err != nil {
+		return fmt.Errorf("error serializing action: %w", err)
+	}
+
+	if err := ioutil.WriteFile(exportedFileName, modifiedFile, 0644); err != nil {
+		return fmt.Errorf("error writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/actions/export.go
+++ b/iamctl/pkg/actions/export.go
@@ -48,36 +48,47 @@ func ExportAll(outputDirPath, format string) {
 
 	if _, err := os.Stat(actionsDir); os.IsNotExist(err) {
 		os.MkdirAll(actionsDir, 0700)
-	} else if utils.TOOL_CONFIGS.AllowDelete {
-		utils.RemoveDeletedLocalDirectories(actionsDir, getDeployedActionTypeIds(types))
 	}
 
+	var typesWithActions []string
 	for _, at := range types {
 		if utils.IsResourceExcluded(at.ID, utils.TOOL_CONFIGS.ActionConfigs) {
 			continue
 		}
-		log.Println("Exporting action type:", at.ID)
-		if err := exportActionType(at, actionsDir, format); err != nil {
+
+		hadActions, err := exportActionType(at, actionsDir, format)
+		if err != nil {
 			utils.UpdateFailureSummary(utils.ACTIONS, at.ID)
 			log.Printf("Error exporting action type %s: %s", at.ID, err)
 		} else {
-			utils.UpdateSuccessSummary(utils.ACTIONS, utils.EXPORT)
-			log.Println("Action type exported successfully:", at.ID)
+			if hadActions {
+				typesWithActions = append(typesWithActions, at.ID)
+				utils.UpdateSuccessSummary(utils.ACTIONS, utils.EXPORT)
+				log.Println("Action type exported successfully:", at.ID)
+			}
 		}
+	}
+
+	if utils.TOOL_CONFIGS.AllowDelete {
+		utils.RemoveDeletedLocalDirectories(actionsDir, typesWithActions)
 	}
 }
 
-func exportActionType(actionType actionType, parentDir, format string) error {
+func exportActionType(actionType actionType, parentDir, format string) (bool, error) {
 
 	actions, err := getActionsList(actionType.ID)
 	if err != nil {
-		return fmt.Errorf("error retrieving actions list: %w", err)
+		return false, fmt.Errorf("error retrieving actions list: %w", err)
+	}
+	if len(actions) == 0 {
+		return false, nil
 	}
 
+	log.Println("Exporting action type:", actionType.ID)
 	typeDir := filepath.Join(parentDir, actionType.ID)
 	if _, err := os.Stat(typeDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(typeDir, 0700); err != nil {
-			return fmt.Errorf("error creating action type directory: %w", err)
+			return false, fmt.Errorf("error creating action type directory: %w", err)
 		}
 	} else if utils.TOOL_CONFIGS.AllowDelete {
 		utils.RemoveDeletedLocalResources(typeDir, getDeployedActionNames(actions))
@@ -85,10 +96,10 @@ func exportActionType(actionType actionType, parentDir, format string) error {
 
 	for _, action := range actions {
 		if err := exportAction(actionType.ID, action.ID, action.Name, typeDir, format); err != nil {
-			return fmt.Errorf("error exporting action %s: %w", action.Name, err)
+			return false, fmt.Errorf("error exporting action %s: %w", action.Name, err)
 		}
 	}
-	return nil
+	return true, nil
 }
 
 func exportAction(typeId, actionId, actionName, outputDir, formatStr string) error {

--- a/iamctl/pkg/actions/export.go
+++ b/iamctl/pkg/actions/export.go
@@ -42,6 +42,10 @@ func ExportAll(outputDirPath, format string) {
 		return
 	}
 
+	if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.ActionConfigs) {
+		log.Println("Warn: Secrets exclusion cannot be disabled for actions. All secrets will be masked.")
+	}
+
 	if _, err := os.Stat(actionsDir); os.IsNotExist(err) {
 		os.MkdirAll(actionsDir, 0700)
 	} else if utils.TOOL_CONFIGS.AllowDelete {
@@ -89,16 +93,24 @@ func exportActionType(actionType actionType, parentDir, format string) error {
 
 func exportAction(typeId, actionId, actionName, outputDir, formatStr string) error {
 
-	action, err := utils.GetResourceData(utils.ACTIONS, typeId+"/"+actionId)
+	actionData, err := utils.GetResourceData(utils.ACTIONS, typeId+"/"+actionId)
 	if err != nil {
 		return fmt.Errorf("error getting action data: %w", err)
+	}
+
+	actionMap, ok := actionData.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for action data")
+	}
+	if err := processAuthProperties(actionMap); err != nil {
+		return fmt.Errorf("error processing auth properties: %w", err)
 	}
 
 	format := utils.FormatFromString(formatStr)
 	exportedFileName := utils.GetExportedFilePath(outputDir, actionName, format)
 
 	keywordMapping := getActionsKeywordMapping(typeId)
-	modifiedData, err := utils.ProcessExportedData(action, exportedFileName, format, keywordMapping, utils.ACTIONS)
+	modifiedData, err := utils.ProcessExportedData(actionMap, exportedFileName, format, keywordMapping, utils.ACTIONS)
 	if err != nil {
 		return fmt.Errorf("error processing exported data: %w", err)
 	}

--- a/iamctl/pkg/actions/export.go
+++ b/iamctl/pkg/actions/export.go
@@ -105,6 +105,9 @@ func exportAction(typeId, actionId, actionName, outputDir, formatStr string) err
 	if err := processAuthProperties(actionMap); err != nil {
 		return fmt.Errorf("error processing auth properties: %w", err)
 	}
+	if err := replaceRuleReferences(actionMap); err != nil {
+		return fmt.Errorf("error replacing rule references: %w", err)
+	}
 
 	format := utils.FormatFromString(formatStr)
 	exportedFileName := utils.GetExportedFilePath(outputDir, actionName, format)

--- a/iamctl/pkg/actions/export.go
+++ b/iamctl/pkg/actions/export.go
@@ -33,7 +33,7 @@ func ExportAll(outputDirPath, format string) {
 	log.Println("Exporting actions...")
 	actionsDir := filepath.Join(outputDirPath, utils.ACTIONS.String())
 
-	if utils.IsResourceTypeExcluded(utils.ACTIONS) {
+	if !utils.IsEntitySupportedInVersion(utils.ACTIONS) || utils.IsResourceTypeExcluded(utils.ACTIONS) {
 		return
 	}
 	types, err := getActionTypesList()

--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.com).
+ *
+ * WSO2 LLC. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package actions
+
+func ImportAll(inputDirPath string) {
+}

--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -115,6 +115,9 @@ func importAction(typeName, actionId, actionName, filePath string) error {
 	if err != nil {
 		return fmt.Errorf("error when deserializing action data: %w", err)
 	}
+	if err := replaceRuleReferences(actionMap); err != nil {
+		return fmt.Errorf("error replacing rule references: %w", err)
+	}
 
 	status, ok := actionMap["status"].(string)
 	if !ok {

--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -19,6 +19,7 @@
 package actions
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -87,8 +88,8 @@ func importActionType(importFilePath, typeName string) error {
 		fileInfo := utils.GetFileInfo(actionFilePath)
 		actionName := fileInfo.ResourceName
 
-		existing := isActionExists(actionName, deployed)
-		err := importAction(typeName, actionName, actionFilePath, existing)
+		actionId := getActionId(actionName, deployed)
+		err := importAction(typeName, actionId, actionName, actionFilePath)
 		if err != nil {
 			return fmt.Errorf("error importing action %s: %w", actionName, err)
 		}
@@ -96,7 +97,7 @@ func importActionType(importFilePath, typeName string) error {
 	return nil
 }
 
-func importAction(typeName, actionName, filePath string, existing *action) error {
+func importAction(typeName, actionId, actionName, filePath string) error {
 
 	format, err := utils.FormatFromExtension(filepath.Ext(filePath))
 	if err != nil {
@@ -110,18 +111,24 @@ func importAction(typeName, actionName, filePath string, existing *action) error
 	keywordMapping := getActionsKeywordMapping(typeName)
 	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), keywordMapping)
 
-	actionMap, err := utils.DeserializeToMap([]byte(modifiedFileData), format, utils.ACTIONS, "id", "type", "status", "createdAt", "updatedAt")
+	actionMap, err := utils.DeserializeToMap([]byte(modifiedFileData), format, utils.ACTIONS, "id", "type", "createdAt", "updatedAt")
 	if err != nil {
 		return fmt.Errorf("error when deserializing action data: %w", err)
 	}
 
-	if existing == nil {
-		return createAction(typeName, actionName, actionMap)
+	status, ok := actionMap["status"].(string)
+	if !ok {
+		return fmt.Errorf("unexpected format for status field")
 	}
-	return updateAction(typeName, actionName, existing.ID, actionMap)
+	delete(actionMap, "status")
+
+	if actionId == "" {
+		return createAction(typeName, actionName, status, actionMap)
+	}
+	return updateAction(typeName, actionId, actionName, status, actionMap)
 }
 
-func createAction(typeName, actionName string, actionMap map[string]interface{}) error {
+func createAction(typeName, actionName, status string, actionMap map[string]interface{}) error {
 
 	log.Printf("Creating new action: %s of type %s", actionName, typeName)
 
@@ -137,12 +144,25 @@ func createAction(typeName, actionName string, actionMap map[string]interface{})
 	}
 	defer resp.Body.Close()
 
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("error reading create response: %w", err)
+	}
+	var created action
+	if err := json.Unmarshal(respBody, &created); err != nil {
+		return fmt.Errorf("error parsing create response: %w", err)
+	}
+
+	if err := setActionStatus(typeName, created.ID, status); err != nil {
+		return fmt.Errorf("error setting action status: %w", err)
+	}
+
 	utils.UpdateSuccessSummary(utils.ACTIONS, utils.IMPORT)
 	log.Println("Action imported successfully.")
 	return nil
 }
 
-func updateAction(typeName, actionName, actionId string, actionMap map[string]interface{}) error {
+func updateAction(typeName, actionId, actionName, status string, actionMap map[string]interface{}) error {
 
 	log.Printf("Updating action: %s of type %s", actionName, typeName)
 
@@ -156,6 +176,10 @@ func updateAction(typeName, actionName, actionId string, actionMap map[string]in
 		return fmt.Errorf("error when updating action: %w", err)
 	}
 	defer resp.Body.Close()
+
+	if err := setActionStatus(typeName, actionId, status); err != nil {
+		return fmt.Errorf("error setting action status: %w", err)
+	}
 
 	utils.UpdateSuccessSummary(utils.ACTIONS, utils.UPDATE)
 	log.Println("Action updated successfully.")

--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -34,7 +34,7 @@ func ImportAll(inputDirPath string) {
 	log.Println("Importing actions...")
 	importFilePath := filepath.Join(inputDirPath, utils.ACTIONS.String())
 
-	if utils.IsResourceTypeExcluded(utils.ACTIONS) {
+	if !utils.IsEntitySupportedInVersion(utils.ACTIONS) || utils.IsResourceTypeExcluded(utils.ACTIONS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {

--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -18,5 +18,172 @@
 
 package actions
 
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
 func ImportAll(inputDirPath string) {
+
+	log.Println("Importing actions...")
+	importFilePath := filepath.Join(inputDirPath, utils.ACTIONS.String())
+
+	if utils.IsResourceTypeExcluded(utils.ACTIONS) {
+		return
+	}
+	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
+		log.Println("No actions to import.")
+		return
+	}
+
+	typeFolders, err := ioutil.ReadDir(importFilePath)
+	if err != nil {
+		log.Println("Error reading action type directories: ", err)
+		return
+	}
+
+	for _, typeFolder := range typeFolders {
+		if !typeFolder.IsDir() {
+			continue
+		}
+		typeName := typeFolder.Name()
+
+		if !utils.IsResourceExcluded(typeName, utils.TOOL_CONFIGS.ActionConfigs) {
+			err := importActionType(importFilePath, typeName)
+			if err != nil {
+				utils.UpdateFailureSummary(utils.ACTIONS, typeName)
+				log.Printf("Error importing action type %s: %s", typeName, err)
+			}
+		}
+	}
+}
+
+func importActionType(importFilePath, typeName string) error {
+
+	typeDir := filepath.Join(importFilePath, typeName)
+
+	deployed, err := getActionsList(typeName)
+	if err != nil {
+		return fmt.Errorf("error retrieving deployed action list: %w", err)
+	}
+	localFiles, err := ioutil.ReadDir(typeDir)
+	if err != nil {
+		return fmt.Errorf("error reading action type directory: %w", err)
+	}
+
+	if utils.TOOL_CONFIGS.AllowDelete {
+		if err := removeDeletedDeployedActions(typeName, localFiles, deployed); err != nil {
+			return fmt.Errorf("error removing deleted deployed actions: %w", err)
+		}
+	}
+
+	for _, file := range localFiles {
+		actionFilePath := filepath.Join(typeDir, file.Name())
+		fileInfo := utils.GetFileInfo(actionFilePath)
+		actionName := fileInfo.ResourceName
+
+		existing := isActionExists(actionName, deployed)
+		err := importAction(typeName, actionName, actionFilePath, existing)
+		if err != nil {
+			return fmt.Errorf("error importing action %s: %w", actionName, err)
+		}
+	}
+	return nil
+}
+
+func importAction(typeName, actionName, filePath string, existing *action) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(filePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format: %w", err)
+	}
+	fileBytes, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("error when reading the file: %w", err)
+	}
+
+	keywordMapping := getActionsKeywordMapping(typeName)
+	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), keywordMapping)
+
+	actionMap, err := utils.DeserializeToMap([]byte(modifiedFileData), format, utils.ACTIONS, "id", "type", "status", "createdAt", "updatedAt")
+	if err != nil {
+		return fmt.Errorf("error when deserializing action data: %w", err)
+	}
+
+	if existing == nil {
+		return createAction(typeName, actionName, actionMap)
+	}
+	return updateAction(typeName, actionName, existing.ID, actionMap)
+}
+
+func createAction(typeName, actionName string, actionMap map[string]interface{}) error {
+
+	log.Printf("Creating new action: %s of type %s", actionName, typeName)
+
+	delete(actionMap, "version")
+	jsonBody, err := utils.Serialize(actionMap, utils.FormatJSON, utils.ACTIONS)
+	if err != nil {
+		return fmt.Errorf("error when serializing action data: %w", err)
+	}
+
+	resp, err := utils.SendPostRequest(utils.ACTIONS, jsonBody, utils.WithPathSuffix(typeName))
+	if err != nil {
+		return fmt.Errorf("error when importing action: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.ACTIONS, utils.IMPORT)
+	log.Println("Action imported successfully.")
+	return nil
+}
+
+func updateAction(typeName, actionName, actionId string, actionMap map[string]interface{}) error {
+
+	log.Printf("Updating action: %s of type %s", actionName, typeName)
+
+	jsonBody, err := utils.Serialize(actionMap, utils.FormatJSON, utils.ACTIONS)
+	if err != nil {
+		return fmt.Errorf("error when serializing action data: %w", err)
+	}
+
+	resp, err := utils.SendPatchRequest(utils.ACTIONS, typeName+"/"+actionId, jsonBody)
+	if err != nil {
+		return fmt.Errorf("error when updating action: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.ACTIONS, utils.UPDATE)
+	log.Println("Action updated successfully.")
+	return nil
+}
+
+func removeDeletedDeployedActions(typeName string, localFiles []os.FileInfo, deployed []action) error {
+
+	if len(deployed) == 0 {
+		return nil
+	}
+
+	localResourceNames := make(map[string]struct{})
+	for _, file := range localFiles {
+		resourceName := utils.GetFileInfo(file.Name()).ResourceName
+		localResourceNames[resourceName] = struct{}{}
+	}
+
+	for _, action := range deployed {
+		if _, existsLocally := localResourceNames[action.Name]; existsLocally {
+			continue
+		}
+		log.Printf("Action: %s of type %s not found locally. Deleting action.\n", action.Name, typeName)
+		if err := utils.SendDeleteRequest(typeName+"/"+action.ID, utils.ACTIONS); err != nil {
+			return fmt.Errorf("error deleting action: %s. %w", action.Name, err)
+		} else {
+			utils.UpdateSuccessSummary(utils.ACTIONS, utils.DELETE)
+		}
+	}
+	return nil
 }

--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -42,10 +42,18 @@ func ImportAll(inputDirPath string) {
 		return
 	}
 
+	deployedTypes, err := getActionTypesList()
+	if err != nil {
+		log.Println("Error retrieving action types list:", err)
+	}
 	typeFolders, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
 		log.Println("Error reading action type directories: ", err)
 		return
+	}
+
+	if utils.TOOL_CONFIGS.AllowDelete {
+		removeDeletedDeployedActionTypes(typeFolders, deployedTypes)
 	}
 
 	for _, typeFolder := range typeFolders {
@@ -187,6 +195,35 @@ func updateAction(typeName, actionId, actionName, status string, actionMap map[s
 	utils.UpdateSuccessSummary(utils.ACTIONS, utils.UPDATE)
 	log.Println("Action updated successfully.")
 	return nil
+}
+
+func removeDeletedDeployedActionTypes(localDirs []os.FileInfo, deployedTypes []actionType) {
+
+	localDirNames := make(map[string]struct{})
+	for _, dir := range localDirs {
+		if dir.IsDir() {
+			localDirNames[dir.Name()] = struct{}{}
+		}
+	}
+
+	for _, deployedType := range deployedTypes {
+		if _, existsLocally := localDirNames[deployedType.ID]; existsLocally {
+			continue
+		}
+		if utils.IsResourceExcluded(deployedType.ID, utils.TOOL_CONFIGS.ActionConfigs) {
+			log.Printf("Action type: %s is excluded from deletion.", deployedType.ID)
+			continue
+		}
+		actions, err := getActionsList(deployedType.ID)
+		if err != nil {
+			log.Printf("Error retrieving deployed actions for type %s: %s", deployedType.ID, err)
+			continue
+		}
+		if err := removeDeletedDeployedActions(deployedType.ID, nil, actions); err != nil {
+			utils.UpdateFailureSummary(utils.ACTIONS, deployedType.ID)
+			log.Printf("Error deleting actions for type %s: %s", deployedType.ID, err)
+		}
+	}
 }
 
 func removeDeletedDeployedActions(typeName string, localFiles []os.FileInfo, deployed []action) error {

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -48,6 +48,10 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 		return
 	}
 
+	if resType == utils.EMAIL_PROVIDERS && !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.EmailProviderConfigs) {
+		log.Println("Warn: Secrets exclusion cannot be disabled for email providers. All secrets will be masked.")
+	}
+
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		os.MkdirAll(exportFilePath, 0700)
 	} else {

--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -135,10 +135,6 @@ func processAuthSecrets(resType utils.ResourceType, data interface{}) (interface
 
 	switch resType {
 	case utils.EMAIL_PROVIDERS:
-		if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.EmailProviderConfigs) {
-			log.Printf("Warn: Secrets exclusion cannot be disabled for Email Providers. All secrets will be masked.")
-		}
-
 		authType, ok = providerMap["authType"].(string)
 		if !ok {
 			return nil, fmt.Errorf("unexpected format for authType")
@@ -159,7 +155,7 @@ func processAuthSecrets(resType utils.ResourceType, data interface{}) (interface
 		}
 
 		if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.SmsProviderConfigs) {
-			log.Printf("Warn: Secrets exclusion cannot be disabled for Custom SMS Providers. All secrets will be masked.")
+			log.Printf("Warn: Secrets exclusion cannot be disabled for Custom sms providers. All secrets will be masked.")
 		}
 		delete(providerMap, "secret")
 

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -622,6 +622,8 @@ func getResourcePath(resourceType ResourceType) string {
 		return "notification-senders/sms"
 	case SMS_TEMPLATES:
 		return "notification/sms/template-types"
+	case ACTIONS:
+		return "actions"
 	}
 	return ""
 }

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -36,6 +36,7 @@ const API_RESOURCES_CONFIG = "API_RESOURCES"
 const VALIDATION_RULES_CONFIG = "VALIDATION_RULES"
 const EMAIL_PROVIDERS_CONFIG = "EMAIL_PROVIDERS"
 const SMS_PROVIDERS_CONFIG = "SMS_PROVIDERS"
+const ACTIONS_CONFIG = "ACTIONS"
 
 // Tool configs
 const EXCLUDE_CONFIG = "EXCLUDE"
@@ -80,6 +81,7 @@ const (
 	EMAIL_PROVIDERS       ResourceType = "EmailProviders"
 	SMS_PROVIDERS         ResourceType = "SmsProviders"
 	SMS_TEMPLATES         ResourceType = "SmsTemplates"
+	ACTIONS               ResourceType = "Actions"
 )
 
 // Sub resource types

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -247,6 +247,12 @@ var notificationProviderArrayIdentifiers = map[string]string{
 	"SmsProviders":   "name",
 }
 
+var actionArrayIdentifiers = map[string]string{
+
+	"rules":       "condition",
+	"expressions": "field",
+}
+
 type ResourceIdentifierMeta struct {
 	IdentifierPath  string // Path to the ID field in the resource object
 	UniqueValuePath string // Path to the unique identifier field

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -46,7 +46,8 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_validation_rule_mgt_update internal_governance_view internal_governance_update " +
 	"internal_organization_view " +
 	"internal_notification_senders_view internal_notification_senders_create internal_notification_senders_update internal_notification_senders_delete " +
-	"internal_template_mgt_view internal_template_mgt_create internal_template_mgt_update internal_template_mgt_delete"
+	"internal_template_mgt_view internal_template_mgt_create internal_template_mgt_update internal_template_mgt_delete " +
+	"internal_action_mgt_view internal_action_mgt_create internal_action_mgt_update internal_action_mgt_delete"
 
 const (
 	AppName       = "IAM-CTL"

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -206,6 +206,8 @@ func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 		return applicationAuthorizedApiArrayIdentifiers
 	case EMAIL_PROVIDERS, SMS_PROVIDERS:
 		return notificationProviderArrayIdentifiers
+	case ACTIONS:
+		return actionArrayIdentifiers
 	default:
 		return make(map[string]string)
 	}

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -42,5 +42,5 @@ var ResourceOrder = []ResourceType{
 	CERTIFICATES,
 	WORKFLOWS, // Dependency: Roles
 	VALIDATION_RULES,
-	ACTIONS, // Dependency: Applications
+	ACTIONS, // Dependency: Applications, Claims
 }

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -42,4 +42,5 @@ var ResourceOrder = []ResourceType{
 	CERTIFICATES,
 	WORKFLOWS, // Dependency: Roles
 	VALIDATION_RULES,
+	ACTIONS, // Dependency: Applications
 }

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -71,6 +71,7 @@ type ToolConfigs struct {
 	EmailProviderConfigs       map[string]interface{} `json:"EMAIL_PROVIDERS"`
 	SmsProviderConfigs         map[string]interface{} `json:"SMS_PROVIDERS"`
 	SmsTemplateConfigs         map[string]interface{} `json:"SMS_TEMPLATES"`
+	ActionConfigs              map[string]interface{} `json:"ACTIONS"`
 }
 
 type KeywordConfigs struct {
@@ -92,6 +93,7 @@ type KeywordConfigs struct {
 	EmailProviderConfigs       map[string]interface{} `json:"EMAIL_PROVIDERS"`
 	SmsProviderConfigs         map[string]interface{} `json:"SMS_PROVIDERS"`
 	SmsTemplateConfigs         map[string]interface{} `json:"SMS_TEMPLATES"`
+	ActionConfigs              map[string]interface{} `json:"ACTIONS"`
 }
 
 var SERVER_CONFIGS ServerConfigs

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -28,6 +28,7 @@ const (
 	MIN_VERSION_EMAIL_PROVIDERS             = "7.2.0"
 	MIN_VERSION_SMS_PROVIDERS               = "7.2.0"
 	MIN_VERSION_SMS_TEMPLATES               = "7.1.0"
+	MIN_VERSION_ACTIONS                     = "7.1.0"
 )
 
 var EntityMinVersionRequirements = map[ResourceType]string{
@@ -38,6 +39,7 @@ var EntityMinVersionRequirements = map[ResourceType]string{
 	EMAIL_PROVIDERS:             MIN_VERSION_EMAIL_PROVIDERS,
 	SMS_PROVIDERS:               MIN_VERSION_SMS_PROVIDERS,
 	SMS_TEMPLATES:               MIN_VERSION_SMS_TEMPLATES,
+	ACTIONS:                     MIN_VERSION_ACTIONS,
 }
 
 // Maximum supported WSO2 Identity Server version for each resource type.


### PR DESCRIPTION
## Purpose                                         
                                                                                                                                                           
  Add export/import support for the Actions resource type. Actions are extensibility hooks that attach to specific Identity Server flow types (`PRE_ISSUE_ACCESS_TOKEN`, `PRE_ISSUE_ID_TOKEN`, `PRE_UPDATE_PASSWORD`, `PRE_UPDATE_PROFILE`) and point at an external HTTPS endpoint with optional authentication and a conditional rule. The implementation handles secret masking, status lifecycle separation, two-level API hierarchy, and in-rule application reference translation.                        

  Related to https://github.com/wso2-enterprise/iam-product-management/issues/662                                                                                                                                                 
  Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/76

  ## Goals

  - Export and import actions via the IS action management REST APIs, grouped by flow type
  - Mask auth endpoint properties on export since the server never returns them in GET responses; inject type-aware placeholder blocks so files can be re-imported
  - Sync action status via separate `/activate` and `/deactivate` calls after every create/update, since PATCH/POST schemas do not accept a `status` field
  - Derive action type identifiers from the `self` URL returned by the `/actions/types` endpoint rather than maintaining a hardcoded enum
  - Translate `field=application` expression values in action rules between server UUIDs (exported) and portable names (local files) using rule walk                                                                                                                                                
  - Strip server-assigned fields (`id`, `type`, `createdAt`, `updatedAt`) on import; strip `version` only on create, keep it on update
  - Remove stale local type folders on export (when `AllowDelete`) if a type has no deployed actions and delete all deployed actions on import (when `AllowDelete`) if a type folder is absent locally
  - Gate the resource on IS 7.1.0 via `IsEntitySupportedInVersion`                                                                                         
                                                                                                                                                           
  ## Approach                                                                                                                                              
                                                                                                                                                           
  ### Two-level hierarchy         

  The IS actions API is two levels deep: `/actions/types` returns the set of implemented flow types, and `/actions/{actionType}` lists the actions within that type. This maps to a folder-per-flow-type / file-per-action layout. Include/exclude is at the action-type level, matching the user expectation of skipping whole flows rather than individual actions.                                                                    
                                                            
  Action type identifiers (used as folder names and API path segments) are extracted from the `self` field of each type entry using `path.Base`. No enum mapping. New flow types the server adds will be picked up automatically without code changes.
                                                                                                                                                           
  ### Secret masking forced on export                       

  The server strips `endpoint.authentication.properties` entirely from GET responses regardless of auth type. Re-importing a file without a properties block causes the API to reject the request. `processAuthProperties` inspects `endpoint.authentication.type` after fetch and injects a type-specific placeholder block:                                                                                                                                       
                                                            
  | Auth type | Injected keys |
  |-----------|---------------|
  | `NONE` | empty map |                                                                                                                                   
  | `BASIC` | `username`, `password` |
  | `BEARER` | `accessToken` |                                                                                                                             
  | `API_KEY` | `header`, `value` |                                                                                                                        
  
  All values are set to `SENSITIVE_FIELD_MASK_WITHOUT_QUOTES` (`********`). Keyword mapping runs after injection, so users can map placeholders to `{{MY_SECRET}}` references in `keywordConfig.json`. Secrets exclusion cannot be disabled for actions. There is no server path to retrieve real values.
                                                                                                                                                           
  ### Status sync as a separate always-send operation       

  Neither POST nor PATCH accepts a `status` field. To make the server reflect the file's `status`, `importAction` extracts status from the deserialized map, deletes it before serializing the request body, then calls `setActionStatus` after every create or update unconditionally. `setActionStatus` POSTs to `{typeName}/{actionId}/activate` or `{typeName}/{actionId}/deactivate` depending on the value.

  `version` follows a parallel pattern: stripped from the body before POST (server rejects it on create) but kept for PATCH (server accepts it on update). The create response body is parsed to obtain the new action's ID before the activate/deactivate call is issued.
                                                                                                                                                           
  ### Reference translation in rules                                                                                                
  
  Action rules use the shape `rule.rules[*].expressions[*]`, where only expressions with `field == "application"` hold app UUIDs that need translation. The existing `ReplaceReferences` utility cannot handle this because the outer `rules` array has no unique key per element and the inner `expressions` array is heterogeneous.                                                                                                                                        
                                                            
As a solution `replaceRuleReferences` in `actionUtils.go` walks the rule tree, skips non-application expressions, and looks up values in `GetResourceIdentifierMap(APPLICATIONS)`, which holds `id→name` during export and `name→id` during import, using the same map populated by the applications package. `ResourceOrder` already places `APPLICATIONS` before `ACTIONS`, so the map is populated in both directions before actions run.

  When a local file has no `rule` field, `replaceRuleReferences` injects `rule: {}` into the action map before returning. This causes the PATCH body to include `"rule": {}`, which clears any existing server-side rule.

### Stale type folder cleanup                                                                                                                                                                                       

  On export, `exportActionType` returns a boolean indicating whether the type had any deployed actions. `ExportAll` accumulates only the non-empty type IDs into `typesWithActions` and calls `RemoveDeletedLocalDirectories` after the loop, so local folders for types that are empty or no longer present on the server are pruned.
                                                                                                                                                                                                                        
  On import, when `AllowDelete` is set, `removeDeletedDeployedActionTypes` compares deployed types against local folders. For any deployed type with no matching local folder, it fetches the type's action list and deletes each action individually.

  ## User Stories

  As a system administrator, I want to export and import action definitions using IAM-CTL to enable version control and maintain consistent IAM configurations.
                                                                                                                                                           
  ## Release Note                                           

  Added Action management support to IAM-CTL tool.

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added export and import support for Workflows, API Resources, Actions, and Validation Rules.
  * Added support for managing email and SMS notification providers.
  * Added SMS template export and import functionality.
  * Added export and import capabilities for Application Authorized APIs.
  * Added Organizations support for current organization identification.
  * Enhanced application export/import with multi-format support and improved role handling.

* **Bug Fixes**
  * Fixed HTTP response handling in import operations to properly close response bodies.
  * Improved multi-format data processing for better compatibility across YAML and JSON formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->