### PR TITLE
 Fix Organization export/import compatibility between Asgardeo and IS

### DIFF
--- a/iamctl/pkg/organizations/export.go
+++ b/iamctl/pkg/organizations/export.go
@@ -49,28 +49,28 @@ func ExportAll(exportFilePath string, format string) {
 		}
 	} else {
 		if utils.TOOL_CONFIGS.AllowDelete {
-			deployedHandles := getDeployedOrganizationHandles(orgs)
-			utils.RemoveDeletedLocalResources(exportFilePath, deployedHandles)
+			deployedOrgNames := getDeployedOrganizationNames(orgs)
+			utils.RemoveDeletedLocalResources(exportFilePath, deployedOrgNames)
 		}
 	}
 
 	for _, org := range orgs {
-		if !utils.IsResourceExcluded(org.OrgHandle, utils.TOOL_CONFIGS.OrganizationConfigs) {
-			log.Println("Exporting organization: ", org.OrgHandle)
+		if !utils.IsResourceExcluded(org.Name, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			log.Println("Exporting organization: ", org.Name)
 
-			err := exportOrganization(org.Id, org.OrgHandle, exportFilePath, format)
+			err := exportOrganization(org.Id, org.Name, exportFilePath, format)
 			if err != nil {
-				utils.UpdateFailureSummary(utils.ORGANIZATIONS, org.OrgHandle)
-				log.Printf("Error while exporting organization: %s. %s", org.OrgHandle, err)
+				utils.UpdateFailureSummary(utils.ORGANIZATIONS, org.Name)
+				log.Printf("Error while exporting organization: %s. %s", org.Name, err)
 			} else {
 				utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.EXPORT)
-				log.Println("Organization exported successfully: ", org.OrgHandle)
+				log.Println("Organization exported successfully: ", org.Name)
 			}
 		}
 	}
 }
 
-func exportOrganization(orgId, orgHandle, outputDirPath, formatString string) error {
+func exportOrganization(orgId, orgName, outputDirPath, formatString string) error {
 
 	org, err := utils.GetResourceData(utils.ORGANIZATIONS, orgId)
 	if err != nil {
@@ -78,9 +78,9 @@ func exportOrganization(orgId, orgHandle, outputDirPath, formatString string) er
 	}
 
 	format := utils.FormatFromString(formatString)
-	exportedFileName := utils.GetExportedFilePath(outputDirPath, orgHandle, format)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, orgName, format)
 
-	orgKeywordMapping := getOrganizationKeywordMapping(orgHandle)
+	orgKeywordMapping := getOrganizationKeywordMapping(orgName)
 	modifiedOrg, err := utils.ProcessExportedData(org, exportedFileName, format, orgKeywordMapping, utils.ORGANIZATIONS)
 	if err != nil {
 		return fmt.Errorf("error while processing exported content: %w", err)

--- a/iamctl/pkg/organizations/export.go
+++ b/iamctl/pkg/organizations/export.go
@@ -49,8 +49,8 @@ func ExportAll(exportFilePath string, format string) {
 		}
 	} else {
 		if utils.TOOL_CONFIGS.AllowDelete {
-			deployedOrgs := getDeployedOrgResourceNames(orgs)
-			utils.RemoveDeletedLocalResources(exportFilePath, deployedOrgs)
+			deployedResourceNames := getDeployedOrgResourceNames(orgs)
+			utils.RemoveDeletedLocalResources(exportFilePath, deployedResourceNames)
 		}
 	}
 

--- a/iamctl/pkg/organizations/export.go
+++ b/iamctl/pkg/organizations/export.go
@@ -49,28 +49,29 @@ func ExportAll(exportFilePath string, format string) {
 		}
 	} else {
 		if utils.TOOL_CONFIGS.AllowDelete {
-			deployedOrgNames := getDeployedOrganizationNames(orgs)
-			utils.RemoveDeletedLocalResources(exportFilePath, deployedOrgNames)
+			deployedOrgs := getDeployedOrgResourceNames(orgs)
+			utils.RemoveDeletedLocalResources(exportFilePath, deployedOrgs)
 		}
 	}
 
 	for _, org := range orgs {
-		if !utils.IsResourceExcluded(org.Name, utils.TOOL_CONFIGS.OrganizationConfigs) {
-			log.Println("Exporting organization: ", org.Name)
+		resourceName := getOrgResourceName(org)
+		if !utils.IsResourceExcluded(resourceName, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			log.Println("Exporting organization: ", resourceName)
 
-			err := exportOrganization(org.Id, org.Name, exportFilePath, format)
+			err := exportOrganization(org.Id, resourceName, exportFilePath, format)
 			if err != nil {
-				utils.UpdateFailureSummary(utils.ORGANIZATIONS, org.Name)
-				log.Printf("Error while exporting organization: %s. %s", org.Name, err)
+				utils.UpdateFailureSummary(utils.ORGANIZATIONS, resourceName)
+				log.Printf("Error while exporting organization: %s. %s", resourceName, err)
 			} else {
 				utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.EXPORT)
-				log.Println("Organization exported successfully: ", org.Name)
+				log.Println("Organization exported successfully: ", resourceName)
 			}
 		}
 	}
 }
 
-func exportOrganization(orgId, orgName, outputDirPath, formatString string) error {
+func exportOrganization(orgId, resourceName, outputDirPath, formatString string) error {
 
 	org, err := utils.GetResourceData(utils.ORGANIZATIONS, orgId)
 	if err != nil {
@@ -78,9 +79,9 @@ func exportOrganization(orgId, orgName, outputDirPath, formatString string) erro
 	}
 
 	format := utils.FormatFromString(formatString)
-	exportedFileName := utils.GetExportedFilePath(outputDirPath, orgName, format)
+	exportedFileName := utils.GetExportedFilePath(outputDirPath, resourceName, format)
 
-	orgKeywordMapping := getOrganizationKeywordMapping(orgName)
+	orgKeywordMapping := getOrganizationKeywordMapping(resourceName)
 	modifiedOrg, err := utils.ProcessExportedData(org, exportedFileName, format, orgKeywordMapping, utils.ORGANIZATIONS)
 	if err != nil {
 		return fmt.Errorf("error while processing exported content: %w", err)

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -65,20 +65,20 @@ func ImportAll(inputDirPath string) {
 	for _, file := range files {
 		orgFilePath := filepath.Join(importFilePath, file.Name())
 		fileInfo := utils.GetFileInfo(orgFilePath)
-		orgName := fileInfo.ResourceName
+		resourceName := fileInfo.ResourceName
 
-		if !utils.IsResourceExcluded(orgName, utils.TOOL_CONFIGS.OrganizationConfigs) {
-			orgId := getOrgId(orgName, existingList)
-			err := importOrganization(orgName, orgId, orgFilePath)
+		if !utils.IsResourceExcluded(resourceName, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			orgId := getOrgId(resourceName, existingList)
+			err := importOrganization(resourceName, orgId, orgFilePath)
 			if err != nil {
 				log.Println("Error importing organization: ", err)
-				utils.UpdateFailureSummary(utils.ORGANIZATIONS, orgName)
+				utils.UpdateFailureSummary(utils.ORGANIZATIONS, resourceName)
 			}
 		}
 	}
 }
 
-func importOrganization(orgName, orgId, importFilePath string) error {
+func importOrganization(resourceName, orgId, importFilePath string) error {
 
 	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
 	if err != nil {
@@ -90,18 +90,18 @@ func importOrganization(orgName, orgId, importFilePath string) error {
 		return fmt.Errorf("error when reading the file for organization: %w", err)
 	}
 
-	orgKeywordMapping := getOrganizationKeywordMapping(orgName)
+	orgKeywordMapping := getOrganizationKeywordMapping(resourceName)
 	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), orgKeywordMapping)
 
 	if orgId == "" {
-		return createOrganization([]byte(modifiedFileData), format, orgName)
+		return createOrganization([]byte(modifiedFileData), format, resourceName)
 	}
-	return updateOrganization(orgId, []byte(modifiedFileData), format, orgName)
+	return updateOrganization(orgId, []byte(modifiedFileData), format, resourceName)
 }
 
-func createOrganization(requestBody []byte, format utils.Format, orgName string) error {
+func createOrganization(requestBody []byte, format utils.Format, resourceName string) error {
 
-	log.Println("Creating new organization: " + orgName)
+	log.Println("Creating new organization: " + resourceName)
 
 	jsonBody, status, err := prepareOrganizationPostBody(requestBody, format, curOrgId)
 	if err != nil {
@@ -132,9 +132,9 @@ func createOrganization(requestBody []byte, format utils.Format, orgName string)
 	return nil
 }
 
-func updateOrganization(orgId string, requestBody []byte, format utils.Format, orgName string) error {
+func updateOrganization(orgId string, requestBody []byte, format utils.Format, resourceName string) error {
 
-	log.Println("Updating organization: " + orgName)
+	log.Println("Updating organization: " + resourceName)
 
 	updateBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.ORGANIZATIONS,
 		"id", "orgHandle", "type", "parent", "permissions", "created", "lastModified", "hasChildren", "ancestorPath")
@@ -166,18 +166,19 @@ func removeDeletedDeployedOrganizations(localFiles []os.FileInfo, deployedOrgs [
 	}
 
 	for _, org := range deployedOrgs {
-		if _, existsLocally := localResourceNames[org.Name]; existsLocally {
+		resourceName := getOrgResourceName(org)
+		if _, existsLocally := localResourceNames[resourceName]; existsLocally {
 			continue
 		}
-		if utils.IsResourceExcluded(org.Name, utils.TOOL_CONFIGS.OrganizationConfigs) {
-			log.Println("Organization is excluded from deletion:", org.Name)
+		if utils.IsResourceExcluded(resourceName, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			log.Println("Organization is excluded from deletion:", resourceName)
 			continue
 		}
 
-		log.Printf("Organization: %s not found locally. Deleting organization.\n", org.Name)
+		log.Printf("Organization: %s not found locally. Deleting organization.\n", resourceName)
 		if err := utils.SendDeleteRequest(org.Id, utils.ORGANIZATIONS); err != nil {
-			utils.UpdateFailureSummary(utils.ORGANIZATIONS, org.Name)
-			log.Println("Error deleting organization:", org.Name, err)
+			utils.UpdateFailureSummary(utils.ORGANIZATIONS, resourceName)
+			log.Println("Error deleting organization:", resourceName, err)
 		} else {
 			utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.DELETE)
 		}

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -65,20 +65,20 @@ func ImportAll(inputDirPath string) {
 	for _, file := range files {
 		orgFilePath := filepath.Join(importFilePath, file.Name())
 		fileInfo := utils.GetFileInfo(orgFilePath)
-		orgHandle := fileInfo.ResourceName
+		orgName := fileInfo.ResourceName
 
-		if !utils.IsResourceExcluded(orgHandle, utils.TOOL_CONFIGS.OrganizationConfigs) {
-			orgId := getOrgId(orgHandle, existingList)
-			err := importOrganization(orgHandle, orgId, orgFilePath)
+		if !utils.IsResourceExcluded(orgName, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			orgId := getOrgId(orgName, existingList)
+			err := importOrganization(orgName, orgId, orgFilePath)
 			if err != nil {
 				log.Println("Error importing organization: ", err)
-				utils.UpdateFailureSummary(utils.ORGANIZATIONS, orgHandle)
+				utils.UpdateFailureSummary(utils.ORGANIZATIONS, orgName)
 			}
 		}
 	}
 }
 
-func importOrganization(orgHandle, orgId, importFilePath string) error {
+func importOrganization(orgName, orgId, importFilePath string) error {
 
 	format, err := utils.FormatFromExtension(filepath.Ext(importFilePath))
 	if err != nil {
@@ -90,18 +90,18 @@ func importOrganization(orgHandle, orgId, importFilePath string) error {
 		return fmt.Errorf("error when reading the file for organization: %w", err)
 	}
 
-	orgKeywordMapping := getOrganizationKeywordMapping(orgHandle)
+	orgKeywordMapping := getOrganizationKeywordMapping(orgName)
 	modifiedFileData := utils.ReplaceKeywords(string(fileBytes), orgKeywordMapping)
 
 	if orgId == "" {
-		return createOrganization([]byte(modifiedFileData), format, orgHandle)
+		return createOrganization([]byte(modifiedFileData), format, orgName)
 	}
-	return updateOrganization(orgId, []byte(modifiedFileData), format, orgHandle)
+	return updateOrganization(orgId, []byte(modifiedFileData), format, orgName)
 }
 
-func createOrganization(requestBody []byte, format utils.Format, orgHandle string) error {
+func createOrganization(requestBody []byte, format utils.Format, orgName string) error {
 
-	log.Println("Creating new organization: " + orgHandle)
+	log.Println("Creating new organization: " + orgName)
 
 	jsonBody, status, err := prepareOrganizationPostBody(requestBody, format, curOrgId)
 	if err != nil {
@@ -132,9 +132,9 @@ func createOrganization(requestBody []byte, format utils.Format, orgHandle strin
 	return nil
 }
 
-func updateOrganization(orgId string, requestBody []byte, format utils.Format, orgHandle string) error {
+func updateOrganization(orgId string, requestBody []byte, format utils.Format, orgName string) error {
 
-	log.Println("Updating organization: " + orgHandle)
+	log.Println("Updating organization: " + orgName)
 
 	updateBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.ORGANIZATIONS,
 		"id", "orgHandle", "type", "parent", "permissions", "created", "lastModified", "hasChildren", "ancestorPath")
@@ -166,18 +166,18 @@ func removeDeletedDeployedOrganizations(localFiles []os.FileInfo, deployedOrgs [
 	}
 
 	for _, org := range deployedOrgs {
-		if _, existsLocally := localResourceNames[org.OrgHandle]; existsLocally {
+		if _, existsLocally := localResourceNames[org.Name]; existsLocally {
 			continue
 		}
-		if utils.IsResourceExcluded(org.OrgHandle, utils.TOOL_CONFIGS.OrganizationConfigs) {
-			log.Println("Organization is excluded from deletion:", org.OrgHandle)
+		if utils.IsResourceExcluded(org.Name, utils.TOOL_CONFIGS.OrganizationConfigs) {
+			log.Println("Organization is excluded from deletion:", org.Name)
 			continue
 		}
 
-		log.Printf("Organization: %s not found locally. Deleting organization.\n", org.OrgHandle)
+		log.Printf("Organization: %s not found locally. Deleting organization.\n", org.Name)
 		if err := utils.SendDeleteRequest(org.Id, utils.ORGANIZATIONS); err != nil {
-			utils.UpdateFailureSummary(utils.ORGANIZATIONS, org.OrgHandle)
-			log.Println("Error deleting organization:", org.OrgHandle, err)
+			utils.UpdateFailureSummary(utils.ORGANIZATIONS, org.Name)
+			log.Println("Error deleting organization:", org.Name, err)
 		} else {
 			utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.DELETE)
 		}

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -120,6 +120,11 @@ func prepareOrganizationPostBody(requestBody []byte, format utils.Format, parent
 	status := orgData["status"]
 	delete(orgData, "status")
 
+	// orgHandle is removed from POST requests for Asgardeo
+	if utils.SERVER_CONFIGS.ServerVersion == "" {
+		delete(orgData, "orgHandle")
+	}
+
 	jsonBody, err := utils.Serialize(orgData, utils.FormatJSON, utils.ORGANIZATIONS)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error serializing to JSON: %w", err)

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -27,9 +27,10 @@ import (
 )
 
 type organization struct {
-	Id     string `json:"id"`
-	Name   string `json:"name"`
-	Status string `json:"status"`
+	Id        string `json:"id"`
+	Name      string `json:"name"`
+	OrgHandle string `json:"orgHandle"`
+	Status    string `json:"status"`
 }
 
 type organizationsResponse struct {
@@ -81,27 +82,27 @@ func getOrganizationList() ([]organization, error) {
 	return nil, fmt.Errorf("unknown error while retrieving list")
 }
 
-func getDeployedOrganizationNames(orgs []organization) []string {
+func getDeployedOrgResourceNames(orgs []organization) []string {
 
-	var orgNames []string
+	var names []string
 	for _, o := range orgs {
-		orgNames = append(orgNames, o.Name)
+		names = append(names, getOrgResourceName(o))
 	}
-	return orgNames
+	return names
 }
 
-func getOrganizationKeywordMapping(orgName string) map[string]interface{} {
+func getOrganizationKeywordMapping(resourceName string) map[string]interface{} {
 
 	if utils.KEYWORD_CONFIGS.OrganizationConfigs != nil {
-		return utils.ResolveAdvancedKeywordMapping(orgName, utils.KEYWORD_CONFIGS.OrganizationConfigs)
+		return utils.ResolveAdvancedKeywordMapping(resourceName, utils.KEYWORD_CONFIGS.OrganizationConfigs)
 	}
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }
 
-func getOrgId(orgName string, list []organization) string {
+func getOrgId(resourceName string, list []organization) string {
 
 	for _, o := range list {
-		if o.Name == orgName {
+		if getOrgResourceName(o) == resourceName {
 			return o.Id
 		}
 	}
@@ -158,4 +159,13 @@ func patchOrganizationStatus(orgId string, rawStatus interface{}) error {
 	resp.Body.Close()
 
 	return nil
+}
+
+func getOrgResourceName(org organization) string {
+
+	// Uses org name as the resource identifier in Asgardeo, org handle for IS.
+	if utils.SERVER_CONFIGS.ServerVersion == "" {
+		return org.Name
+	}
+	return org.OrgHandle
 }

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -27,10 +27,9 @@ import (
 )
 
 type organization struct {
-	Id        string `json:"id"`
-	Name      string `json:"name"`
-	OrgHandle string `json:"orgHandle"`
-	Status    string `json:"status"`
+	Id     string `json:"id"`
+	Name   string `json:"name"`
+	Status string `json:"status"`
 }
 
 type organizationsResponse struct {
@@ -82,27 +81,27 @@ func getOrganizationList() ([]organization, error) {
 	return nil, fmt.Errorf("unknown error while retrieving list")
 }
 
-func getDeployedOrganizationHandles(orgs []organization) []string {
+func getDeployedOrganizationNames(orgs []organization) []string {
 
-	var handles []string
+	var orgNames []string
 	for _, o := range orgs {
-		handles = append(handles, o.OrgHandle)
+		orgNames = append(orgNames, o.Name)
 	}
-	return handles
+	return orgNames
 }
 
-func getOrganizationKeywordMapping(orgHandle string) map[string]interface{} {
+func getOrganizationKeywordMapping(orgName string) map[string]interface{} {
 
 	if utils.KEYWORD_CONFIGS.OrganizationConfigs != nil {
-		return utils.ResolveAdvancedKeywordMapping(orgHandle, utils.KEYWORD_CONFIGS.OrganizationConfigs)
+		return utils.ResolveAdvancedKeywordMapping(orgName, utils.KEYWORD_CONFIGS.OrganizationConfigs)
 	}
 	return utils.KEYWORD_CONFIGS.KeywordMappings
 }
 
-func getOrgId(orgHandle string, list []organization) string {
+func getOrgId(orgName string, list []organization) string {
 
 	for _, o := range list {
-		if o.OrgHandle == orgHandle {
+		if o.Name == orgName {
 			return o.Id
 		}
 	}


### PR DESCRIPTION
## Purpose
 - Asgardeo uses a `orgId` as `orgHandle`, which is not human-friendly and causes POST failures when importing into a different org (UUID is unique). IS uses a user-defined string for orgHandle, which is safe to use as-is.
  - Introduced `getOrgResourceName()` to select the resource identifier per server type: `orgName` for Asgardeo (`ServerVersion == ""`), `orgHandle` for IS.
  - Removed `orgHandle` from organization POST request bodies on Asgardeo, so Asgardeo generates a fresh handle on create rather than rejecting the imported UUID.
  - All resource identifier logic (file naming, exclusion checks, keyword mapping, deployed-vs-local diffing) now routes through getOrgResourceName().

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved organization import and export operations with refined resource identification mechanism.
  * Updated organization removal logic for more consistent handling of deployed resources.
  * Enhanced organization management utilities to better support multiple server configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/99?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->