### PR TITLE
Add support for Organizations resource type

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -33,6 +33,7 @@ import (
 	notificationProviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationProviders"
 	notificationTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationTemplates"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
+	organizations "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/organizations"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
 	userstores "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/userStores"
@@ -74,6 +75,7 @@ var exportAllCmd = &cobra.Command{
 			utils.SMS_PROVIDERS:         notificationProviders.ExportAllSmsProviders,
 			utils.SMS_TEMPLATES:         notificationTemplates.ExportAllSmsTemplates,
 			utils.ACTIONS:               actions.ExportAll,
+			utils.ORGANIZATIONS:         organizations.ExportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -33,6 +33,7 @@ import (
 	notificationProviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationProviders"
 	notificationTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationTemplates"
 	oidcScopes "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/oidcScopes"
+	organizations "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/organizations"
 	roles "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	scriptLibraries "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/scriptLibraries"
 	userstores "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/userStores"
@@ -73,6 +74,7 @@ var importAllCmd = &cobra.Command{
 			utils.SMS_PROVIDERS:         notificationProviders.ImportAllSmsProviders,
 			utils.SMS_TEMPLATES:         notificationTemplates.ImportAllSmsTemplates,
 			utils.ACTIONS:               actions.ImportAll,
+			utils.ORGANIZATIONS:         organizations.ImportAll,
 		}
 
 		for _, resourceType := range utils.ResourceOrder {

--- a/iamctl/pkg/organizations/export.go
+++ b/iamctl/pkg/organizations/export.go
@@ -1,0 +1,97 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package organizations
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ExportAll(exportFilePath string, format string) {
+
+	log.Println("Exporting organizations...")
+	exportFilePath = filepath.Join(exportFilePath, utils.ORGANIZATIONS.String())
+
+	if utils.IsResourceTypeExcluded(utils.ORGANIZATIONS) {
+		return
+	}
+	orgs, err := getOrganizationList()
+	if err != nil {
+		log.Println("Error retrieving organizations list:", err)
+		return
+	}
+
+	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
+		os.MkdirAll(exportFilePath, 0700)
+	} else {
+		if utils.TOOL_CONFIGS.AllowDelete {
+			deployedHandles := getDeployedOrganizationHandles(orgs)
+			utils.RemoveDeletedLocalResources(exportFilePath, deployedHandles)
+		}
+	}
+
+	for _, org := range orgs {
+		if !utils.IsResourceExcluded(org.OrgHandle, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			log.Println("Exporting organization: ", org.OrgHandle)
+
+			err := exportOrganization(org.Id, org.OrgHandle, exportFilePath, format)
+			if err != nil {
+				utils.UpdateFailureSummary(utils.ORGANIZATIONS, org.OrgHandle)
+				log.Printf("Error while exporting organization: %s. %s", org.OrgHandle, err)
+			} else {
+				utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.EXPORT)
+				log.Println("Organization exported successfully: ", org.OrgHandle)
+			}
+		}
+	}
+}
+
+func exportOrganization(orgId, orgHandle, outputDirPath, formatString string) error {
+
+	org, err := utils.GetResourceData(utils.ORGANIZATIONS, orgId)
+	if err != nil {
+		return fmt.Errorf("error while getting organization: %w", err)
+	}
+
+	format := utils.FormatFromString(formatString)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, orgHandle, format)
+
+	orgKeywordMapping := getOrganizationKeywordMapping(orgHandle)
+	modifiedOrg, err := utils.ProcessExportedData(org, exportedFileName, format, orgKeywordMapping, utils.ORGANIZATIONS)
+	if err != nil {
+		return fmt.Errorf("error while processing exported content: %w", err)
+	}
+
+	modifiedFile, err := utils.Serialize(modifiedOrg, format, utils.ORGANIZATIONS)
+	if err != nil {
+		return fmt.Errorf("error while serializing organization: %w", err)
+	}
+
+	err = ioutil.WriteFile(exportedFileName, modifiedFile, 0644)
+	if err != nil {
+		return fmt.Errorf("error when writing exported content to file: %w", err)
+	}
+
+	return nil
+}

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -19,6 +19,7 @@
 package organizations
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -102,23 +103,29 @@ func createOrganization(requestBody []byte, format utils.Format, orgHandle strin
 
 	log.Println("Creating new organization: " + orgHandle)
 
-	orgData, err := utils.DeserializeToMap(requestBody, format, utils.ORGANIZATIONS,
-		"id", "parent", "version", "status", "permissions", "created", "lastModified", "hasChildren", "ancestorPath")
+	jsonBody, status, err := prepareOrganizationPostBody(requestBody, format, curOrgId)
 	if err != nil {
-		return fmt.Errorf("error deserializing organization: %w", err)
-	}
-
-	orgData["parentId"] = curOrgId
-	jsonBody, err := utils.Serialize(orgData, utils.FormatJSON, utils.ORGANIZATIONS)
-	if err != nil {
-		return fmt.Errorf("error serializing to JSON: %w", err)
+		return err
 	}
 
 	resp, err := utils.SendPostRequest(utils.ORGANIZATIONS, jsonBody)
 	if err != nil {
 		return fmt.Errorf("error when creating organization: %w", err)
 	}
-	defer resp.Body.Close()
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	if err != nil {
+		return fmt.Errorf("error reading create response: %w", err)
+	}
+	var createdOrg organization
+	if err := json.Unmarshal(respBody, &createdOrg); err != nil {
+		return fmt.Errorf("error parsing create response: %w", err)
+	}
+
+	if err := patchOrganizationStatus(createdOrg.Id, status); err != nil {
+		return fmt.Errorf("error updating status field: %w", err)
+	}
 
 	utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.IMPORT)
 	log.Println("Organization created successfully.")

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -1,0 +1,166 @@
+/**
+* Copyright (c) 2026, WSO2 LLC. (https://www.wso2.com).
+*
+* WSO2 LLC. licenses this file to you under the Apache License,
+* Version 2.0 (the "License"); you may not use this file except
+* in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied. See the License for the
+* specific language governing permissions and limitations
+* under the License.
+ */
+
+package organizations
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
+)
+
+func ImportAll(inputDirPath string) {
+
+	log.Println("Importing organizations...")
+	importFilePath := filepath.Join(inputDirPath, utils.ORGANIZATIONS.String())
+
+	if utils.IsResourceTypeExcluded(utils.ORGANIZATIONS) {
+		return
+	}
+	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
+		log.Println("No organizations to import.")
+		return
+	}
+
+	existingList, err := getOrganizationList()
+	if err != nil {
+		log.Println("Error retrieving the deployed organization list: ", err)
+		return
+	}
+	files, err := ioutil.ReadDir(importFilePath)
+	if err != nil {
+		log.Println("Error reading local organization  files: ", err)
+		return
+	}
+	if utils.TOOL_CONFIGS.AllowDelete {
+		removeDeletedDeployedOrganizations(files, existingList)
+	}
+
+	for _, file := range files {
+		orgFilePath := filepath.Join(importFilePath, file.Name())
+		fileInfo := utils.GetFileInfo(orgFilePath)
+		orgHandle := fileInfo.ResourceName
+
+		if !utils.IsResourceExcluded(orgHandle, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			orgId := getOrgId(orgHandle, existingList)
+			err := importOrganization(orgHandle, orgId, orgFilePath)
+			if err != nil {
+				log.Println("Error importing organization: ", err)
+				utils.UpdateFailureSummary(utils.ORGANIZATIONS, orgHandle)
+			}
+		}
+	}
+}
+
+func importOrganization(orgHandle, orgId, importFilePath string) error {
+
+	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
+	if err != nil {
+		return fmt.Errorf("unsupported file format for organization: %w", err)
+	}
+
+	fileBytes, err := ioutil.ReadFile(importFilePath)
+	if err != nil {
+		return fmt.Errorf("error when reading the file for organization: %w", err)
+	}
+
+	orgKeywordMapping := getOrganizationKeywordMapping(orgHandle)
+	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), orgKeywordMapping)
+
+	if orgId == "" {
+		return createOrganization([]byte(modifiedFileData), format, orgHandle)
+	}
+	return updateOrganization(orgId, []byte(modifiedFileData), format, orgHandle)
+}
+
+func createOrganization(requestBody []byte, format utils.Format, orgHandle string) error {
+
+	log.Println("Creating new organization: " + orgHandle)
+
+	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.ORGANIZATIONS,
+		"id", "parent", "version", "status", "permissions", "created", "lastModified", "hasChildren", "ancestorPath")
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPostRequest(utils.ORGANIZATIONS, jsonBody)
+	if err != nil {
+		return fmt.Errorf("error when creating organization: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.IMPORT)
+	log.Println("Organization created successfully.")
+	return nil
+}
+
+func updateOrganization(orgId string, requestBody []byte, format utils.Format, orgHandle string) error {
+
+	log.Println("Updating organization: " + orgHandle)
+
+	updateBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.ORGANIZATIONS,
+		"id", "orgHandle", "type", "parent", "permissions", "created", "lastModified", "hasChildren", "ancestorPath")
+	if err != nil {
+		return err
+	}
+
+	resp, err := utils.SendPutRequest(utils.ORGANIZATIONS, orgId, updateBody)
+	if err != nil {
+		return fmt.Errorf("error when updating organization: %w", err)
+	}
+	defer resp.Body.Close()
+
+	utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.UPDATE)
+	log.Println("Organization updated successfully.")
+	return nil
+}
+
+func removeDeletedDeployedOrganizations(localFiles []os.FileInfo, deployedOrgs []organization) {
+
+	if len(deployedOrgs) == 0 {
+		return
+	}
+
+	localResourceNames := make(map[string]struct{})
+	for _, file := range localFiles {
+		resourceName := utils.GetFileInfo(file.Name()).ResourceName
+		localResourceNames[resourceName] = struct{}{}
+	}
+
+	for _, org := range deployedOrgs {
+		if _, existsLocally := localResourceNames[org.OrgHandle]; existsLocally {
+			continue
+		}
+		if utils.IsResourceExcluded(org.OrgHandle, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			log.Println("Organization is excluded from deletion:", org.OrgHandle)
+			continue
+		}
+
+		log.Printf("Organization: %s not found locally. Deleting organization.\n", org.OrgHandle)
+		if err := utils.SendDeleteRequest(org.Id, utils.ORGANIZATIONS); err != nil {
+			utils.UpdateFailureSummary(utils.ORGANIZATIONS, org.OrgHandle)
+			log.Println("Error deleting organization:", org.OrgHandle, err)
+		} else {
+			utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.DELETE)
+		}
+	}
+}

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -48,9 +48,15 @@ func ImportAll(inputDirPath string) {
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error reading local organization  files: ", err)
+		log.Println("Error reading local organization files: ", err)
 		return
 	}
+	curOrgId, err = GetCurrentOrganizationId()
+	if err != nil {
+		log.Println("error while retrieving current organization ID")
+		return
+	}
+
 	if utils.TOOL_CONFIGS.AllowDelete {
 		removeDeletedDeployedOrganizations(files, existingList)
 	}
@@ -96,10 +102,16 @@ func createOrganization(requestBody []byte, format utils.Format, orgHandle strin
 
 	log.Println("Creating new organization: " + orgHandle)
 
-	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.ORGANIZATIONS,
+	orgData, err := utils.DeserializeToMap(requestBody, format, utils.ORGANIZATIONS,
 		"id", "parent", "version", "status", "permissions", "created", "lastModified", "hasChildren", "ancestorPath")
 	if err != nil {
-		return err
+		return fmt.Errorf("error deserializing organization: %w", err)
+	}
+
+	orgData["parentId"] = curOrgId
+	jsonBody, err := utils.Serialize(orgData, utils.FormatJSON, utils.ORGANIZATIONS)
+	if err != nil {
+		return fmt.Errorf("error serializing to JSON: %w", err)
 	}
 
 	resp, err := utils.SendPostRequest(utils.ORGANIZATIONS, jsonBody)

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -96,3 +96,13 @@ func getOrganizationKeywordMapping(orgHandle string) map[string]interface{} {
 	}
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }
+
+func getOrgId(orgHandle string, list []organization) string {
+
+	for _, o := range list {
+		if o.OrgHandle == orgHandle {
+			return o.Id
+		}
+	}
+	return ""
+}

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -79,7 +79,7 @@ func getOrganizationList() ([]organization, error) {
 	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
 		return nil, fmt.Errorf("Status code: %d, Error: %s", statusCode, error)
 	}
-	return nil, fmt.Errorf("unknown error while retrieving  list")
+	return nil, fmt.Errorf("unknown error while retrieving list")
 }
 
 func getDeployedOrganizationHandles(orgs []organization) []string {

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -19,14 +19,22 @@
 package organizations
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
 type organization struct {
-	Id   string `json:"id"`
-	Name string `json:"name"`
+	Id        string `json:"id"`
+	Name      string `json:"name"`
+	OrgHandle string `json:"orgHandle"`
+	Status    string `json:"status"`
+}
+
+type organizationsResponse struct {
+	Organizations []organization `json:"organizations"`
 }
 
 func GetCurrentOrganizationId() (id string, err error) {
@@ -41,4 +49,50 @@ func GetCurrentOrganizationId() (id string, err error) {
 		return "", fmt.Errorf("error while deserializing JSON response: %w", err)
 	}
 	return curOrg.Id, nil
+}
+
+func getOrganizationList() ([]organization, error) {
+
+	resp, err := utils.SendGetListRequest(utils.ORGANIZATIONS, -1,
+		utils.WithQueryParams(map[string]string{"recursive": "false"}))
+	if err != nil {
+		return nil, fmt.Errorf("error while retrieving list. %w", err)
+	}
+	defer resp.Body.Close()
+
+	statusCode := resp.StatusCode
+	if statusCode == 200 {
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error when reading the retrieved list. %w", err)
+		}
+
+		var wrapper organizationsResponse
+		err = json.Unmarshal(body, &wrapper)
+		if err != nil {
+			return nil, fmt.Errorf("error when unmarshalling the retrieved list. %w", err)
+		}
+		return wrapper.Organizations, nil
+
+	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
+		return nil, fmt.Errorf("Status code: %d, Error: %s", statusCode, error)
+	}
+	return nil, fmt.Errorf("unknown error while retrieving  list")
+}
+
+func getDeployedOrganizationHandles(orgs []organization) []string {
+
+	var handles []string
+	for _, o := range orgs {
+		handles = append(handles, o.OrgHandle)
+	}
+	return handles
+}
+
+func getOrganizationKeywordMapping(orgHandle string) map[string]interface{} {
+
+	if utils.KEYWORD_CONFIGS.OrganizationConfigs != nil {
+		return utils.ResolveAdvancedKeywordMapping(orgHandle, utils.KEYWORD_CONFIGS.OrganizationConfigs)
+	}
+	return utils.KEYWORD_CONFIGS.KeywordMappings
 }

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -37,6 +37,8 @@ type organizationsResponse struct {
 	Organizations []organization `json:"organizations"`
 }
 
+var curOrgId string
+
 func GetCurrentOrganizationId() (id string, err error) {
 
 	org, err := utils.SendGetRequest(utils.ORGANIZATIONS, "self")

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -108,3 +108,50 @@ func getOrgId(orgHandle string, list []organization) string {
 	}
 	return ""
 }
+
+func prepareOrganizationPostBody(requestBody []byte, format utils.Format, parentId string) ([]byte, interface{}, error) {
+
+	orgData, err := utils.DeserializeToMap(requestBody, format, utils.ORGANIZATIONS,
+		"id", "parent", "version", "permissions", "created", "lastModified", "hasChildren", "ancestorPath")
+	if err != nil {
+		return nil, nil, fmt.Errorf("error deserializing organization: %w", err)
+	}
+
+	orgData["parentId"] = parentId
+	status := orgData["status"]
+	delete(orgData, "status")
+
+	jsonBody, err := utils.Serialize(orgData, utils.FormatJSON, utils.ORGANIZATIONS)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error serializing to JSON: %w", err)
+	}
+	return jsonBody, status, nil
+}
+
+func patchOrganizationStatus(orgId string, rawStatus interface{}) error {
+
+	status, ok := rawStatus.(string)
+	if !ok {
+		return fmt.Errorf("unexpected format for status field")
+	}
+
+	patchBody := []map[string]string{
+		{
+			"operation": "REPLACE",
+			"path":      "/status",
+			"value":     status,
+		},
+	}
+	jsonBody, err := json.Marshal(patchBody)
+	if err != nil {
+		return fmt.Errorf("error serializing PATCH body: %w", err)
+	}
+
+	resp, err := utils.SendPatchRequest(utils.ORGANIZATIONS, orgId, jsonBody)
+	if err != nil {
+		return err
+	}
+	resp.Body.Close()
+
+	return nil
+}

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -683,7 +683,7 @@ func buildRequestUrl(requestType string, resourceType ResourceType, resourceId s
 	case DELETE:
 		reqUrl = getResourceBaseUrl(resourceType) + resourceId
 	}
-	return reqUrl
+	return strings.TrimSuffix(reqUrl, "/")
 }
 
 func addQueryParams(reqURL string, resourceType ResourceType, operation string) string {

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -37,6 +37,7 @@ const VALIDATION_RULES_CONFIG = "VALIDATION_RULES"
 const EMAIL_PROVIDERS_CONFIG = "EMAIL_PROVIDERS"
 const SMS_PROVIDERS_CONFIG = "SMS_PROVIDERS"
 const ACTIONS_CONFIG = "ACTIONS"
+const ORGANIZATIONS_CONFIG = "ORGANIZATIONS"
 
 // Tool configs
 const EXCLUDE_CONFIG = "EXCLUDE"
@@ -251,6 +252,12 @@ var actionArrayIdentifiers = map[string]string{
 
 	"rules":       "condition",
 	"expressions": "field",
+}
+
+var organizationArrayIdentifiers = map[string]string{
+
+	"attributes":   "key",
+	"ancestorPath": "id",
 }
 
 type ResourceIdentifierMeta struct {

--- a/iamctl/pkg/utils/init.go
+++ b/iamctl/pkg/utils/init.go
@@ -44,7 +44,7 @@ const SCOPE string = "internal_application_mgt_update internal_application_mgt_c
 	"internal_workflow_association_view internal_workflow_association_create internal_workflow_association_update internal_workflow_association_delete " +
 	"internal_api_resource_view internal_api_resource_create internal_api_resource_update internal_api_resource_delete " +
 	"internal_validation_rule_mgt_update internal_governance_view internal_governance_update " +
-	"internal_organization_view " +
+	"internal_organization_view internal_organization_create internal_organization_update internal_organization_delete " +
 	"internal_notification_senders_view internal_notification_senders_create internal_notification_senders_update internal_notification_senders_delete " +
 	"internal_template_mgt_view internal_template_mgt_create internal_template_mgt_update internal_template_mgt_delete " +
 	"internal_action_mgt_view internal_action_mgt_create internal_action_mgt_update internal_action_mgt_delete"

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -208,6 +208,8 @@ func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 		return notificationProviderArrayIdentifiers
 	case ACTIONS:
 		return actionArrayIdentifiers
+	case ORGANIZATIONS:
+		return organizationArrayIdentifiers
 	default:
 		return make(map[string]string)
 	}

--- a/iamctl/pkg/utils/resourceOrder.go
+++ b/iamctl/pkg/utils/resourceOrder.go
@@ -43,4 +43,5 @@ var ResourceOrder = []ResourceType{
 	WORKFLOWS, // Dependency: Roles
 	VALIDATION_RULES,
 	ACTIONS, // Dependency: Applications, Claims
+	ORGANIZATIONS,
 }

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -72,6 +72,7 @@ type ToolConfigs struct {
 	SmsProviderConfigs         map[string]interface{} `json:"SMS_PROVIDERS"`
 	SmsTemplateConfigs         map[string]interface{} `json:"SMS_TEMPLATES"`
 	ActionConfigs              map[string]interface{} `json:"ACTIONS"`
+	OrganizationConfigs        map[string]interface{} `json:"ORGANIZATIONS"`
 }
 
 type KeywordConfigs struct {
@@ -94,6 +95,7 @@ type KeywordConfigs struct {
 	SmsProviderConfigs         map[string]interface{} `json:"SMS_PROVIDERS"`
 	SmsTemplateConfigs         map[string]interface{} `json:"SMS_TEMPLATES"`
 	ActionConfigs              map[string]interface{} `json:"ACTIONS"`
+	OrganizationConfigs        map[string]interface{} `json:"ORGANIZATIONS"`
 }
 
 var SERVER_CONFIGS ServerConfigs


### PR DESCRIPTION
## Purpose                                                                                                                                                 
                                                                         
  Add export/import support for the Organizations resource type. Organizations are tenant-scoped sub-orgs in a hierarchy (each with a unique `orgHandle`, a display `name`, a `status` lifecycle, and optional `attributes`). The implementation handles parent-id resolution that is absent from GET responses, status reconciliation via a separate JSON-Patch call, and a trailing-slash quirk in the Organization Management API's authorization filter.                      
                                                                                                                                                             
  Related to https://github.com/wso2-enterprise/iam-product-management/issues/662                                                                                                                                                 
  Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/77                                                                            
  
  ## Goals                                                                                                                                                   
                  
  - Export and import first-level organizations via the IS Organization Management REST APIs                                                                 
  - Inject `parentId` into create bodies from the authenticated tenant's root org id, since GET responses omit it and exported files do not carry it
  - Sync `status` on create via a follow-up JSON-Patch call, since POST organizations rejects the `status` field              
  - Use `orgHandle` (URL/filesystem-safe, hierarchy-unique) as the file name; keep the human-readable `name` field inside file content                       
  - Keep the full GET payload verbatim in exported files; strip server-only fields only when constructing POST/PUT bodies, with separate exclude lists for create vs update                                                                                                                                                                                                                   
  - Restrict scope to first-level orgs via `recursive=false`
  - Trim the trailing slash from collection-endpoint URLs so that the Organization Management API's strict authorization filter accepts the request          
                                                                                                                                                             
  ## Approach                                                                                                                                                
                                                                                                                                                             
  ### First-level only, flat layout                                                                                                                          
   
  The list endpoint is called with `recursive=false`, so only direct children of the authenticated tenant are exported. Each org becomes a single `Organizations/<orgHandle>.yaml` file; a flat layout. `orgHandle` is used as the file name because it is unique across the hierarchy, URL-safe, and stable (PUT does not allow changing it). The display `name` field, which permits spaces and non-ASCII, lives inside file content.

  The list response is a wrapper object `{ organizations: [...], links: [...] }` rather than a bare array, so `getOrganizationList` unmarshals into an `organizationsResponse` struct and returns the inner slice.
                                                                                                                                                             
  ### `parentId` injection on create                                                                                                                         
   
 POST organizations call requires a `parentId` field, but export does not return one (the GET payload exposes a `parent` object instead). Exported files therefore never contain `parentId`, and a fresh export → import cycle would fail every create.
                                                                                                                                                             
`ImportAll` resolves the authenticated tenant's root org id once via the existing `GetCurrentOrganizationId()` helper  and stores it in a package-level `curOrgId`. `prepareOrganizationPostBody` then sets `orgData["parentId"] = curOrgId` before serialization. If the lookup fails, import bails immediately rather than proceeding with malformed bodies.   

  ### Status sync as a separate PATCH after POST                                                                                                             
                  
  POST organizations call does not accept a `status` field, so newly created orgs always land in the server's default state regardless of what the local file specifies. To reconcile, `prepareOrganizationPostBody` extracts `status` from the deserialized map and deletes it before serializing the POST body. After a successful create, `createOrganization` reads the response body to obtain the new org's id, then `patchOrganizationStatus` issues a JSON-Patch.      
                                                                                                                                                            
  Status sync runs on create only; PUT updates accept status directly in the body, so the update path uses `PrepareJSONRequestBody` with status left in.       
                  
  ### Separate exclude lists for create and update                                                                                                               
                  
  The POST and PUT schemas for Organizations are different strict subsets of the GET schema, so the two paths cannot share a single exclude list:            
   
  - POST strips `id`, `parent`, `version`, `permissions`, `created`, `lastModified`, `hasChildren`, `ancestorPath` (and `status`, handled separately above).
  - PUT strips `id`, `orgHandle`, `type`, `parent`, `permissions`, `created`, `lastModified`, `hasChildren`, `ancestorPath`.              
                                                                                                                                                     
   ### Trailing-slash fix in buildRequestUrl

  The Organization Management API's authorization filter is registered against `/api/server/v1/organizations` and rejects requests to `…/organizations/` with 403 Forbidden even when the bearer token carries the correct scopes. `buildRequestUrl` was producing the trailing-slash form for collection-endpoint POSTs (empty resourceId). Other resources' POST paths (applications, identity-providers, roles, ...) tolerate both forms, so the bug surfaced only on org create.

  `buildRequestUrl` now returns `strings.TrimSuffix(reqUrl, "/")`. The trim is a no-op for every request shape that already ends in a non-slash segment (GET/PUT/PATCH/DELETE with id, sub-resource paths), so this is safe across all existing resources.
                                                                                                                                                                                                                                                                              
  ## User Stories                                                                                                                                               
   
  As a system administrator, I want to export and import organization definitions using IAM-CTL to enable version control and maintain consistent IAM configurations.
                                                                                                                                                             
  ## Release Note                                                                                                                                               
   
  Added Organization management support to IAM-CTL tool. 

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Organizations can now be exported and imported with other system resources
  * Organization management operations added (create, update, delete functionality)
  * Configuration structure extended to support organization-specific settings

* **Bug Fixes**
  * Fixed URL path formatting to properly handle trailing slashes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->