### PR TITLE
Extend Identity provider management to support IS versions above 6.1 and fix related bugs

### DIFF
--- a/iamctl/pkg/identityProviders/export.go
+++ b/iamctl/pkg/identityProviders/export.go
@@ -89,8 +89,8 @@ func ExportAll(exportFilePath string, format string) {
 			log.Println("Resident identity provider exported successfully")
 		}
 	}
-	if exportAPIExists {
-		log.Println("Warn: Provisioning roles of identity providers are not exported")
+	if shouldRemoveOutboundProvisioningRoles() {
+		log.Println("Warn: Outbound provisioning groups of identity providers are not exported")
 	}
 }
 
@@ -204,6 +204,9 @@ func getIdp(idpId string, excludeSecrets bool) (map[string]interface{}, error) {
 	}
 	if err := processClaims(idpMap); err != nil {
 		return nil, fmt.Errorf("error while processing claims of IDP: %w", err)
+	}
+	if err := removeOutboundProvisioningRoles(idpMap); err != nil {
+		return nil, fmt.Errorf("error while processing outbound provisioning roles: %w", err)
 	}
 
 	return idpMap, nil

--- a/iamctl/pkg/identityProviders/export.go
+++ b/iamctl/pkg/identityProviders/export.go
@@ -64,12 +64,7 @@ func ExportAll(exportFilePath string, format string) {
 			if !utils.IsResourceExcluded(idp.Name, utils.TOOL_CONFIGS.IdpConfigs) {
 				log.Println("Exporting identity provider: ", idp.Name)
 
-				var err error
-				if exportAPIExists {
-					err = exportIdp(idp.Id, exportFilePath, format, excludeSecerts)
-				} else {
-					err = exportIdpWithCRUD(idp.Id, idp.Name, exportFilePath, format, excludeSecerts)
-				}
+				err := exportIdpWithCRUD(idp.Id, idp.Name, exportFilePath, format, excludeSecerts)
 				if err != nil {
 					utils.UpdateFailureSummary(utils.IDENTITY_PROVIDERS, idp.Name)
 					log.Printf("Error while exporting identity providers: %s. %s", idp.Name, err)

--- a/iamctl/pkg/identityProviders/export.go
+++ b/iamctl/pkg/identityProviders/export.go
@@ -200,6 +200,9 @@ func getIdp(idpId string, excludeSecrets bool) (map[string]interface{}, error) {
 	if err := processClaims(idpMap); err != nil {
 		return nil, fmt.Errorf("error while processing claims of IDP: %w", err)
 	}
+	if err := processGroups(idpMap); err != nil {
+		return nil, fmt.Errorf("error while processing groups of IDP: %w", err)
+	}
 	if err := processImplicitAssociation(idpMap); err != nil {
 		return nil, fmt.Errorf("error while processing implicit association of IDP: %w", err)
 	}

--- a/iamctl/pkg/identityProviders/export.go
+++ b/iamctl/pkg/identityProviders/export.go
@@ -125,7 +125,7 @@ func exportIdp(idpId string, outputDirPath string, format string, excludeSecrets
 	body = removeProvisioningRole(body)
 
 	idpKeywordMapping := getIdpKeywordMapping(fileInfo.ResourceName)
-	modifiedFile, err := utils.ProcessExportedContent(exportedFileName, body, idpKeywordMapping, utils.IDENTITY_PROVIDERS)
+	modifiedFile, err := utils.ProcessExportedContent(exportedFileName, body, idpKeywordMapping, utils.IDENTITY_PROVIDERS_EXPORT_API)
 	if err != nil {
 		return fmt.Errorf("error while processing the exported content: %s", err)
 	}

--- a/iamctl/pkg/identityProviders/export.go
+++ b/iamctl/pkg/identityProviders/export.go
@@ -205,6 +205,9 @@ func getIdp(idpId string, excludeSecrets bool) (map[string]interface{}, error) {
 	if err := processClaims(idpMap); err != nil {
 		return nil, fmt.Errorf("error while processing claims of IDP: %w", err)
 	}
+	if err := processImplicitAssociation(idpMap); err != nil {
+		return nil, fmt.Errorf("error while processing implicit association of IDP: %w", err)
+	}
 	if err := removeOutboundProvisioningRoles(idpMap); err != nil {
 		return nil, fmt.Errorf("error while processing outbound provisioning roles: %w", err)
 	}

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -492,8 +492,23 @@ func patchIdp(idpId string, patchOps []map[string]interface{}) error {
 	return nil
 }
 
+func removeOutboundProvisioningRoles(idpMap map[string]interface{}) error {
+
+	if shouldRemoveOutboundProvisioningRoles() {
+		roles, ok := idpMap["roles"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected format for roles")
+		}
+		delete(roles, "outboundProvisioningRoles")
+	}
+	return nil
+}
+
 func removeProvisioningRole(fileContent []byte) []byte {
 
+	if !shouldRemoveOutboundProvisioningRoles() {
+		return fileContent
+	}
 	yamlPattern := regexp.MustCompile(`(?m)(^\s*provisioningRole:)[^\n]*`)
 	result := yamlPattern.ReplaceAllString(string(fileContent), `${1} ""`)
 
@@ -520,4 +535,14 @@ func processIdpGroupFields(fileContent []byte) []byte {
 func init() {
 
 	utils.DataPreprocessFuncs[utils.IDENTITY_PROVIDERS] = preprocessIdpKeys
+}
+
+func shouldRemoveOutboundProvisioningRoles() bool {
+
+	if utils.SERVER_CONFIGS.ServerVersion == "" {
+		return true
+	}
+	cmp, err := utils.CompareVersions(utils.SERVER_CONFIGS.ServerVersion, utils.MIN_VERSION_OUTBOUND_PROV_GROUPS)
+	// Consider outbound provisioning groups exist when the server version is not properly configured
+	return err != nil || cmp >= 0
 }

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -74,6 +74,9 @@ var idpPatchSkipKeys = map[string]bool{
 	"provisioning":            true,
 	"claims":                  true,
 	"roles":                   true,
+	"groups":                  true,
+	"implicitAssociation":     true,
+	"templateId":              true,
 }
 
 func getIdpList() ([]identityProvider, error) {

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -51,9 +51,11 @@ type idpConfig struct {
 			Connectors         []interface{} `json:"connectors" yaml:"connectors"`
 		} `json:"outboundConnectors" yaml:"outboundConnectors"`
 	} `json:"provisioning" yaml:"provisioning"`
-	Claims      interface{} `json:"claims" yaml:"claims"`
-	Roles       interface{} `json:"roles" yaml:"roles"`
-	Certificate *struct {
+	Claims              interface{} `json:"claims" yaml:"claims"`
+	Roles               interface{} `json:"roles" yaml:"roles"`
+	Groups              interface{} `json:"groups" yaml:"groups"`
+	ImplicitAssociation interface{} `json:"implicitAssociation" yaml:"implicitAssociation"`
+	Certificate         *struct {
 		Certificates []string `json:"certificates" yaml:"certificates"`
 		JwksUri      string   `json:"jwksUri" yaml:"jwksUri"`
 	} `json:"certificate" yaml:"certificate"`

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -308,6 +308,26 @@ func processClaims(idpMap map[string]interface{}) error {
 	return nil
 }
 
+func processGroups(idpMap map[string]interface{}) error {
+
+	raw, exists := idpMap["groups"]
+	if !exists {
+		return nil
+	}
+	groups, ok := raw.([]interface{})
+	if !ok {
+		return fmt.Errorf("invalid format for groups")
+	}
+	for _, grp := range groups {
+		group, ok := grp.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("invalid format for group")
+		}
+		delete(group, "id")
+	}
+	return nil
+}
+
 func processImplicitAssociation(idpMap map[string]interface{}) error {
 
 	raw, exists := idpMap["implicitAssociation"]

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -204,17 +204,29 @@ func processFederatedAuthenticators(idpId string, idpStruct idpConfig, idpMap ma
 		if err != nil {
 			return fmt.Errorf("error while retrieving federated authenticator %s: %w", authId, err)
 		}
-		if excludeSecrets {
-			fullAuthMap, ok := fullAuth.(map[string]interface{})
-			if !ok {
-				return fmt.Errorf("unexpected format for retrieved federated authenticator: %s", authId)
+		fullAuthMap, ok := fullAuth.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected format for retrieved federated authenticator: %s", authId)
+		}
+
+		definedBy, ok := fullAuthMap["definedBy"].(string)
+		if !ok {
+			return fmt.Errorf("unexpected format for definedBy field of federated authenticator: %s", authId)
+		}
+		if definedBy == "USER" {
+			if !excludeSecrets {
+				log.Println("Warn: Secrets exclusion cannot be disabled for custom external user authenticators. All secrets will be masked.")
 			}
+			if err := processEndpointAuthProperties(fullAuthMap); err != nil {
+				return fmt.Errorf("error processing endpoint auth properties for authenticator %s: %v", authId, err)
+			}
+		} else if excludeSecrets {
 			if err := maskSecretProperties(fullAuthMap, "meta/federated-authenticators/"+authId); err != nil {
 				return fmt.Errorf("error masking secrets for authenticator %s: %v", authId, err)
 			}
 		}
 
-		auths = append(auths, fullAuth)
+		auths = append(auths, fullAuthMap)
 	}
 	fedAuths["authenticators"] = auths
 
@@ -314,6 +326,58 @@ func processImplicitAssociation(idpMap map[string]interface{}) error {
 	if len(attrs) == 0 {
 		assoc["lookupAttribute"] = append(attrs, "")
 	}
+	return nil
+}
+
+func processEndpointAuthProperties(authenticatorMap map[string]interface{}) error {
+
+	endpoint, ok := authenticatorMap["endpoint"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for endpoint")
+	}
+	auth, ok := endpoint["authentication"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for endpoint authentication")
+	}
+	authType, ok := auth["type"].(string)
+	if !ok {
+		return fmt.Errorf("unexpected format for endpoint authentication type")
+	}
+
+	var props map[string]interface{}
+	if rawProps, exists := auth["properties"]; !exists {
+		props = map[string]interface{}{}
+	} else {
+		props, ok = rawProps.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected format for authentication properties")
+		}
+	}
+
+	switch authType {
+	case "NONE":
+	case "BASIC":
+		if _, exists := props["username"]; !exists {
+			props["username"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+		}
+		props["password"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+	case "BEARER":
+		props["accessToken"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+	case "API_KEY":
+		if _, exists := props["header"]; !exists {
+			props["header"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+		}
+		props["value"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+	case "CLIENT_CREDENTIAL":
+		props["clientSecret"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+	case "PASSWORD_CREDENTIAL":
+		props["clientSecret"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+		props["password"] = utils.SENSITIVE_FIELD_MASK_WITHOUT_QUOTES
+	default:
+		return fmt.Errorf("unknown endpoint authentication type: %s", authType)
+	}
+
+	auth["properties"] = props
 	return nil
 }
 

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -296,6 +296,27 @@ func processClaims(idpMap map[string]interface{}) error {
 	return nil
 }
 
+func processImplicitAssociation(idpMap map[string]interface{}) error {
+
+	raw, exists := idpMap["implicitAssociation"]
+	if !exists {
+		return nil
+	}
+	assoc, ok := raw.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("invalid format for implicit association")
+	}
+
+	attrs, ok := assoc["lookupAttribute"].([]interface{})
+	if !ok {
+		return fmt.Errorf("invalid format for lookupAttribute in implicit association")
+	}
+	if len(attrs) == 0 {
+		assoc["lookupAttribute"] = append(attrs, "")
+	}
+	return nil
+}
+
 func maskSecretProperties(resourceMap map[string]interface{}, metaPath string) error {
 
 	body, err := utils.SendGetRequest(utils.IDENTITY_PROVIDERS, metaPath)

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -398,6 +398,13 @@ func processEndpointAuthProperties(authenticatorMap map[string]interface{}) erro
 	}
 
 	auth["properties"] = props
+
+	if _, exists := endpoint["allowedHeaders"]; !exists {
+		endpoint["allowedHeaders"] = []interface{}{}
+	}
+	if _, exists := endpoint["allowedParameters"]; !exists {
+		endpoint["allowedParameters"] = []interface{}{}
+	}
 	return nil
 }
 

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -421,10 +421,6 @@ func maskSecretProperties(resourceMap map[string]interface{}, metaPath string) e
 
 func preprocessIdpKeys(data interface{}) (interface{}, error) {
 
-	if utils.ExportAPIExists(utils.IDENTITY_PROVIDERS) {
-		return data, nil
-	}
-
 	data = utils.ConvertToStringKeyMap(data)
 	d, ok := data.(map[string]interface{})
 	if !ok {

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -209,8 +209,9 @@ func processFederatedAuthenticators(idpId string, idpStruct idpConfig, idpMap ma
 			return fmt.Errorf("unexpected format for retrieved federated authenticator: %s", authId)
 		}
 
-		definedBy, ok := fullAuthMap["definedBy"].(string)
-		if !ok {
+		definedByRaw, exists := fullAuthMap["definedBy"]
+		definedBy, ok := definedByRaw.(string)
+		if exists && !ok {
 			return fmt.Errorf("unexpected format for definedBy field of federated authenticator: %s", authId)
 		}
 		if definedBy == "USER" {

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -215,7 +215,7 @@ func processFederatedAuthenticators(idpId string, idpStruct idpConfig, idpMap ma
 		}
 		if definedBy == "USER" {
 			if !excludeSecrets {
-				log.Println("Warn: Secrets exclusion cannot be disabled for custom external user authenticators. All secrets will be masked.")
+				log.Println("Warn: Secrets exclusion cannot be disabled for custom authenticators(service-based). All secrets will be masked.")
 			}
 			if err := processEndpointAuthProperties(fullAuthMap); err != nil {
 				return fmt.Errorf("error processing endpoint auth properties for authenticator %s: %v", authId, err)

--- a/iamctl/pkg/identityProviders/import.go
+++ b/iamctl/pkg/identityProviders/import.go
@@ -79,8 +79,8 @@ func ImportAll(inputDirPath string) {
 			}
 		}
 	}
-	if exportAPIExists {
-		log.Println("Warn: Provisioning roles of identity providers are removed during import")
+	if shouldRemoveOutboundProvisioningRoles() {
+		log.Println("Warn: Outbound provisioning groups of identity providers are removed during import")
 	}
 }
 

--- a/iamctl/pkg/identityProviders/import.go
+++ b/iamctl/pkg/identityProviders/import.go
@@ -94,10 +94,7 @@ func importIdp(idpId string, idpName string, importFilePath string, exportAPIExi
 	idpKeywordMapping := getIdpKeywordMapping(idpName)
 	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), idpKeywordMapping)
 
-	if exportAPIExists {
-		if idpId == "" {
-			return importIdentityProvider(idpName, importFilePath, modifiedFileData)
-		}
+	if exportAPIExists && idpId == utils.RESIDENT_IDP_NAME {
 		return updateIdentityProvider(idpId, idpName, importFilePath, modifiedFileData)
 	}
 

--- a/iamctl/pkg/identityProviders/import.go
+++ b/iamctl/pkg/identityProviders/import.go
@@ -279,6 +279,30 @@ func updateIdpSubResources(idpId string, idpStruct idpConfig) error {
 		resp.Body.Close()
 	}
 
+	if idpStruct.Groups != nil {
+		body, err := json.Marshal(idpStruct.Groups)
+		if err != nil {
+			return fmt.Errorf("error marshalling groups: %w", err)
+		}
+		resp, err := utils.SendPutRequest(utils.IDENTITY_PROVIDERS, idpId+"/groups", body)
+		if err != nil {
+			return fmt.Errorf("error updating groups: %w", err)
+		}
+		resp.Body.Close()
+	}
+
+	if idpStruct.ImplicitAssociation != nil {
+		body, err := json.Marshal(idpStruct.ImplicitAssociation)
+		if err != nil {
+			return fmt.Errorf("error marshalling implicit association: %w", err)
+		}
+		resp, err := utils.SendPutRequest(utils.IDENTITY_PROVIDERS, idpId+"/implicit-association", body)
+		if err != nil {
+			return fmt.Errorf("error updating implicit association: %w", err)
+		}
+		resp.Body.Close()
+	}
+
 	if idpStruct.Provisioning != nil {
 		if idpStruct.Provisioning.Jit != nil {
 			body, err := json.Marshal(idpStruct.Provisioning.Jit)

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -201,6 +201,7 @@ var idpGetAPIArrayIdentifiers = map[string]string{
 	"claimMappings":      "localClaim.uri",
 	"roleMappings":       "localRole",
 	"provisioningClaims": "claim.uri",
+	"groups":             "name",
 }
 
 var userStoreArrayIdentifiers = map[string]string{

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -98,6 +98,7 @@ const BRANDING ResourceType = "Branding"
 const WORKFLOW_ASSOCIATIONS ResourceType = "WorkflowAssociations"
 const API_RESOURCE_SCOPES ResourceType = "ApiResourceScopes"
 const APPLICATION_AUTHORIZED_APIS ResourceType = "ApplicationAuthorizedApis"
+const IDENTITY_PROVIDERS_EXPORT_API ResourceType = "IdentityProvidersExportAPI"
 
 // Config file names
 const SERVER_CONFIG_FILE = "serverConfig.json"

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -184,10 +184,9 @@ func GetArrayIdentifiers(resourceType ResourceType) map[string]string {
 		}
 		return appGetAPIArrayIdentifiers
 	case IDENTITY_PROVIDERS:
-		if ExportAPIExists(IDENTITY_PROVIDERS) {
-			return idpExportAPIArrayIdentifiers
-		}
 		return idpGetAPIArrayIdentifiers
+	case IDENTITY_PROVIDERS_EXPORT_API:
+		return idpExportAPIArrayIdentifiers
 	case USERSTORES:
 		return userStoreArrayIdentifiers
 	case CLAIMS:

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -70,10 +70,11 @@ const (
 	MIN_VERSION_NOTIFICATION_TEMPLATES_API = "7.1.0"
 )
 
-// Minimum WSO2 Identity Server version requirements for other behavioural changes
+// Minimum WSO2 Identity Server version for resource-specific behavioural changes
 const (
 	MIN_VERSION_ASSOCIATION_SHARING_ACROSS_WORKFLOWS = "7.3.0"
 	MIN_VERSION_WORKFLOW_ASSOCIATION_RULES           = "7.3.0"
+	MIN_VERSION_OUTBOUND_PROV_GROUPS                 = "7.3.0"
 )
 
 var ExportAPIMinVersionRequirements = map[ResourceType]string{

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -65,6 +65,7 @@ var EntityMaxSupportedVersion = map[ResourceType]string{
 // Minimum WSO2 Identity Server version requirements for resource-specific APIs
 const (
 	MIN_VERSION_USERSTORE_EXPORT_API       = "6.1.0"
+	MIN_VERSION_IDP_EXPORT_API             = "6.1.0"
 	MIN_VERSION_APP_EXPORT_API             = "6.1.0"
 	MIN_VERSION_ROLES_V2_API               = "7.0.0"
 	MIN_VERSION_NOTIFICATION_TEMPLATES_API = "7.1.0"
@@ -78,6 +79,7 @@ const (
 )
 
 var ExportAPIMinVersionRequirements = map[ResourceType]string{
-	USERSTORES:   MIN_VERSION_USERSTORE_EXPORT_API,
-	APPLICATIONS: MIN_VERSION_APP_EXPORT_API,
+	USERSTORES:         MIN_VERSION_USERSTORE_EXPORT_API,
+	IDENTITY_PROVIDERS: MIN_VERSION_IDP_EXPORT_API,
+	APPLICATIONS:       MIN_VERSION_APP_EXPORT_API,
 }

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -65,7 +65,6 @@ var EntityMaxSupportedVersion = map[ResourceType]string{
 // Minimum WSO2 Identity Server version requirements for resource-specific APIs
 const (
 	MIN_VERSION_USERSTORE_EXPORT_API       = "6.1.0"
-	MIN_VERSION_IDP_EXPORT_API             = "6.1.0"
 	MIN_VERSION_APP_EXPORT_API             = "6.1.0"
 	MIN_VERSION_ROLES_V2_API               = "7.0.0"
 	MIN_VERSION_NOTIFICATION_TEMPLATES_API = "7.1.0"
@@ -78,7 +77,6 @@ const (
 )
 
 var ExportAPIMinVersionRequirements = map[ResourceType]string{
-	USERSTORES:         MIN_VERSION_USERSTORE_EXPORT_API,
-	IDENTITY_PROVIDERS: MIN_VERSION_IDP_EXPORT_API,
-	APPLICATIONS:       MIN_VERSION_APP_EXPORT_API,
+	USERSTORES:   MIN_VERSION_USERSTORE_EXPORT_API,
+	APPLICATIONS: MIN_VERSION_APP_EXPORT_API,
 }


### PR DESCRIPTION
 ## Purpose
  
  Identity provider export/import previously had two code paths: CRUD APIs for IS versions below 6.1.0, and the file-based export API for IS 6.1.0 and above. This PR removes `IDENTITY_PROVIDERS` from `ExportAPIMinVersionRequirements`, making the CRUD path the single implementation for all IS versions. The file-based export API is retained exclusively for the Resident IDP (`LOCAL`), which has no CRUD export path and must be handled separately.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
  
  ## Goals

  - Use CRUD APIs for all regular IDP export and import across all IS versions
  - Retain the file-based export API only for the Resident IDP 
  - Support `groups` and `implicitAssociation` sub-resources introduced in IS 7.3.0
  - Mask secrets in custom authenticators by endpoint authentication type
  - Strip `outboundProvisioningRoles` on IS 7.3+ as it contains groups, not supported by the tool

  ## Approach
  
  ### Dropping the export API path and the Resident IDP exception
  
All identity providers get routed through `exportIdpWithCRUD`. The export API (`exportIdp`) is still called, but only when `exportAPIExists` is true AND the IDP is the Resident IDP (The only case where no CRUD export path exists). Import mirrors this: the export API update path (`updateIdentityProvider`) is now only invoked for `idpId == RESIDENT_IDP_NAME`.
  
  ### Key preprocessing now always runs

  `preprocessIdpKeys` previously returned early (no-op) when `ExportAPIExists` was true, meaning the `mappings → claimMappings` / `mappings → roleMappings` key renames were never applied for IS 6.1.0+. This broke keyword resolution for claim and role mapping arrays on those versions. With the export API path removed, the preprocessing now always runs, fixing this for all versions.
  
  ### Groups sub-resource (IS 7.3.0+)

  Added `processGroups()` to strip the internal `id` from each group entry on export, since IDs are environment-specific. Added `"groups": "name"` to `idpGetAPIArrayIdentifiers` so arrays within groups serialize with a stable identifier. Groups are imported via a PUT to `/groups`.
  
  ### Implicit association sub-resource

  Added `processImplicitAssociation()` to normalize the `lookupAttribute` field. When the field is present but empty, the API rejects an import payload with an empty array. Appending a sentinel empty string preserves the field in the exported file and allows the import to succeed. Imported via PUT to `/implicit-association`.
  
  ### `outboundProvisioningRoles` and version gating

  The `roles` object contains an `outboundProvisioningRoles` array. On IS 7.3+ this contains groups which are environment-specific and non-portable. Added `shouldRemoveOutboundProvisioningRoles()` which returns `true` for IS 7.3.0+ (comparing against `MIN_VERSION_OUTBOUND_PROV_GROUPS`). `removeOutboundProvisioningRoles()` strips the field from the CRUD export map.
  
  ### Custom authenticator secret masking

  System-defined authenticators expose a `meta/federated-authenticators/{id}` endpoint listing confidential properties and the existing `maskSecretProperties()` handles these. USER-defined (service-based) custom authenticators have no such metadata endpoint; their secrets live inside `endpoint.authentication.properties` keyed by an `authentication.type` field. Added `processEndpointAuthProperties()` which dispatches on type (`BASIC`, `BEARER`, `API_KEY`, `CLIENT_CREDENTIAL`, `PASSWORD_CREDENTIAL`, `NONE`) and masks the type-appropriate fields. Secrets exclusion cannot be disabled for custom authenticators since the api does not support retrieving these secrets.

A related fix was needed for `allowedHeaders` and `allowedParameters` on the custom authenticator endpoint: when these fields are absent from the exported file, a PUT on import leaves any previously deployed values intact rather than clearing them. `processEndpointAuthProperties` now always writes both fields as empty arrays when they are not present, ensuring the import payload explicitly clears them instead of silently preserving stale values.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for identity provider groups and implicit associations
  * Improved endpoint authentication normalization and secret-handling behavior
  * Enhanced import/export to reliably persist IDP sub-resources and export via the export API

* **Bug Fixes**
  * Fixed resident identity provider update logic during import

* **Chores**
  * Added a minimum-server-version requirement for outbound provisioning groups and updated related messaging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/92?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->