### PR TITLE
Add full pagination support for all paginated list APIs

### DIFF
--- a/iamctl/pkg/apiResources/apiResourceUtils.go
+++ b/iamctl/pkg/apiResources/apiResourceUtils.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"path/filepath"
+	"strconv"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -58,58 +59,32 @@ func GetApiResourceList(limitToBusinessApis bool) ([]ApiResource, error) {
 		return []ApiResource{}, nil
 	}
 
+	queryParams["limit"] = strconv.Itoa(totalResults)
 	var listResponse apiResourceListResponse
-	resp, err := utils.SendGetListRequest(utils.API_RESOURCES, totalResults,
+	body, err := utils.SendGetListRequest(utils.API_RESOURCES,
 		utils.WithQueryParams(queryParams))
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving API resource list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved API resource list. %w", err)
-		}
-
-		err = json.Unmarshal(body, &listResponse)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved API resource list. %w", err)
-		}
-
-		return listResponse.APIResources, nil
-	} else if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving API resource list. Status code: %d, Error: %s", statusCode, errMsg)
+	if err = json.Unmarshal(body, &listResponse); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved API resource list. %w", err)
 	}
-	return nil, fmt.Errorf("error while retrieving API resource list")
+	return listResponse.APIResources, nil
 }
 
 func getApiResourceCount(queryParams map[string]string) (int, error) {
 
-	resp, err := utils.SendGetListRequest(utils.API_RESOURCES, 1,
+	queryParams["limit"] = "1"
+	body, err := utils.SendGetListRequest(utils.API_RESOURCES,
 		utils.WithQueryParams(queryParams))
 	if err != nil {
 		return 0, fmt.Errorf("error while retrieving API resource count. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return 0, fmt.Errorf("error when reading API resource count response. %w", err)
+	var countResponse apiResourceListResponse
+	if err := json.Unmarshal(body, &countResponse); err != nil {
+		return 0, fmt.Errorf("error when unmarshalling API resource count response. %w", err)
 	}
-
-	if statusCode == 200 {
-		var countResponse apiResourceListResponse
-		if err := json.Unmarshal(body, &countResponse); err != nil {
-			return 0, fmt.Errorf("error when unmarshalling API resource count response. %w", err)
-		}
-		return countResponse.TotalResults, nil
-	} else if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
-		return 0, fmt.Errorf("error while retrieving API resource count. Status code: %d, Error: %s", statusCode, errMsg)
-	}
-	return 0, fmt.Errorf("unexpected error while retrieving API resource count. Status code: %d", statusCode)
+	return countResponse.TotalResults, nil
 }
 
 func getDeployedApiResourceIdentifiers(resources []ApiResource) []string {

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -24,7 +24,6 @@ import (
 	"log"
 	"path"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
@@ -38,11 +37,6 @@ type Application struct {
 	Id               string               `json:"id"`
 	Name             string               `json:"name"`
 	InboundProtocols []inboundProtocolRef `json:"inboundProtocols"`
-}
-
-type AppList struct {
-	AppCount     int           `json:"totalResults"`
-	Applications []Application `json:"applications"`
 }
 
 var protocolPathToKey = map[string]string{
@@ -80,32 +74,23 @@ func getDeployedAppNames(apps []Application) []string {
 
 func getAppList() ([]Application, error) {
 
-	totalAppCount, err := getTotalAppCount()
-	if err != nil {
-		return nil, fmt.Errorf("error while retrieving application count: %w", err)
-	}
-	var list AppList
-	body, err := utils.SendGetListRequest(utils.APPLICATIONS, utils.WithQueryParams(map[string]string{"limit": strconv.Itoa(totalAppCount)}))
+	data, err := utils.SendPaginatedGetListRequest(
+		utils.APPLICATIONS,
+		"totalResults",
+		"count",
+		"offset",
+		"limit",
+		"applications",
+		0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving application list: %w", err)
 	}
-	if err = json.Unmarshal(body, &list); err != nil {
-		return nil, fmt.Errorf("error when unmarshalling the retrieved application list: %w", err)
+	var apps []Application
+	if err := json.Unmarshal(data, &apps); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling application list: %w", err)
 	}
-	return list.Applications, nil
-}
-
-func getTotalAppCount() (count int, err error) {
-
-	var list AppList
-	body, err := utils.SendGetListRequest(utils.APPLICATIONS)
-	if err != nil {
-		return -1, fmt.Errorf("failed to retrieve available app list. %w", err)
-	}
-	if err = json.Unmarshal(body, &list); err != nil {
-		return -1, fmt.Errorf("error when unmarshalling the retrieved app list. %w", err)
-	}
-	return list.AppCount, nil
+	return apps, nil
 }
 
 func getAppKeywordMapping(appName string) map[string]interface{} {

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -21,13 +21,11 @@ package applications
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"os"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
-	"text/tabwriter"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -71,9 +69,8 @@ type AuthConfig struct {
 	} `yaml:"inboundAuthenticationConfig" json:"inboundAuthenticationConfig"`
 }
 
-func getDeployedAppNames() []string {
+func getDeployedAppNames(apps []Application) []string {
 
-	apps := getAppList()
 	var appNames []string
 	for _, app := range apps {
 		appNames = append(appNames, app.Name)
@@ -81,71 +78,34 @@ func getDeployedAppNames() []string {
 	return appNames
 }
 
-func getAppList() (spIdList []Application) {
+func getAppList() ([]Application, error) {
 
 	totalAppCount, err := getTotalAppCount()
 	if err != nil {
-		log.Println("Error while retrieving application count. Retrieving only the default count.", err)
+		return nil, fmt.Errorf("error while retrieving application count: %w", err)
 	}
 	var list AppList
-	resp, err := utils.SendGetListRequest(utils.APPLICATIONS, totalAppCount)
+	body, err := utils.SendGetListRequest(utils.APPLICATIONS, utils.WithQueryParams(map[string]string{"limit": strconv.Itoa(totalAppCount)}))
 	if err != nil {
-		log.Println("Error while retrieving application list", err)
+		return nil, fmt.Errorf("error while retrieving application list: %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Fatalln(err)
-		}
-		writer := new(tabwriter.Writer)
-		writer.Init(os.Stdout, 8, 8, 0, '\t', 0)
-		defer writer.Flush()
-
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			log.Fatalln(err)
-		}
-		resp.Body.Close()
-
-		spIdList = list.Applications
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		log.Println(error)
-	} else {
-		log.Println("Error while retrieving application list")
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved application list: %w", err)
 	}
-	return spIdList
+	return list.Applications, nil
 }
 
 func getTotalAppCount() (count int, err error) {
 
 	var list AppList
-	resp, err := utils.SendGetListRequest(utils.APPLICATIONS, -1)
+	body, err := utils.SendGetListRequest(utils.APPLICATIONS)
 	if err != nil {
 		return -1, fmt.Errorf("failed to retrieve available app list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return -1, fmt.Errorf("error when reading the retrieved app list. %w", err)
-		}
-
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return -1, fmt.Errorf("error when unmarshalling the retrieved app list. %w", err)
-		}
-		resp.Body.Close()
-
-		return list.AppCount, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return -1, fmt.Errorf("error while retrieving app count. Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return -1, fmt.Errorf("error when unmarshalling the retrieved app list. %w", err)
 	}
-	return -1, fmt.Errorf("error while retrieving application count")
+	return list.AppCount, nil
 }
 
 func getAppKeywordMapping(appName string) map[string]interface{} {

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -42,8 +42,14 @@ func ExportAll(exportFilePath string, format string) {
 		return
 	}
 	exportAPIExists := utils.ExportAPIExists(utils.APPLICATIONS)
-	deployedAppNames := getDeployedAppNames()
 	applicationAuthorizedApis.InitIsSupported()
+
+	apps, err := getAppList()
+	if err != nil {
+		log.Println("Error retrieving applications list:", err)
+		return
+	}
+	deployedAppNames := getDeployedAppNames(apps)
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
@@ -68,8 +74,6 @@ func ExportAll(exportFilePath string, format string) {
 			}
 		}
 	}
-
-	apps := getAppList()
 	excludeSecrets := utils.AreSecretsExcluded(utils.TOOL_CONFIGS.ApplicationConfigs)
 	for _, app := range apps {
 		if !utils.IsResourceExcluded(app.Name, utils.TOOL_CONFIGS.ApplicationConfigs) {

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -54,7 +54,11 @@ func ImportAll(inputDirPath string) {
 		}
 	}
 
-	deployedApps := getAppList()
+	deployedApps, err := getAppList()
+	if err != nil {
+		log.Println("Error retrieving applications list:", err)
+		return
+	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
 		log.Println("Error importing applications: ", err)

--- a/iamctl/pkg/certificates/certificateUtils.go
+++ b/iamctl/pkg/certificates/certificateUtils.go
@@ -21,7 +21,6 @@ package certificates
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -33,29 +32,14 @@ type certificate struct {
 func getCertificateList() ([]certificate, error) {
 
 	var list []certificate
-	resp, err := utils.SendGetListRequest(utils.CERTIFICATES, -1)
+	body, err := utils.SendGetListRequest(utils.CERTIFICATES)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving certificate list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved certificate list. %w", err)
-		}
-
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved certificate list. %w", err)
-		}
-
-		return list, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving certificate list. Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved certificate list. %w", err)
 	}
-	return nil, fmt.Errorf("error while retrieving certificate list")
+	return list, nil
 }
 
 func getDeployedCertificateAliases() []string {

--- a/iamctl/pkg/challengeQuestions/challengeQuestionUtils.go
+++ b/iamctl/pkg/challengeQuestions/challengeQuestionUtils.go
@@ -21,7 +21,6 @@ package challengeQuestions
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -33,26 +32,14 @@ type challengeSet struct {
 func getChallengeSetList() ([]challengeSet, error) {
 
 	var list []challengeSet
-	resp, err := utils.SendGetListRequest(utils.CHALLENGE_QUESTIONS, -1)
+	body, err := utils.SendGetListRequest(utils.CHALLENGE_QUESTIONS)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving challenge question set list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved challenge question set list. %w", err)
-		}
-		if err = json.Unmarshal(body, &list); err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved challenge question set list. %w", err)
-		}
-		return list, nil
-	} else if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving challenge question set list. Status code: %d, Error: %s", statusCode, errMsg)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved challenge question set list. %w", err)
 	}
-	return nil, fmt.Errorf("error while retrieving challenge question set list")
+	return list, nil
 }
 
 func getDeployedChallengeSetIds() []string {

--- a/iamctl/pkg/claims/claimUtils.go
+++ b/iamctl/pkg/claims/claimUtils.go
@@ -51,30 +51,14 @@ var localClaimDialectSummary LocalClaimDialectSummary
 func getClaimDialectsList() ([]claimDialect, error) {
 
 	var list []claimDialect
-	resp, err := utils.SendGetListRequest(utils.CLAIMS, -1)
+	body, err := utils.SendGetListRequest(utils.CLAIMS)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving claim dialect list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved claim dialect list. %w", err)
-		}
-
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved claim dialect list. %w", err)
-		}
-		resp.Body.Close()
-
-		return list, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving claim dialect list. Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved claim dialect list. %w", err)
 	}
-	return nil, fmt.Errorf("unexpected error while retrieving claim dialect list")
+	return list, nil
 }
 
 func getClaimsList(dialectId string) ([]map[string]interface{}, error) {

--- a/iamctl/pkg/emailTemplates/emailTemplateUtils.go
+++ b/iamctl/pkg/emailTemplates/emailTemplateUtils.go
@@ -39,26 +39,14 @@ type emailTemplate struct {
 func getEmailTemplateTypeList() ([]emailTemplateType, error) {
 
 	var list []emailTemplateType
-	resp, err := utils.SendGetListRequest(utils.EMAIL_TEMPLATES, -1)
+	body, err := utils.SendGetListRequest(utils.EMAIL_TEMPLATES)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving email template type list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved email template type list. %w", err)
-		}
-		if err = json.Unmarshal(body, &list); err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved email template type list. %w", err)
-		}
-		return list, nil
-	} else if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving email template type list. Status code: %d, Error: %s", statusCode, errMsg)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved email template type list. %w", err)
 	}
-	return nil, fmt.Errorf("error while retrieving email template type list")
+	return list, nil
 }
 
 func getDeployedEmailTemplateTypeNames() []string {

--- a/iamctl/pkg/governanceConnectors/governanceConnectorUtils.go
+++ b/iamctl/pkg/governanceConnectors/governanceConnectorUtils.go
@@ -21,7 +21,6 @@ package governanceConnectors
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"strings"
 
@@ -51,26 +50,14 @@ type connector struct {
 func getCategoryList() ([]connectorCategory, error) {
 
 	var categories []connectorCategory
-	resp, err := utils.SendGetListRequest(utils.GOVERNANCE_CONNECTORS, -1)
+	body, err := utils.SendGetListRequest(utils.GOVERNANCE_CONNECTORS)
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving governance connector category list: %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error reading governance connector category list response: %w", err)
-		}
-		if err := json.Unmarshal(body, &categories); err != nil {
-			return nil, fmt.Errorf("error unmarshalling governance connector categories: %w", err)
-		}
-		return categories, nil
-	} else if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error retrieving governance connector category list. Status code: %d, Error: %s", statusCode, errMsg)
+	if err := json.Unmarshal(body, &categories); err != nil {
+		return nil, fmt.Errorf("error unmarshalling governance connector categories: %w", err)
 	}
-	return nil, fmt.Errorf("error retrieving governance connector category list")
+	return categories, nil
 }
 
 func getConnectorListForCategory(categoryId string) ([]connector, error) {

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"log"
 	"regexp"
-	"strconv"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -33,10 +32,6 @@ type identityProvider struct {
 	Name string `json:"name"`
 }
 
-type idpList struct {
-	IdpCount          int                `json:"totalResults"`
-	IdentityProviders []identityProvider `json:"identityProviders"`
-}
 type idpConfig struct {
 	Id                      string `json:"id" yaml:"id"`
 	Name                    string `json:"name" yaml:"name"`
@@ -83,36 +78,23 @@ var idpPatchSkipKeys = map[string]bool{
 
 func getIdpList() ([]identityProvider, error) {
 
-	idpCount, err := getTotalIdpCount()
+	data, err := utils.SendPaginatedGetListRequest(
+		utils.IDENTITY_PROVIDERS,
+		"totalResults",
+		"count",
+		"offset",
+		"limit",
+		"identityProviders",
+		0,
+	)
 	if err != nil {
-		return nil, fmt.Errorf("error while retrieving IDP count: %w", err)
+		return nil, fmt.Errorf("error while retrieving IDP list. %w", err)
 	}
-	var list idpList
-	if idpCount == 0 {
-		return []identityProvider{}, nil
+	var idps []identityProvider
+	if err := json.Unmarshal(data, &idps); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling IDP list. %w", err)
 	}
-	body, err := utils.SendGetListRequest(utils.IDENTITY_PROVIDERS,
-		utils.WithQueryParams(map[string]string{"limit": strconv.Itoa(idpCount)}))
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve available IDP list. %w", err)
-	}
-	if err = json.Unmarshal(body, &list); err != nil {
-		return nil, fmt.Errorf("error when unmarshalling the retrieved IDP list. %w", err)
-	}
-	return list.IdentityProviders, nil
-}
-
-func getTotalIdpCount() (count int, err error) {
-
-	var list idpList
-	body, err := utils.SendGetListRequest(utils.IDENTITY_PROVIDERS)
-	if err != nil {
-		return -1, fmt.Errorf("failed to retrieve available IDP list. %w", err)
-	}
-	if err = json.Unmarshal(body, &list); err != nil {
-		return -1, fmt.Errorf("error when unmarshalling the retrieved IDP list. %w", err)
-	}
-	return list.IdpCount, nil
+	return idps, nil
 }
 
 func getDeployedIdpNames() []string {

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -21,9 +21,9 @@ package identityproviders
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"regexp"
+	"strconv"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -85,65 +85,34 @@ func getIdpList() ([]identityProvider, error) {
 
 	idpCount, err := getTotalIdpCount()
 	if err != nil {
-		log.Println("Error: when retrieving IDP count. Retrieving only the default count.", err)
+		return nil, fmt.Errorf("error while retrieving IDP count: %w", err)
 	}
 	var list idpList
 	if idpCount == 0 {
 		return []identityProvider{}, nil
 	}
-	resp, err := utils.SendGetListRequest(utils.IDENTITY_PROVIDERS, idpCount)
+	body, err := utils.SendGetListRequest(utils.IDENTITY_PROVIDERS,
+		utils.WithQueryParams(map[string]string{"limit": strconv.Itoa(idpCount)}))
 	if err != nil {
 		return nil, fmt.Errorf("failed to retrieve available IDP list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved IDP list. %w", err)
-		}
-
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved IDP list. %w", err)
-		}
-		resp.Body.Close()
-
-		return list.IdentityProviders, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving IDP list. Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved IDP list. %w", err)
 	}
-	return nil, fmt.Errorf("error while retrieving identity provider list")
+	return list.IdentityProviders, nil
 }
 
 func getTotalIdpCount() (count int, err error) {
 
 	var list idpList
-	resp, err := utils.SendGetListRequest(utils.IDENTITY_PROVIDERS, -1)
+	body, err := utils.SendGetListRequest(utils.IDENTITY_PROVIDERS)
 	if err != nil {
 		return -1, fmt.Errorf("failed to retrieve available IDP list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return -1, fmt.Errorf("error when reading the retrieved IDP list. %w", err)
-		}
-
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return -1, fmt.Errorf("error when unmarshalling the retrieved IDP list. %w", err)
-		}
-		resp.Body.Close()
-
-		return list.IdpCount, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return -1, fmt.Errorf("error while retrieving IDP count. Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return -1, fmt.Errorf("error when unmarshalling the retrieved IDP list. %w", err)
 	}
-	return -1, fmt.Errorf("error while retrieving identity provider count")
+	return list.IdpCount, nil
 }
 
 func getDeployedIdpNames() []string {

--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -21,7 +21,6 @@ package notificationProviders
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
@@ -67,27 +66,14 @@ func getProviderLogName(resType utils.ResourceType) string {
 func getProviderList(resType utils.ResourceType) ([]notificationProvider, error) {
 
 	var list []notificationProvider
-	resp, err := utils.SendGetListRequest(resType, -1)
+	body, err := utils.SendGetListRequest(resType)
 	if err != nil {
 		return nil, fmt.Errorf("error while getting the list: %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the list: %w", err)
-		}
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the list: %w", err)
-		}
-		return list, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the list: %w", err)
 	}
-	return nil, fmt.Errorf("unknown error while getting the list")
+	return list, nil
 }
 
 func getDeployedProviderNames(providers []notificationProvider) []string {

--- a/iamctl/pkg/notificationTemplates/notificationTemplateUtils.go
+++ b/iamctl/pkg/notificationTemplates/notificationTemplateUtils.go
@@ -86,27 +86,14 @@ func getTemplateChannel(rt utils.ResourceType) string {
 func getTemplateTypeList(rt utils.ResourceType) ([]notificationTemplateType, error) {
 
 	var list []notificationTemplateType
-	resp, err := utils.SendGetListRequest(rt, -1)
+	body, err := utils.SendGetListRequest(rt)
 	if err != nil {
 		return nil, fmt.Errorf("error while getting the list: %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the list: %w", err)
-		}
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the list: %w", err)
-		}
-		return list, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the list: %w", err)
 	}
-	return nil, fmt.Errorf("unknown error while getting the list")
+	return list, nil
 }
 
 func getTemplatesList(rt utils.ResourceType, typeId string) ([]notificationTemplate, error) {

--- a/iamctl/pkg/oidcScopes/oidcScopeUtils.go
+++ b/iamctl/pkg/oidcScopes/oidcScopeUtils.go
@@ -21,7 +21,6 @@ package oidcScopes
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -33,29 +32,14 @@ type oidcScope struct {
 func getOidcScopeList() ([]oidcScope, error) {
 
 	var list []oidcScope
-	resp, err := utils.SendGetListRequest(utils.OIDC_SCOPES, -1)
+	body, err := utils.SendGetListRequest(utils.OIDC_SCOPES)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving OIDC scope list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved OIDC scope list. %w", err)
-		}
-
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved OIDC scope list. %w", err)
-		}
-
-		return list, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving OIDC scope list. Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved OIDC scope list. %w", err)
 	}
-	return nil, fmt.Errorf("error while retrieving OIDC scope list")
+	return list, nil
 }
 
 func getDeployedOidcScopeNames() []string {

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -21,6 +21,8 @@ package organizations
 import (
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -32,8 +34,14 @@ type organization struct {
 	Status    string `json:"status"`
 }
 
+type orgLink struct {
+	Href string `json:"href"`
+	Rel  string `json:"rel"`
+}
+
 type organizationsResponse struct {
 	Organizations []organization `json:"organizations"`
+	Links         []orgLink      `json:"links"`
 }
 
 var curOrgId string
@@ -57,13 +65,44 @@ func getOrganizationList() ([]organization, error) {
 	body, err := utils.SendGetListRequest(utils.ORGANIZATIONS,
 		utils.WithQueryParams(map[string]string{"recursive": "false"}))
 	if err != nil {
-		return nil, fmt.Errorf("error while retrieving list. %w", err)
+		return nil, fmt.Errorf("error while retrieving organization list: %w", err)
 	}
-	var wrapper organizationsResponse
-	if err = json.Unmarshal(body, &wrapper); err != nil {
-		return nil, fmt.Errorf("error when unmarshalling the retrieved list. %w", err)
+	var page organizationsResponse
+	if err = json.Unmarshal(body, &page); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling organization list: %w", err)
 	}
-	return wrapper.Organizations, nil
+	allResults := page.Organizations
+
+	for {
+		nextHref := ""
+		for _, link := range page.Links {
+			if link.Rel == "next" {
+				nextHref = link.Href
+				break
+			}
+		}
+		if nextHref == "" {
+			break
+		}
+
+		resp, err := utils.SendCustomRequest(http.MethodGet, utils.SERVER_CONFIGS.ServerUrl+nextHref, nil, "")
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving page of organization list: %w", err)
+		}
+		defer resp.Body.Close()
+
+		nextBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return nil, fmt.Errorf("error reading page of organization list: %w", err)
+		}
+		page = organizationsResponse{}
+		if err = json.Unmarshal(nextBody, &page); err != nil {
+			return nil, fmt.Errorf("error when unmarshalling organization list page: %w", err)
+		}
+		allResults = append(allResults, page.Organizations...)
+	}
+
+	return allResults, nil
 }
 
 func getDeployedOrgResourceNames(orgs []organization) []string {

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -21,7 +21,6 @@ package organizations
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -55,31 +54,16 @@ func GetCurrentOrganizationId() (id string, err error) {
 
 func getOrganizationList() ([]organization, error) {
 
-	resp, err := utils.SendGetListRequest(utils.ORGANIZATIONS, -1,
+	body, err := utils.SendGetListRequest(utils.ORGANIZATIONS,
 		utils.WithQueryParams(map[string]string{"recursive": "false"}))
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved list. %w", err)
-		}
-
-		var wrapper organizationsResponse
-		err = json.Unmarshal(body, &wrapper)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved list. %w", err)
-		}
-		return wrapper.Organizations, nil
-
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("Status code: %d, Error: %s", statusCode, error)
+	var wrapper organizationsResponse
+	if err = json.Unmarshal(body, &wrapper); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved list. %w", err)
 	}
-	return nil, fmt.Errorf("unknown error while retrieving list")
+	return wrapper.Organizations, nil
 }
 
 func getDeployedOrgResourceNames(orgs []organization) []string {

--- a/iamctl/pkg/organizations/organizationUtils.go
+++ b/iamctl/pkg/organizations/organizationUtils.go
@@ -89,9 +89,17 @@ func getOrganizationList() ([]organization, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving page of organization list: %w", err)
 		}
-		defer resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			if errMsg, ok := utils.ErrorCodes[resp.StatusCode]; ok {
+				return nil, fmt.Errorf("error response for organization list page request: %s", errMsg)
+			}
+			return nil, fmt.Errorf("unexpected error when retrieving organization list page: %s", resp.Status)
+		}
 
 		nextBody, err := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
 		if err != nil {
 			return nil, fmt.Errorf("error reading page of organization list: %w", err)
 		}

--- a/iamctl/pkg/roles/rolesUtils.go
+++ b/iamctl/pkg/roles/rolesUtils.go
@@ -21,7 +21,6 @@ package roles
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"strings"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/organizations"
@@ -49,30 +48,14 @@ type rolePatchRequest struct {
 
 func getRoleList() ([]role, error) {
 
-	resp, err := utils.SendGetListRequest(utils.ROLES, -1)
+	body, err := utils.SendGetListRequest(utils.ROLES)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving role list: %w", err)
 	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != 200 {
-		if errMsg, ok := utils.ErrorCodes[resp.StatusCode]; ok {
-			return nil, fmt.Errorf("error while retrieving roles list. Status: %d, Error: %s", resp.StatusCode, errMsg)
-		}
-		return nil, fmt.Errorf("error while retrieving roles list. Status: %d", resp.StatusCode)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error when reading the retrieved roles list: %w", err)
-	}
-
 	var listResp roleListResponse
-	err = json.Unmarshal(body, &listResp)
-	if err != nil {
+	if err = json.Unmarshal(body, &listResp); err != nil {
 		return nil, fmt.Errorf("error when unmarshalling the retrieved roles list: %w", err)
 	}
-
 	return listResp.Resources, nil
 }
 

--- a/iamctl/pkg/roles/rolesUtils.go
+++ b/iamctl/pkg/roles/rolesUtils.go
@@ -32,10 +32,6 @@ type role struct {
 	DisplayName string `json:"displayName"`
 }
 
-type roleListResponse struct {
-	Resources []role `json:"Resources"`
-}
-
 type patchOperation struct {
 	Op    string                 `json:"op"`
 	Value map[string]interface{} `json:"value"`
@@ -48,15 +44,23 @@ type rolePatchRequest struct {
 
 func getRoleList() ([]role, error) {
 
-	body, err := utils.SendGetListRequest(utils.ROLES)
+	data, err := utils.SendPaginatedGetListRequest(
+		utils.ROLES,
+		"totalResults",
+		"itemsPerPage",
+		"startIndex",
+		"count",
+		"Resources",
+		1,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving role list: %w", err)
 	}
-	var listResp roleListResponse
-	if err = json.Unmarshal(body, &listResp); err != nil {
-		return nil, fmt.Errorf("error when unmarshalling the retrieved roles list: %w", err)
+	var roles []role
+	if err := json.Unmarshal(data, &roles); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling roles list: %w", err)
 	}
-	return listResp.Resources, nil
+	return roles, nil
 }
 
 func getDeployedRoleLocalFileNames(roles []role) []string {

--- a/iamctl/pkg/scriptLibraries/scriptLibraryUtils.go
+++ b/iamctl/pkg/scriptLibraries/scriptLibraryUtils.go
@@ -30,21 +30,25 @@ type scriptLibrary struct {
 	Description string `json:"description"`
 }
 
-type scriptLibraryListResponse struct {
-	ScriptLibraries []scriptLibrary `json:"scriptLibraries"`
-}
-
 func getScriptLibraryList() ([]scriptLibrary, error) {
 
-	body, err := utils.SendGetListRequest(utils.SCRIPT_LIBRARIES)
+	data, err := utils.SendPaginatedGetListRequest(
+		utils.SCRIPT_LIBRARIES,
+		"totalResults",
+		"count",
+		"offset",
+		"limit",
+		"scriptLibraries",
+		0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving script library list. %w", err)
 	}
-	var listResponse scriptLibraryListResponse
-	if err = json.Unmarshal(body, &listResponse); err != nil {
-		return nil, fmt.Errorf("error when unmarshalling the retrieved script library list. %w", err)
+	var libraries []scriptLibrary
+	if err := json.Unmarshal(data, &libraries); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling script library list. %w", err)
 	}
-	return listResponse.ScriptLibraries, nil
+	return libraries, nil
 }
 
 func getDeployedScriptLibraryNames() []string {
@@ -99,4 +103,3 @@ func getScriptLibraryData(libraryName string) (map[string]interface{}, error) {
 	dataMap["content"] = string(contentBytes)
 	return dataMap, nil
 }
-

--- a/iamctl/pkg/scriptLibraries/scriptLibraryUtils.go
+++ b/iamctl/pkg/scriptLibraries/scriptLibraryUtils.go
@@ -21,7 +21,6 @@ package scriptLibraries
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -37,30 +36,15 @@ type scriptLibraryListResponse struct {
 
 func getScriptLibraryList() ([]scriptLibrary, error) {
 
-	resp, err := utils.SendGetListRequest(utils.SCRIPT_LIBRARIES, -1)
+	body, err := utils.SendGetListRequest(utils.SCRIPT_LIBRARIES)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving script library list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved script library list. %w", err)
-		}
-
-		var listResponse scriptLibraryListResponse
-		err = json.Unmarshal(body, &listResponse)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved script library list. %w", err)
-		}
-
-		return listResponse.ScriptLibraries, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving script library list. Status code: %d, Error: %s", statusCode, error)
+	var listResponse scriptLibraryListResponse
+	if err = json.Unmarshal(body, &listResponse); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved script library list. %w", err)
 	}
-	return nil, fmt.Errorf("error while retrieving script library list")
+	return listResponse.ScriptLibraries, nil
 }
 
 func getDeployedScriptLibraryNames() []string {

--- a/iamctl/pkg/userStores/userStoreUtils.go
+++ b/iamctl/pkg/userStores/userStoreUtils.go
@@ -21,7 +21,6 @@ package userstores
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"regexp"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
@@ -42,30 +41,14 @@ type UserStoreConfigurations struct {
 func getUserStoreList() ([]userStore, error) {
 
 	var list []userStore
-	resp, err := utils.SendGetListRequest(utils.USERSTORES, -1)
+	body, err := utils.SendGetListRequest(utils.USERSTORES)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving user store list. %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode == 200 {
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, fmt.Errorf("error when reading the retrieved user store list. %w", err)
-		}
-
-		err = json.Unmarshal(body, &list)
-		if err != nil {
-			return nil, fmt.Errorf("error when unmarshalling the retrieved user store list. %w", err)
-		}
-		resp.Body.Close()
-
-		return list, nil
-	} else if error, ok := utils.ErrorCodes[statusCode]; ok {
-		return nil, fmt.Errorf("error while retrieving user store list. Status code: %d, Error: %s", statusCode, error)
+	if err = json.Unmarshal(body, &list); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling the retrieved user store list. %w", err)
 	}
-	return nil, fmt.Errorf("unexpected error while retrieving user store list")
+	return list, nil
 }
 
 func getDeployedUserstoreNames() []string {

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -530,36 +530,50 @@ func SendPatchRequest(resourceType ResourceType, resourceId string, requestBody 
 	return resp, nil
 }
 
-func SendGetListRequest(resourceType ResourceType, resourceLimit int, opts ...SendOption) (*http.Response, error) {
+func SendGetListRequest(resourceType ResourceType, opts ...SendOption) ([]byte, error) {
 
 	cfg := applySendOptions(opts)
-	var reqUrl = buildRequestUrl(LIST, resourceType, "")
+	reqUrl := buildRequestUrl(LIST, resourceType, "")
 	reqUrl = addQueryParams(reqUrl, resourceType, LIST)
-	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
 
 	req, err := http.NewRequest("GET", reqUrl, bytes.NewBuffer(nil))
 	if err != nil {
-		return nil, fmt.Errorf("error creating Get List request: %w", err)
+		return nil, fmt.Errorf("error creating GET list request: %w", err)
 	}
 	req.Header.Set("Authorization", "Bearer "+SERVER_CONFIGS.Token)
-	req.Header.Set("accept", "*/*")
+	req.Header.Set("Accept", MEDIA_TYPE_JSON)
 
 	query := req.URL.Query()
-	if resourceLimit != -1 {
-		query.Add("limit", strconv.Itoa(resourceLimit))
-	}
 	for k, v := range cfg.queryParams {
 		query.Add(k, v)
 	}
 	req.URL.RawQuery = query.Encode()
 	defer req.Body.Close()
 
-	httpClient := &http.Client{}
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve available resource list. %w", err)
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		},
 	}
-	return resp, nil
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("error sending GET list request. %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		if errMsg, ok := ErrorCodes[resp.StatusCode]; ok {
+			return nil, fmt.Errorf("error response for the GET list request. Error: %s", errMsg)
+		}
+		return nil, fmt.Errorf("unexpected error when sending GET list request: %d", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading response body: %w", err)
+	}
+	return body, nil
 }
 
 func SendCustomRequest(method, reqURL string, body []byte, contentType string) (*http.Response, error) {

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -597,9 +597,12 @@ func SendPaginatedGetListRequest(resourceType ResourceType, totField, curCountFi
 	if err != nil {
 		return nil, fmt.Errorf("error reading %s from response: %w", curCountField, err)
 	}
-	allResults, err := extractResultsArray(firstResponse, resultsField)
+	allResults, exists, err := extractResultsArray(firstResponse, resultsField)
 	if err != nil {
 		return nil, fmt.Errorf("error reading results array from response: %w", err)
+	}
+	if !exists && totalCount > 0 {
+		return nil, fmt.Errorf("results field %q not found in response", resultsField)
 	}
 
 	if totalCount <= pageSize || pageSize == 0 {
@@ -627,7 +630,7 @@ func SendPaginatedGetListRequest(resourceType ResourceType, totField, curCountFi
 			return nil, fmt.Errorf("error parsing paginated list response: %w", err)
 		}
 
-		pageResults, err := extractResultsArray(pageResponse, resultsField)
+		pageResults, _, err := extractResultsArray(pageResponse, resultsField)
 		if err != nil {
 			return nil, fmt.Errorf("error reading results array from response: %w", err)
 		}
@@ -834,15 +837,15 @@ func extractIntField(m map[string]interface{}, field string) (int, error) {
 	return int(f), nil
 }
 
-func extractResultsArray(m map[string]interface{}, field string) ([]interface{}, error) {
+func extractResultsArray(m map[string]interface{}, field string) (results []interface{}, exists bool, err error) {
 
 	val, ok := m[field]
 	if !ok {
-		return []interface{}{}, nil
+		return []interface{}{}, false, nil
 	}
 	arr, ok := val.([]interface{})
 	if !ok {
-		return nil, fmt.Errorf("unexpected format for results field %q", field)
+		return nil, true, fmt.Errorf("unexpected format for results field %q", field)
 	}
-	return arr, nil
+	return arr, true, nil
 }

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -576,6 +576,74 @@ func SendGetListRequest(resourceType ResourceType, opts ...SendOption) ([]byte, 
 	return body, nil
 }
 
+func SendPaginatedGetListRequest(resourceType ResourceType, totField, curCountField, offsetField, limitField, resultsField string, startIndex int, opts ...SendOption) ([]byte, error) {
+
+	cfg := applySendOptions(opts)
+
+	firstBody, err := SendGetListRequest(resourceType, WithQueryParams(cfg.queryParams))
+	if err != nil {
+		return nil, err
+	}
+	var firstResponse map[string]interface{}
+	if err := json.Unmarshal(firstBody, &firstResponse); err != nil {
+		return nil, fmt.Errorf("error parsing paginated list response: %w", err)
+	}
+
+	totalCount, err := extractIntField(firstResponse, totField)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s from response: %w", totField, err)
+	}
+	pageSize, err := extractIntField(firstResponse, curCountField)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s from response: %w", curCountField, err)
+	}
+	allResults, err := extractResultsArray(firstResponse, resultsField)
+	if err != nil {
+		return nil, fmt.Errorf("error reading results array from response: %w", err)
+	}
+
+	if totalCount <= pageSize || pageSize == 0 {
+		data, err := json.Marshal(allResults)
+		if err != nil {
+			return nil, fmt.Errorf("error marshalling initial results: %w", err)
+		}
+		return data, nil
+	}
+
+	for nextOffset := startIndex + pageSize; len(allResults) < totalCount; nextOffset += pageSize {
+		pageParams := make(map[string]string)
+		for k, v := range cfg.queryParams {
+			pageParams[k] = v
+		}
+		pageParams[offsetField] = strconv.Itoa(nextOffset)
+		pageParams[limitField] = strconv.Itoa(pageSize)
+
+		pageBody, err := SendGetListRequest(resourceType, WithQueryParams(pageParams))
+		if err != nil {
+			return nil, err
+		}
+		var pageResponse map[string]interface{}
+		if err := json.Unmarshal(pageBody, &pageResponse); err != nil {
+			return nil, fmt.Errorf("error parsing paginated list response: %w", err)
+		}
+
+		pageResults, err := extractResultsArray(pageResponse, resultsField)
+		if err != nil {
+			return nil, fmt.Errorf("error reading results array from response: %w", err)
+		}
+		if len(pageResults) == 0 {
+			break
+		}
+		allResults = append(allResults, pageResults...)
+	}
+
+	data, err := json.Marshal(allResults)
+	if err != nil {
+		return nil, fmt.Errorf("error marshalling combined results: %w", err)
+	}
+	return data, nil
+}
+
 func SendCustomRequest(method, reqURL string, body []byte, contentType string) (*http.Response, error) {
 
 	var reqBody io.Reader
@@ -751,4 +819,30 @@ func addQueryParams(reqURL string, resourceType ResourceType, operation string) 
 func IsResourceNotFound(err error) bool {
 
 	return err != nil && strings.Contains(err.Error(), ErrorCodes[404])
+}
+
+func extractIntField(m map[string]interface{}, field string) (int, error) {
+
+	val, ok := m[field]
+	if !ok {
+		return 0, fmt.Errorf("field %q not found in response", field)
+	}
+	f, ok := val.(float64)
+	if !ok {
+		return 0, fmt.Errorf("unexpected type for field %q", field)
+	}
+	return int(f), nil
+}
+
+func extractResultsArray(m map[string]interface{}, field string) ([]interface{}, error) {
+
+	val, ok := m[field]
+	if !ok {
+		return []interface{}{}, nil
+	}
+	arr, ok := val.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("unexpected format for results field %q", field)
+	}
+	return arr, nil
 }

--- a/iamctl/pkg/workflows/workflowUtils.go
+++ b/iamctl/pkg/workflows/workflowUtils.go
@@ -57,60 +57,27 @@ var exportedAssociationNames []string
 
 func getWorkflowList() ([]workflow, error) {
 
-	resp, err := utils.SendGetListRequest(utils.WORKFLOWS, -1)
+	body, err := utils.SendGetListRequest(utils.WORKFLOWS)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving workflow list: %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode != 200 {
-		if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
-			return nil, fmt.Errorf("error while retrieving workflow list. Status code: %d, Error: %s", statusCode, errMsg)
-		}
-		return nil, fmt.Errorf("error while retrieving workflow list. Status code: %d", statusCode)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error when reading the retrieved workflow list: %w", err)
-	}
-
 	var listResponse workflowListResponse
-	err = json.Unmarshal(body, &listResponse)
-	if err != nil {
+	if err = json.Unmarshal(body, &listResponse); err != nil {
 		return nil, fmt.Errorf("error when unmarshalling the retrieved workflow list: %w", err)
 	}
-
 	return listResponse.Workflows, nil
 }
 
 func getWorkflowAssociationsList() ([]workflowAssociation, error) {
 
-	resp, err := utils.SendGetListRequest(utils.WORKFLOW_ASSOCIATIONS, -1)
+	body, err := utils.SendGetListRequest(utils.WORKFLOW_ASSOCIATIONS)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving workflow association list: %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode != 200 {
-		if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
-			return nil, fmt.Errorf("error while retrieving workflow association list. Status code: %d, Error: %s", statusCode, errMsg)
-		}
-		return nil, fmt.Errorf("error while retrieving workflow association list. Status code: %d", statusCode)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("error when reading the retrieved workflow association list: %w", err)
-	}
-
 	var listResponse workflowAssociationListResponse
 	if err := json.Unmarshal(body, &listResponse); err != nil {
 		return nil, fmt.Errorf("error when unmarshalling the retrieved workflow association list: %w", err)
 	}
-
 	return listResponse.WorkflowAssociations, nil
 }
 
@@ -164,26 +131,11 @@ func getWfAssocId(name string, list []workflowAssociation) string {
 
 func getAssociationsOfWorkflow(workflowId string) ([]interface{}, []workflowAssociation, error) {
 
-	resp, err := utils.SendGetListRequest(utils.WORKFLOW_ASSOCIATIONS, -1,
+	body, err := utils.SendGetListRequest(utils.WORKFLOW_ASSOCIATIONS,
 		utils.WithQueryParams(map[string]string{"filter": "workflowId eq " + workflowId}))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error while retrieving associations: %w", err)
 	}
-	defer resp.Body.Close()
-
-	statusCode := resp.StatusCode
-	if statusCode != 200 {
-		if errMsg, ok := utils.ErrorCodes[statusCode]; ok {
-			return nil, nil, fmt.Errorf("error while retrieving associations. Status code: %d, Error: %s", statusCode, errMsg)
-		}
-		return nil, nil, fmt.Errorf("error while retrieving associations for workflow. Status code: %d", statusCode)
-	}
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error when reading associations: %w", err)
-	}
-
 	var rawResp associationsOfWorkflowResponse
 	if err := json.Unmarshal(body, &rawResp); err != nil {
 		return nil, nil, fmt.Errorf("error when unmarshalling associations data: %w", err)

--- a/iamctl/pkg/workflows/workflowUtils.go
+++ b/iamctl/pkg/workflows/workflowUtils.go
@@ -33,10 +33,6 @@ type workflow struct {
 	Name string `json:"name"`
 }
 
-type workflowListResponse struct {
-	Workflows []workflow `json:"workflows"`
-}
-
 type workflowAssociation struct {
 	ID           string `json:"id"`
 	Name         string `json:"associationName"`
@@ -57,28 +53,44 @@ var exportedAssociationNames []string
 
 func getWorkflowList() ([]workflow, error) {
 
-	body, err := utils.SendGetListRequest(utils.WORKFLOWS)
+	data, err := utils.SendPaginatedGetListRequest(
+		utils.WORKFLOWS,
+		"totalResults",
+		"count",
+		"offset",
+		"limit",
+		"workflows",
+		0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving workflow list: %w", err)
 	}
-	var listResponse workflowListResponse
-	if err = json.Unmarshal(body, &listResponse); err != nil {
-		return nil, fmt.Errorf("error when unmarshalling the retrieved workflow list: %w", err)
+	var workflows []workflow
+	if err := json.Unmarshal(data, &workflows); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling workflow list: %w", err)
 	}
-	return listResponse.Workflows, nil
+	return workflows, nil
 }
 
 func getWorkflowAssociationsList() ([]workflowAssociation, error) {
 
-	body, err := utils.SendGetListRequest(utils.WORKFLOW_ASSOCIATIONS)
+	data, err := utils.SendPaginatedGetListRequest(
+		utils.WORKFLOW_ASSOCIATIONS,
+		"totalResults",
+		"count",
+		"offset",
+		"limit",
+		"workflowAssociations",
+		0,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error while retrieving workflow association list: %w", err)
 	}
-	var listResponse workflowAssociationListResponse
-	if err := json.Unmarshal(body, &listResponse); err != nil {
-		return nil, fmt.Errorf("error when unmarshalling the retrieved workflow association list: %w", err)
+	var associations []workflowAssociation
+	if err := json.Unmarshal(data, &associations); err != nil {
+		return nil, fmt.Errorf("error when unmarshalling workflow association list: %w", err)
 	}
-	return listResponse.WorkflowAssociations, nil
+	return associations, nil
 }
 
 func getDeployedWorkflowNames(workflows []workflow) []string {


### PR DESCRIPTION
## Purpose

 List API calls across all resource types previously fetched only the first page of results (or used a fragile two-step count-then-fetch approach). On servers with large numbers of resources, this silently truncated the working set, exported files would be incomplete and imports would incorrectly create resources that already existed beyond the first page.

 This PR adds correct pagination handling for all resource types, and refactors `SendGetListRequest` to consolidate response-body reading that was previously duplicated across 15+ callers.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Fixes: https://github.com/wso2/product-is/issues/27617

  ## Goals

  - Ensure all list fetches retrieve the complete set of deployed resources regardless of server-side page limits
  - Provide a reusable `SendPaginatedGetListRequest` utility for offset-based pagination
  - Handle SCIM (1-based `startIndex`) and cursor-based (Organizations `links[]`) pagination patterns without forcing them into a common mold
  - Eliminate duplicated response-reading boilerplate from every `getXxxList` function

  ## Approach

  ### `SendGetListRequest` refactor

  Previously, `SendGetListRequest` returned `*http.Response` and every caller was responsible for reading the body, checking the status code, and closing the response. This commit centralises that: `SendGetListRequest` now returns `([]byte, error)`, handles status-code checking internally, and all 15+ callers were updated to match.

  ### `SendPaginatedGetListRequest`

  A new utility in `apiUtils.go` that handles offset-based pagination generically. It accepts the field names for total count, current page count, offset param, limit param, and results array as string arguments, allowing it to cover APIs that differ in naming:

  | Resource | `totField` | `curCountField` | `offsetField` | `limitField` | `resultsField` | `startIndex` |
  |---|---|---|---|---|---|---|
  | Applications, IDPs, Workflows, Script Libraries | `totalResults` | `count` | `offset` | `limit` | (resource name) | `0` |
  | Roles (SCIM) | `totalResults` | `itemsPerPage` | `startIndex` | `count` | `Resources` | `1` |

  The function fetches the first page via `SendGetListRequest`, reads `totalResults` and the current page count, and if more pages exist loops with increasing offset until all results are accumulated. The combined results array is returned as `[]byte` for direct `json.Unmarshal` by the caller.

  ### Per-resource migrations

  **Applications** — also fixes `getAppList()` which previously suppressed errors and had `getDeployedAppNames` calling the API internally. The function now returns `([]Application, error)` and `getDeployedAppNames` takes the already-fetched slice.

  **Identity Providers** — the two-step `getTotalIdpCount()` + `SendGetListRequest(limit=N)` pattern is replaced with a single `SendPaginatedGetListRequest` call. `getTotalIdpCount` and the `idpList` wrapper struct are removed.

  **Workflows / Workflow Associations** — both list functions migrated; `workflowListResponse` struct removed. `getAssociationsOfWorkflow` (a filtered sub-query by workflow ID, not a full list) is intentionally left on `SendGetListRequest`.

  **Script Libraries** — straightforward migration; `scriptLibraryListResponse` struct removed.

  **Roles** — uses SCIM field names and `startIndex=1` (1-based). `roleListResponse` struct removed.

  **Organizations** — the IS organizations API uses cursor-based pagination: the response body contains a `links` array where an entry with `"rel": "next"` carries an `href` for the next page. This cannot use `SendPaginatedGetListRequest`. Instead, `getOrganizationList` loops: after each page it checks for a next link, calls `SendCustomRequest` with `SERVER_CONFIGS.ServerUrl + href`, reads the body, and appends until no next link is present. An `orgLink` struct and an updated `organizationsResponse` (adding `Links []orgLink`) support this. The first page still goes through `SendGetListRequest` to keep auth and error handling consistent.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved pagination support for API requests to better handle large result sets

* **Refactor**
  * Standardized internal API request handling across modules for consistent behavior
  * Refined error handling with more descriptive contextual messages
  * Cleaned up deprecated dependencies from internal utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-extensions/identity-tools-cli/pull/102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->