### PR TITLE
Improve logging: structured PrintLog, log level config, per-resource summary, debug API logging

### DIFF
--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -19,6 +19,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
 	actions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/actions"
@@ -82,6 +84,7 @@ var exportAllCmd = &cobra.Command{
 			utils.FLOWS:                 flows.ExportAll,
 		}
 
+		utils.StartTime = time.Now()
 		for _, resourceType := range utils.ResourceOrder {
 			if exportFunc, exists := exportFunctions[resourceType]; exists {
 				if resourceType != utils.BRANDING {

--- a/iamctl/cmd/cli/exportAll.go
+++ b/iamctl/cmd/cli/exportAll.go
@@ -22,14 +22,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
 	actions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/actions"
-	branding "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/branding"
 	apiResources "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/apiResources"
-	flows "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/flows"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/applications"
+	branding "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/branding"
 	certificates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/certificates"
 	challengeQuestions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/challengeQuestions"
 	claims "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/claims"
 	emailTemplates "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/emailTemplates"
+	flows "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/flows"
 	governanceConnectors "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/governanceConnectors"
 	identityproviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/identityProviders"
 	notificationProviders "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/notificationProviders"
@@ -84,7 +84,13 @@ var exportAllCmd = &cobra.Command{
 
 		for _, resourceType := range utils.ResourceOrder {
 			if exportFunc, exists := exportFunctions[resourceType]; exists {
+				if resourceType != utils.BRANDING {
+					utils.MarkResTypeStart(resourceType)
+				}
 				exportFunc(outputDirPath, format)
+				if resourceType != utils.BRANDING {
+					utils.MarkResTypeEnd(resourceType)
+				}
 			}
 		}
 

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -83,7 +83,13 @@ var importAllCmd = &cobra.Command{
 
 		for _, resourceType := range utils.ResourceOrder {
 			if importFunc, exists := importFunctions[resourceType]; exists {
+				if resourceType != utils.BRANDING {
+					utils.MarkResTypeStart(resourceType)
+				}
 				importFunc(inputDirPath)
+				if resourceType != utils.BRANDING {
+					utils.MarkResTypeEnd(resourceType)
+				}
 			}
 		}
 

--- a/iamctl/cmd/cli/importAll.go
+++ b/iamctl/cmd/cli/importAll.go
@@ -19,6 +19,8 @@
 package cli
 
 import (
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/cmd"
 	actions "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/actions"
@@ -81,6 +83,7 @@ var importAllCmd = &cobra.Command{
 			utils.FLOWS:                 flows.ImportAll,
 		}
 
+		utils.StartTime = time.Now()
 		for _, resourceType := range utils.ResourceOrder {
 			if importFunc, exists := importFunctions[resourceType]; exists {
 				if resourceType != utils.BRANDING {

--- a/iamctl/pkg/actions/export.go
+++ b/iamctl/pkg/actions/export.go
@@ -21,7 +21,6 @@ package actions
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(outputDirPath, format string) {
 
-	log.Println("Exporting actions...")
+	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, "", "Exporting actions...")
 	actionsDir := filepath.Join(outputDirPath, utils.ACTIONS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.ACTIONS) || !utils.IsEntitySupportedInOrg(utils.ACTIONS) || utils.IsResourceTypeExcluded(utils.ACTIONS) {
@@ -38,17 +37,17 @@ func ExportAll(outputDirPath, format string) {
 	}
 	types, err := getActionTypesList()
 	if err != nil {
-		log.Println("Error retrieving action types list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error retrieving action types list: %s", err))
 		return
 	}
 
 	if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.ActionConfigs) {
-		log.Println("Warn: Secrets exclusion cannot be disabled for actions. All secrets will be masked.")
+		utils.PrintLog(utils.LogLevelWarn, utils.ACTIONS, "", "Secrets exclusion cannot be disabled for actions. All secrets will be masked.")
 	}
 
 	if _, err := os.Stat(actionsDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(actionsDir, 0700); err != nil {
-			log.Println("Error creating actions directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error creating actions directory: %s", err))
 			return
 		}
 	}
@@ -62,12 +61,12 @@ func ExportAll(outputDirPath, format string) {
 		hadActions, err := exportActionType(at, actionsDir, format)
 		if err != nil {
 			utils.UpdateFailureSummary(utils.ACTIONS, at.ID)
-			log.Printf("Error exporting action type %s: %s", at.ID, err)
+			utils.PrintLog(utils.LogLevelError, utils.ACTIONS, at.ID, fmt.Sprintf("Error exporting action type: %s", err))
 		} else {
 			if hadActions {
 				typesWithActions = append(typesWithActions, at.ID)
 				utils.UpdateSuccessSummary(utils.ACTIONS, utils.EXPORT)
-				log.Println("Action type exported successfully:", at.ID)
+				utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, at.ID, "Exported successfully")
 			}
 		}
 	}
@@ -87,7 +86,7 @@ func exportActionType(actionType actionType, parentDir, format string) (bool, er
 		return false, nil
 	}
 
-	log.Println("Exporting action type:", actionType.ID)
+	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, actionType.ID, "Exporting action type")
 	typeDir := filepath.Join(parentDir, actionType.ID)
 	if _, err := os.Stat(typeDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(typeDir, 0700); err != nil {

--- a/iamctl/pkg/actions/export.go
+++ b/iamctl/pkg/actions/export.go
@@ -32,12 +32,13 @@ func ExportAll(outputDirPath, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, "", "Exporting actions...")
 	actionsDir := filepath.Join(outputDirPath, utils.ACTIONS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.ACTIONS) || !utils.IsEntitySupportedInOrg(utils.ACTIONS) || utils.IsResourceTypeExcluded(utils.ACTIONS) {
+	if utils.ShouldSkip(utils.ACTIONS) {
 		return
 	}
 	types, err := getActionTypesList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error retrieving action types list: %s", err))
+		utils.MarkResTypeFailure(utils.ACTIONS)
 		return
 	}
 
@@ -48,6 +49,7 @@ func ExportAll(outputDirPath, format string) {
 	if _, err := os.Stat(actionsDir); os.IsNotExist(err) {
 		if err := os.MkdirAll(actionsDir, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error creating actions directory: %s", err))
+			utils.MarkResTypeFailure(utils.ACTIONS)
 			return
 		}
 	}

--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -31,24 +30,24 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing actions...")
+	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, "", "Importing actions...")
 	importFilePath := filepath.Join(inputDirPath, utils.ACTIONS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.ACTIONS) || !utils.IsEntitySupportedInOrg(utils.ACTIONS) || utils.IsResourceTypeExcluded(utils.ACTIONS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No actions to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, "", "No actions to import.")
 		return
 	}
 
 	deployedTypes, err := getActionTypesList()
 	if err != nil {
-		log.Println("Error retrieving action types list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error retrieving action types list: %s", err))
 	}
 	typeFolders, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error reading action type directories: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error reading action type directories: %s", err))
 		return
 	}
 
@@ -66,7 +65,7 @@ func ImportAll(inputDirPath string) {
 			err := importActionType(importFilePath, typeName)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.ACTIONS, typeName)
-				log.Printf("Error importing action type %s: %s", typeName, err)
+				utils.PrintLog(utils.LogLevelError, utils.ACTIONS, typeName, fmt.Sprintf("Error importing action type: %s", err))
 			}
 		}
 	}
@@ -141,7 +140,7 @@ func importAction(typeName, actionId, actionName, filePath string) error {
 
 func createAction(typeName, actionName, status string, actionMap map[string]interface{}) error {
 
-	log.Printf("Creating new action: %s of type %s", actionName, typeName)
+	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, actionName, fmt.Sprintf("Creating new action of type %s", typeName))
 
 	delete(actionMap, "version")
 	jsonBody, err := utils.Serialize(actionMap, utils.FormatJSON, utils.ACTIONS)
@@ -169,13 +168,13 @@ func createAction(typeName, actionName, status string, actionMap map[string]inte
 	}
 
 	utils.UpdateSuccessSummary(utils.ACTIONS, utils.IMPORT)
-	log.Println("Action imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, actionName, "Imported successfully")
 	return nil
 }
 
 func updateAction(typeName, actionId, actionName, status string, actionMap map[string]interface{}) error {
 
-	log.Printf("Updating action: %s of type %s", actionName, typeName)
+	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, actionName, fmt.Sprintf("Updating action of type %s", typeName))
 
 	if err := addMissingFields(actionMap, typeName, actionId); err != nil {
 		return fmt.Errorf("error adding missing fields: %w", err)
@@ -196,7 +195,7 @@ func updateAction(typeName, actionId, actionName, status string, actionMap map[s
 	}
 
 	utils.UpdateSuccessSummary(utils.ACTIONS, utils.UPDATE)
-	log.Println("Action updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, actionName, "Updated successfully")
 	return nil
 }
 
@@ -214,17 +213,17 @@ func removeDeletedDeployedActionTypes(localDirs []os.FileInfo, deployedTypes []a
 			continue
 		}
 		if utils.IsResourceExcluded(deployedType.ID, utils.TOOL_CONFIGS.ActionConfigs) {
-			log.Printf("Action type: %s is excluded from deletion.", deployedType.ID)
+			utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, deployedType.ID, "Excluded from deletion.")
 			continue
 		}
 		actions, err := getActionsList(deployedType.ID)
 		if err != nil {
-			log.Printf("Error retrieving deployed actions for type %s: %s", deployedType.ID, err)
+			utils.PrintLog(utils.LogLevelError, utils.ACTIONS, deployedType.ID, fmt.Sprintf("Error retrieving deployed actions: %s", err))
 			continue
 		}
 		if err := removeDeletedDeployedActions(deployedType.ID, nil, actions); err != nil {
 			utils.UpdateFailureSummary(utils.ACTIONS, deployedType.ID)
-			log.Printf("Error deleting actions for type %s: %s", deployedType.ID, err)
+			utils.PrintLog(utils.LogLevelError, utils.ACTIONS, deployedType.ID, fmt.Sprintf("Error deleting actions: %s", err))
 		}
 	}
 }
@@ -245,7 +244,7 @@ func removeDeletedDeployedActions(typeName string, localFiles []os.FileInfo, dep
 		if _, existsLocally := localResourceNames[action.Name]; existsLocally {
 			continue
 		}
-		log.Printf("Action: %s of type %s not found locally. Deleting action.\n", action.Name, typeName)
+		utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, action.Name, fmt.Sprintf("Not found locally. Deleting action of type %s.", typeName))
 		if err := utils.SendDeleteRequest(typeName+"/"+action.ID, utils.ACTIONS); err != nil {
 			return fmt.Errorf("error deleting action: %s. %w", action.Name, err)
 		} else {

--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -33,7 +33,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.ACTIONS, "", "Importing actions...")
 	importFilePath := filepath.Join(inputDirPath, utils.ACTIONS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.ACTIONS) || !utils.IsEntitySupportedInOrg(utils.ACTIONS) || utils.IsResourceTypeExcluded(utils.ACTIONS) {
+	if utils.ShouldSkip(utils.ACTIONS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -44,6 +44,7 @@ func ImportAll(inputDirPath string) {
 	deployedTypes, err := getActionTypesList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error retrieving action types list: %s", err))
+		utils.MarkResTypeFailure(utils.ACTIONS)
 	}
 	typeFolders, err := ioutil.ReadDir(importFilePath)
 	if err != nil {

--- a/iamctl/pkg/apiResources/export.go
+++ b/iamctl/pkg/apiResources/export.go
@@ -32,18 +32,20 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, "", "Exporting API resources...")
 	exportFilePath = filepath.Join(exportFilePath, utils.API_RESOURCES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.API_RESOURCES) || !utils.IsEntitySupportedInOrg(utils.API_RESOURCES) || utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
+	if utils.ShouldSkip(utils.API_RESOURCES) {
 		return
 	}
 	resources, err := GetApiResourceList(true)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error when retrieving API resource list: %s", err))
+		utils.MarkResTypeFailure(utils.API_RESOURCES)
 		return
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error creating API resources directory: %s", err))
+			utils.MarkResTypeFailure(utils.API_RESOURCES)
 			return
 		}
 	} else {

--- a/iamctl/pkg/apiResources/export.go
+++ b/iamctl/pkg/apiResources/export.go
@@ -21,7 +21,6 @@ package apiResources
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting API resources...")
+	utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, "", "Exporting API resources...")
 	exportFilePath = filepath.Join(exportFilePath, utils.API_RESOURCES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.API_RESOURCES) || !utils.IsEntitySupportedInOrg(utils.API_RESOURCES) || utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
@@ -38,13 +37,13 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	resources, err := GetApiResourceList(true)
 	if err != nil {
-		log.Println("Error: when retrieving API resource list.", err)
+		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error when retrieving API resource list: %s", err))
 		return
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating API resources directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error creating API resources directory: %s", err))
 			return
 		}
 	} else {
@@ -59,15 +58,15 @@ func ExportAll(exportFilePath string, format string) {
 
 	for _, resource := range resources {
 		if !utils.IsResourceExcluded(resource.Identifier, utils.TOOL_CONFIGS.ApiResourceConfigs) {
-			log.Println("Exporting API resource:", resource.Identifier)
+			utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resource.Identifier, "Exporting")
 			err := exportApiResource(resource.ID, resource.Identifier, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.API_RESOURCES, resource.Identifier)
-				log.Printf("Error while exporting API resource: %s. %s", resource.Identifier, err)
+				utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, resource.Identifier, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				successCount++
 				utils.AddToIdentifierMap(utils.API_RESOURCES, resource.ID, resource.Identifier, utils.EXPORT)
-				log.Println("API resource exported successfully:", resource.Identifier)
+				utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resource.Identifier, "Exported successfully")
 			}
 		}
 	}
@@ -75,7 +74,7 @@ func ExportAll(exportFilePath string, format string) {
 	err = writeScopesMap(exportFilePath, exportedScopesMap, format)
 	updateApiResourceExportSummary(err == nil, successCount)
 	if err != nil {
-		log.Println("Error writing scope name map:", err)
+		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error writing scope name map: %s", err))
 	}
 }
 

--- a/iamctl/pkg/apiResources/import.go
+++ b/iamctl/pkg/apiResources/import.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -31,25 +30,25 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing API resources...")
+	utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, "", "Importing API resources...")
 	importFilePath := filepath.Join(inputDirPath, utils.API_RESOURCES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.API_RESOURCES) || !utils.IsEntitySupportedInOrg(utils.API_RESOURCES) || utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No API resources to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, "", "No API resources to import.")
 		return
 	}
 
 	deployedResources, err := GetApiResourceList(true)
 	if err != nil {
-		log.Println("Error retrieving the deployed API resource list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error retrieving the deployed API resource list: %s", err))
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing API resources:", err)
+		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error importing API resources: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -58,7 +57,7 @@ func ImportAll(inputDirPath string) {
 
 	localScopeMap, err := readLocalScopesMap(importFilePath)
 	if err != nil {
-		log.Println("Error reading local scope name map:", err)
+		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error reading local scope name map: %s", err))
 		utils.UpdateFailureSummary(utils.API_RESOURCES, utils.API_RESOURCE_SCOPES.String())
 		return
 	}
@@ -73,14 +72,14 @@ func ImportAll(inputDirPath string) {
 			continue
 		}
 		if _, failed := failedResources[resourceName]; failed {
-			log.Printf("Skipping API resource %s: deleting stale scopes failed", resourceName)
+			utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resourceName, "Skipping: deleting stale scopes failed")
 			utils.UpdateFailureSummary(utils.API_RESOURCES, resourceName)
 			continue
 		}
 		if !utils.IsResourceExcluded(resourceName, utils.TOOL_CONFIGS.ApiResourceConfigs) {
 			resourceId := getApiResourceId(resourceName, deployedResources)
 			if err := importApiResource(resourceId, resourceName, apiResFilePath); err != nil {
-				log.Println("Error importing API resource:", err)
+				utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, resourceName, fmt.Sprintf("Error importing API resource: %s", err))
 				utils.UpdateFailureSummary(utils.API_RESOURCES, resourceName)
 			}
 		}
@@ -110,7 +109,7 @@ func importApiResource(resourceId, resourceIdentifier, importFilePath string) er
 
 func createApiResource(resourceIdentifier string, requestBody []byte, format utils.Format) error {
 
-	log.Println("Creating new API resource:", resourceIdentifier)
+	utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resourceIdentifier, "Creating new API resource")
 
 	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.API_RESOURCES,
 		"id", "type", "properties", "authorizationDetailsTypes")
@@ -135,13 +134,13 @@ func createApiResource(resourceIdentifier string, requestBody []byte, format uti
 	utils.AddToIdentifierMap(utils.API_RESOURCES, created.ID, resourceIdentifier, utils.IMPORT)
 
 	utils.UpdateSuccessSummary(utils.API_RESOURCES, utils.IMPORT)
-	log.Println("API resource created successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resourceIdentifier, "Created successfully")
 	return nil
 }
 
 func updateApiResource(resourceId, resourceIdentifier string, requestBody []byte, format utils.Format) error {
 
-	log.Println("Updating API resource:", resourceIdentifier)
+	utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resourceIdentifier, "Updating API resource")
 
 	dataMap, err := utils.DeserializeToMap(requestBody, format, utils.API_RESOURCES)
 	if err != nil {
@@ -165,7 +164,7 @@ func updateApiResource(resourceId, resourceIdentifier string, requestBody []byte
 
 	utils.AddToIdentifierMap(utils.API_RESOURCES, resourceId, resourceIdentifier, utils.IMPORT)
 	utils.UpdateSuccessSummary(utils.API_RESOURCES, utils.UPDATE)
-	log.Println("API resource updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resourceIdentifier, "Updated successfully")
 	return nil
 }
 
@@ -187,15 +186,15 @@ func removeDeletedDeployedApiResources(localFiles []os.FileInfo, deployedResourc
 			continue
 		}
 		if utils.IsResourceExcluded(resource.Identifier, utils.TOOL_CONFIGS.ApiResourceConfigs) {
-			log.Println("API resource is excluded from deletion:", resource.Identifier)
+			utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resource.Identifier, "Excluded from deletion")
 			remainingResources = append(remainingResources, resource)
 			continue
 		}
 
-		log.Printf("API resource: %s not found locally. Deleting.\n", resource.Identifier)
+		utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, resource.Identifier, "Not found locally. Deleting.")
 		if err := utils.SendDeleteRequest(resource.ID, utils.API_RESOURCES); err != nil {
 			utils.UpdateFailureSummary(utils.API_RESOURCES, resource.Identifier)
-			log.Println("Error deleting API resource:", resource.Identifier, err)
+			utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, resource.Identifier, fmt.Sprintf("Error deleting API resource: %s", err))
 			remainingResources = append(remainingResources, resource)
 		} else {
 			utils.UpdateSuccessSummary(utils.API_RESOURCES, utils.DELETE)
@@ -214,7 +213,7 @@ func removeDeletedDeployedScopes(localScopeMap map[string]string, deployedResour
 		}
 		scopes, err := getApiResourceScopes(resource.ID)
 		if err != nil {
-			log.Printf("Error retrieving scopes for API resource %s: %v", resource.Identifier, err)
+			utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, resource.Identifier, fmt.Sprintf("Error retrieving scopes: %s", err))
 			failedResources[resource.Identifier] = struct{}{}
 			continue
 		}
@@ -233,7 +232,7 @@ func removeDeletedDeployedScopes(localScopeMap map[string]string, deployedResour
 			}
 
 			if err := utils.SendDeleteRequest(resource.ID+"/scopes/id/"+scope.ID, utils.API_RESOURCES); err != nil {
-				log.Printf("Error deleting scope %s from API resource %s: %v", scope.Name, resource.Identifier, err)
+				utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, resource.Identifier, fmt.Sprintf("Error deleting scope %s: %s", scope.Name, err))
 				failedResources[resource.Identifier] = struct{}{}
 			}
 		}

--- a/iamctl/pkg/apiResources/import.go
+++ b/iamctl/pkg/apiResources/import.go
@@ -33,7 +33,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.API_RESOURCES, "", "Importing API resources...")
 	importFilePath := filepath.Join(inputDirPath, utils.API_RESOURCES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.API_RESOURCES) || !utils.IsEntitySupportedInOrg(utils.API_RESOURCES) || utils.IsResourceTypeExcluded(utils.API_RESOURCES) {
+	if utils.ShouldSkip(utils.API_RESOURCES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -44,11 +44,13 @@ func ImportAll(inputDirPath string) {
 	deployedResources, err := GetApiResourceList(true)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error retrieving the deployed API resource list: %s", err))
+		utils.MarkResTypeFailure(utils.API_RESOURCES)
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error importing API resources: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error reading API resources directory: %s", err))
+		utils.MarkResTypeFailure(utils.API_RESOURCES)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -58,6 +60,7 @@ func ImportAll(inputDirPath string) {
 	localScopeMap, err := readLocalScopesMap(importFilePath)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.API_RESOURCES, "", fmt.Sprintf("Error reading local scope name map: %s", err))
+		utils.MarkResTypeFailure(utils.API_RESOURCES)
 		utils.UpdateFailureSummary(utils.API_RESOURCES, utils.API_RESOURCE_SCOPES.String())
 		return
 	}

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -21,7 +21,6 @@ package applications
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"path"
 	"regexp"
 	"strings"
@@ -275,7 +274,7 @@ func processInboundProtocolConfigs(appId string, inboundProtocols []inboundProto
 		result["custom"] = customProtocols
 	}
 	if len(skippedProtocols) > 0 {
-		log.Printf("Warn: Skipped unsupported inbound protocols: %v", skippedProtocols)
+		utils.PrintLog(utils.LogLevelWarn, utils.APPLICATIONS, "", fmt.Sprintf("Skipped unsupported inbound protocols: %v", skippedProtocols))
 	}
 
 	delete(appMap, "inboundProtocols")

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"mime"
 	"os"
 	"path/filepath"
@@ -34,7 +33,7 @@ import (
 func ExportAll(exportFilePath string, format string) {
 
 	// Export all applications to the Applications folder.
-	log.Println("Exporting applications...")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, "", "Exporting applications...")
 	exportFilePath = filepath.Join(exportFilePath, utils.APPLICATIONS.String())
 	authAPIsOutputDir := applicationAuthorizedApis.GetOutputDirPath(exportFilePath)
 
@@ -46,14 +45,14 @@ func ExportAll(exportFilePath string, format string) {
 
 	apps, err := getAppList()
 	if err != nil {
-		log.Println("Error retrieving applications list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error retrieving applications list: %s", err))
 		return
 	}
 	deployedAppNames := getDeployedAppNames(apps)
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating applications directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error creating applications directory: %s", err))
 			return
 		}
 	} else {
@@ -65,7 +64,7 @@ func ExportAll(exportFilePath string, format string) {
 	if applicationAuthorizedApis.IsSupported {
 		if _, err := os.Stat(authAPIsOutputDir); os.IsNotExist(err) {
 			if err := os.MkdirAll(authAPIsOutputDir, 0700); err != nil {
-				log.Println("Error creating authorized APIs directory:", err)
+				utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error creating authorized APIs directory: %s", err))
 				return
 			}
 		} else {
@@ -77,7 +76,7 @@ func ExportAll(exportFilePath string, format string) {
 	excludeSecrets := utils.AreSecretsExcluded(utils.TOOL_CONFIGS.ApplicationConfigs)
 	for _, app := range apps {
 		if !utils.IsResourceExcluded(app.Name, utils.TOOL_CONFIGS.ApplicationConfigs) {
-			log.Println("Exporting application: ", app.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, app.Name, "Exporting")
 			var err error
 			if exportAPIExists {
 				err = exportApp(app.Id, exportFilePath, format, excludeSecrets)
@@ -86,11 +85,11 @@ func ExportAll(exportFilePath string, format string) {
 			}
 			if err != nil {
 				utils.UpdateFailureSummary(utils.APPLICATIONS, app.Name)
-				log.Printf("Error while exporting application: %s. %s", app.Name, err)
+				utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, app.Name, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				utils.AddToIdentifierMap(utils.APPLICATIONS, app.Id, app.Name, utils.EXPORT)
 				utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.EXPORT)
-				log.Println("Application exported successfully: ", app.Name)
+				utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, app.Name, "Exported successfully")
 			}
 		}
 	}
@@ -98,15 +97,15 @@ func ExportAll(exportFilePath string, format string) {
 	if !utils.IsResourceExcluded(utils.RESIDENT_APP, utils.TOOL_CONFIGS.ApplicationConfigs) {
 		if err := exportResidentApp(exportFilePath, format); err != nil {
 			utils.UpdateFailureSummary(utils.APPLICATIONS, utils.RESIDENT_APP)
-			log.Printf("Error while exporting resident application: %s", err)
+			utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, utils.RESIDENT_APP, fmt.Sprintf("Error while exporting resident application: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.EXPORT)
-			log.Println("Resident application exported successfully.")
+			utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, utils.RESIDENT_APP, "Exported successfully")
 		}
 	}
 
 	if utils.IsResourceTypeExcluded(utils.ROLES) && exportAPIExists {
-		log.Println("Warn: Roles are excluded from export. Export Roles to persist Role audiences of applications.")
+		utils.PrintLog(utils.LogLevelWarn, utils.APPLICATIONS, "", "Roles are excluded from export. Export Roles to persist Role audiences of applications.")
 	}
 }
 
@@ -192,7 +191,7 @@ func exportAppWithCRUD(appId, appName, outputDirPath, formatString string, exclu
 
 func exportResidentApp(outputDirPath, formatString string) error {
 
-	log.Println("Exporting Resident application...")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, utils.RESIDENT_APP, "Exporting Resident application...")
 
 	appData, err := utils.GetResourceData(utils.APPLICATIONS, "resident")
 	if err != nil {

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -46,6 +46,7 @@ func ExportAll(exportFilePath string, format string) {
 	apps, err := getAppList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error retrieving applications list: %s", err))
+		utils.MarkResTypeFailure(utils.APPLICATIONS)
 		return
 	}
 	deployedAppNames := getDeployedAppNames(apps)
@@ -53,6 +54,7 @@ func ExportAll(exportFilePath string, format string) {
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error creating applications directory: %s", err))
+			utils.MarkResTypeFailure(utils.APPLICATIONS)
 			return
 		}
 	} else {
@@ -65,6 +67,7 @@ func ExportAll(exportFilePath string, format string) {
 		if _, err := os.Stat(authAPIsOutputDir); os.IsNotExist(err) {
 			if err := os.MkdirAll(authAPIsOutputDir, 0700); err != nil {
 				utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error creating authorized APIs directory: %s", err))
+				utils.MarkResTypeFailure(utils.APPLICATIONS)
 				return
 			}
 		} else {

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -49,6 +49,7 @@ func ImportAll(inputDirPath string) {
 		err := applicationAuthorizedApis.GetAPIResources()
 		if err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error retrieving API resource list: %s", err))
+			utils.MarkResTypeFailure(utils.APPLICATIONS)
 			return
 		}
 	}

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -33,7 +32,7 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing applications...")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, "", "Importing applications...")
 	importFilePath := filepath.Join(inputDirPath, utils.APPLICATIONS.String())
 	exportAPIExists := utils.ExportAPIExists(utils.APPLICATIONS)
 	applicationAuthorizedApis.InitIsSupported()
@@ -42,26 +41,26 @@ func ImportAll(inputDirPath string) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No applications to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, "", "No applications to import.")
 		return
 	}
 
 	if applicationAuthorizedApis.IsSupported {
 		err := applicationAuthorizedApis.GetAPIResources()
 		if err != nil {
-			log.Println("Error retrieving API resource list: ", err)
+			utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error retrieving API resource list: %s", err))
 			return
 		}
 	}
 
 	deployedApps, err := getAppList()
 	if err != nil {
-		log.Println("Error retrieving applications list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error retrieving applications list: %s", err))
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing applications: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error importing applications: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -80,21 +79,21 @@ func ImportAll(inputDirPath string) {
 			appId := getAppId(appName, deployedApps)
 			err := importApp(appId, appName, appFilePath, exportAPIExists)
 			if err != nil {
-				log.Println("Error importing application: ", err)
+				utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, appName, fmt.Sprintf("Error importing application: %s", err))
 				utils.UpdateFailureSummary(utils.APPLICATIONS, appName)
 			}
 		}
 	}
 
 	if utils.IsResourceTypeExcluded(utils.ROLES) && exportAPIExists {
-		log.Println("Warn: Roles are excluded from import. Import Roles to persist Role audiences of applications.")
+		utils.PrintLog(utils.LogLevelWarn, utils.APPLICATIONS, "", "Roles are excluded from import. Import Roles to persist Role audiences of applications.")
 	}
 }
 
 func importApp(appId, appName, importFilePath string, exportAPIExists bool) error {
 
 	if appName == utils.CONSOLE || appName == utils.MY_ACCOUNT || appName == utils.CARBON_SP {
-		log.Printf("Application: %s is a system application. Skipping import.\n", appName)
+		utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "System application. Skipping import.")
 		return nil
 	}
 
@@ -150,7 +149,7 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 
 func importApplication(appName, importFilePath, modifiedFileData string, format utils.Format) (appId string, err error) {
 
-	log.Println("Creating new application: " + appName)
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Creating new application")
 	resp, err := utils.SendImportRequest(importFilePath, modifiedFileData, utils.APPLICATIONS)
 	if err != nil {
 		return "", fmt.Errorf("error when importing application: %s", err)
@@ -174,13 +173,13 @@ func importApplication(appName, importFilePath, modifiedFileData string, format 
 	utils.AddToIdentifierMap(utils.APPLICATIONS, appId, appName, utils.IMPORT)
 
 	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.IMPORT)
-	log.Println("Application imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Imported successfully")
 	return appId, nil
 }
 
 func updateApplication(appId, appName, importFilePath, modifiedFileData string, format utils.Format) error {
 
-	log.Println("Updating application: " + appName)
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Updating application")
 	fileData, err := injectDeployedOAuthCredentials(appId, modifiedFileData, format)
 	if err != nil {
 		return fmt.Errorf("error injecting deployed OAuth credentials: %w", err)
@@ -194,13 +193,13 @@ func updateApplication(appId, appName, importFilePath, modifiedFileData string, 
 	utils.AddToIdentifierMap(utils.APPLICATIONS, appId, appName, utils.IMPORT)
 
 	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.UPDATE)
-	log.Println("Application updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Updated successfully")
 	return nil
 }
 
 func importAppWithCRUD(appName string, appMap map[string]interface{}) error {
 
-	log.Println("Creating new application: " + appName)
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Creating new application")
 
 	newSecretCreated, err := processInboundProtocolsForPost(appMap)
 	if err != nil {
@@ -230,13 +229,13 @@ func importAppWithCRUD(appName string, appMap map[string]interface{}) error {
 	utils.AddToIdentifierMap(utils.APPLICATIONS, appId, appName, utils.IMPORT)
 
 	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.IMPORT)
-	log.Println("Application imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Imported successfully")
 	return nil
 }
 
 func updateAppWithCRUD(appId, appName string, appMap map[string]interface{}) error {
 
-	log.Println("Updating application: " + appName)
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Updating application")
 
 	localProtocolConfig, ok := appMap["inboundProtocolConfiguration"].(map[string]interface{})
 	if !ok {
@@ -267,13 +266,13 @@ func updateAppWithCRUD(appId, appName string, appMap map[string]interface{}) err
 	utils.AddToIdentifierMap(utils.APPLICATIONS, appId, appName, utils.IMPORT)
 
 	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.UPDATE)
-	log.Println("Application updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Updated successfully")
 	return nil
 }
 
 func updateResidentApp(appMap map[string]interface{}) error {
 
-	log.Println("Updating Resident application")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, utils.RESIDENT_APP, "Updating Resident application")
 
 	provConfig, ok := appMap["provisioningConfigurations"].(map[string]interface{})
 	if !ok {
@@ -296,7 +295,7 @@ func updateResidentApp(appMap map[string]interface{}) error {
 	resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.UPDATE)
-	log.Println("Resident application updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, utils.RESIDENT_APP, "Updated successfully")
 	return nil
 }
 
@@ -352,23 +351,23 @@ func removeDeletedDeployedApps(localFiles []os.FileInfo, deployedApps []Applicat
 
 		if utils.IsResourceExcluded(app.Name, utils.TOOL_CONFIGS.ApplicationConfigs) ||
 			app.Name == utils.CONSOLE || app.Name == utils.MY_ACCOUNT || app.Name == utils.CARBON_SP {
-			log.Printf("Application: %s is excluded from deletion.\n", app.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, app.Name, "Excluded from deletion.")
 			continue
 		}
 		if isToolMgt, err := isToolMgtApp(app.Id); err != nil {
-			log.Printf("Error checking if application is the tool management app: %s\n", err.Error())
-			log.Printf("Application: %s is excluded from deletion.\n", app.Name)
+			utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, app.Name, fmt.Sprintf("Error checking if application is the tool management app: %s", err.Error()))
+			utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, app.Name, "Excluded from deletion.")
 			continue
 		} else if isToolMgt {
-			log.Printf("Info: Tool Management App: %s is excluded from deletion.\n", app.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, app.Name, "Tool Management App. Excluded from deletion.")
 			continue
 		}
 
-		log.Println("Application not found locally. Deleting app: ", app.Name)
+		utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, app.Name, "Not found locally. Deleting app.")
 		err := utils.SendDeleteRequest(app.Id, utils.APPLICATIONS)
 		if err != nil {
 			utils.UpdateFailureSummary(utils.APPLICATIONS, app.Name)
-			log.Println("Error deleting application: ", app.Name, err)
+			utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, app.Name, fmt.Sprintf("Error deleting application: %s", err))
 		}
 		utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.DELETE)
 	}

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -56,11 +56,13 @@ func ImportAll(inputDirPath string) {
 	deployedApps, err := getAppList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error retrieving applications list: %s", err))
+		utils.MarkResTypeFailure(utils.APPLICATIONS)
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error importing applications: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error reading applications directory: %s", err))
+		utils.MarkResTypeFailure(utils.APPLICATIONS)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/branding/branding.go
+++ b/iamctl/pkg/branding/branding.go
@@ -31,8 +31,13 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING, "", "Exporting branding...")
 	exportFilePath = filepath.Join(exportFilePath, utils.BRANDING.String())
 
+	utils.MarkResTypeStart(utils.BRANDING_PREFERENCES)
 	brandingPreferences.ExportAll(exportFilePath, format)
+	utils.MarkResTypeEnd(utils.BRANDING_PREFERENCES)
+
+	utils.MarkResTypeStart(utils.CUSTOM_TEXTS)
 	customTexts.ExportAll(exportFilePath, format)
+	utils.MarkResTypeEnd(utils.CUSTOM_TEXTS)
 }
 
 func ImportAll(inputDirPath string) {
@@ -40,6 +45,11 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING, "", "Importing branding...")
 	inputDirPath = filepath.Join(inputDirPath, utils.BRANDING.String())
 
+	utils.MarkResTypeStart(utils.BRANDING_PREFERENCES)
 	brandingPreferences.ImportAll(inputDirPath)
+	utils.MarkResTypeEnd(utils.BRANDING_PREFERENCES)
+
+	utils.MarkResTypeStart(utils.CUSTOM_TEXTS)
 	customTexts.ImportAll(inputDirPath)
+	utils.MarkResTypeEnd(utils.CUSTOM_TEXTS)
 }

--- a/iamctl/pkg/branding/branding.go
+++ b/iamctl/pkg/branding/branding.go
@@ -19,7 +19,6 @@
 package branding
 
 import (
-	"log"
 	"path/filepath"
 
 	brandingPreferences "github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/branding/brandingPreferences"
@@ -29,7 +28,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting branding...")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING, "", "Exporting branding...")
 	exportFilePath = filepath.Join(exportFilePath, utils.BRANDING.String())
 
 	brandingPreferences.ExportAll(exportFilePath, format)
@@ -38,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing branding...")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING, "", "Importing branding...")
 	inputDirPath = filepath.Join(inputDirPath, utils.BRANDING.String())
 
 	brandingPreferences.ImportAll(inputDirPath)

--- a/iamctl/pkg/branding/brandingPreferences/export.go
+++ b/iamctl/pkg/branding/brandingPreferences/export.go
@@ -21,7 +21,6 @@ package brandingPreferences
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(parentDir string, formatString string) {
 
-	log.Println("Exporting branding preferences...")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Exporting branding preferences...")
 	exportFilePath := filepath.Join(parentDir, utils.BRANDING_PREFERENCES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.BRANDING_PREFERENCES) || !utils.IsEntitySupportedInOrg(utils.BRANDING_PREFERENCES) || utils.IsResourceTypeExcluded(utils.BRANDING_PREFERENCES) {
@@ -38,7 +37,7 @@ func ExportAll(parentDir string, formatString string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating branding preferences directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.BRANDING_PREFERENCES, "", fmt.Sprintf("Error creating branding preferences directory: %s", err))
 			return
 		}
 	}
@@ -46,17 +45,17 @@ func ExportAll(parentDir string, formatString string) {
 	err := exportBrandingPreferences(exportFilePath, formatString)
 	if err != nil {
 		if utils.IsResourceNotFound(err) {
-			log.Println("No branding preferences configured.")
+			utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "No branding preferences configured.")
 			if utils.TOOL_CONFIGS.AllowDelete {
 				utils.RemoveDeletedLocalResources(exportFilePath, []string{})
 			}
 			return
 		}
 		utils.UpdateFailureSummary(utils.BRANDING_PREFERENCES, resourceFileName)
-		log.Println("Error while exporting branding preferences:", err)
+		utils.PrintLog(utils.LogLevelError, utils.BRANDING_PREFERENCES, "", fmt.Sprintf("Error while exporting branding preferences: %s", err))
 	} else {
 		utils.UpdateSuccessSummary(utils.BRANDING_PREFERENCES, utils.EXPORT)
-		log.Println("Branding preferences exported successfully.")
+		utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Exported successfully")
 	}
 }
 

--- a/iamctl/pkg/branding/brandingPreferences/export.go
+++ b/iamctl/pkg/branding/brandingPreferences/export.go
@@ -32,12 +32,13 @@ func ExportAll(parentDir string, formatString string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Exporting branding preferences...")
 	exportFilePath := filepath.Join(parentDir, utils.BRANDING_PREFERENCES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.BRANDING_PREFERENCES) || !utils.IsEntitySupportedInOrg(utils.BRANDING_PREFERENCES) || utils.IsResourceTypeExcluded(utils.BRANDING_PREFERENCES) {
+	if utils.ShouldSkip(utils.BRANDING_PREFERENCES) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.BRANDING_PREFERENCES, "", fmt.Sprintf("Error creating branding preferences directory: %s", err))
+			utils.MarkResTypeFailure(utils.BRANDING_PREFERENCES)
 			return
 		}
 	}

--- a/iamctl/pkg/branding/brandingPreferences/import.go
+++ b/iamctl/pkg/branding/brandingPreferences/import.go
@@ -32,7 +32,7 @@ func ImportAll(parentDir string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Importing branding preferences...")
 	importFilePath := filepath.Join(parentDir, utils.BRANDING_PREFERENCES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.BRANDING_PREFERENCES) || !utils.IsEntitySupportedInOrg(utils.BRANDING_PREFERENCES) || utils.IsResourceTypeExcluded(utils.BRANDING_PREFERENCES) {
+	if utils.ShouldSkip(utils.BRANDING_PREFERENCES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {

--- a/iamctl/pkg/branding/brandingPreferences/import.go
+++ b/iamctl/pkg/branding/brandingPreferences/import.go
@@ -21,7 +21,6 @@ package brandingPreferences
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,25 +29,25 @@ import (
 
 func ImportAll(parentDir string) {
 
-	log.Println("Importing branding preferences...")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Importing branding preferences...")
 	importFilePath := filepath.Join(parentDir, utils.BRANDING_PREFERENCES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.BRANDING_PREFERENCES) || !utils.IsEntitySupportedInOrg(utils.BRANDING_PREFERENCES) || utils.IsResourceTypeExcluded(utils.BRANDING_PREFERENCES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No branding preferences to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "No branding preferences to import.")
 		return
 	}
 
 	isDeployed, err := isBrandingPreferencesExist()
 	if err != nil {
-		log.Println("Error retrieving deployed branding preferences:", err)
+		utils.PrintLog(utils.LogLevelError, utils.BRANDING_PREFERENCES, "", fmt.Sprintf("Error retrieving deployed branding preferences: %s", err))
 		return
 	}
 	filePath, fileExists, err := getBrandingPreferencesFilePath(importFilePath)
 	if err != nil {
-		log.Println("Error reading branding preferences file path:", err)
+		utils.PrintLog(utils.LogLevelError, utils.BRANDING_PREFERENCES, "", fmt.Sprintf("Error reading branding preferences file path: %s", err))
 		return
 	}
 
@@ -62,7 +61,7 @@ func ImportAll(parentDir string) {
 	err = importBrandingPreferences(filePath, isDeployed)
 	if err != nil {
 		utils.UpdateFailureSummary(utils.BRANDING_PREFERENCES, resourceFileName)
-		log.Println("Error while importing branding preferences:", err)
+		utils.PrintLog(utils.LogLevelError, utils.BRANDING_PREFERENCES, "", fmt.Sprintf("Error while importing branding preferences: %s", err))
 	}
 }
 
@@ -93,7 +92,7 @@ func importBrandingPreferences(filePath string, exists bool) error {
 
 func createBrandingPreferences(jsonBody []byte) error {
 
-	log.Println("Creating branding preferences.")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Creating branding preferences")
 
 	resp, err := utils.SendPostRequest(utils.BRANDING_PREFERENCES, jsonBody)
 	if err != nil {
@@ -102,13 +101,13 @@ func createBrandingPreferences(jsonBody []byte) error {
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.BRANDING_PREFERENCES, utils.IMPORT)
-	log.Println("Branding preferences created successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Created successfully")
 	return nil
 }
 
 func updateBrandingPreferences(jsonBody []byte) error {
 
-	log.Println("Updating branding preferences.")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Updating branding preferences")
 
 	resp, err := utils.SendPutRequest(utils.BRANDING_PREFERENCES, "", jsonBody)
 	if err != nil {
@@ -117,19 +116,19 @@ func updateBrandingPreferences(jsonBody []byte) error {
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.BRANDING_PREFERENCES, utils.UPDATE)
-	log.Println("Branding preferences updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Updated successfully")
 	return nil
 }
 
 func removeDeletedDeployedBrandingPreferences() {
 
-	log.Printf("Branding preferences not found locally. Deleting preferences.")
+	utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Not found locally. Deleting preferences.")
 
 	if err := utils.SendDeleteRequest("", utils.BRANDING_PREFERENCES); err != nil {
 		utils.UpdateFailureSummary(utils.BRANDING_PREFERENCES, resourceFileName)
-		log.Println("Error while deleting branding preferences:", err)
+		utils.PrintLog(utils.LogLevelError, utils.BRANDING_PREFERENCES, "", fmt.Sprintf("Error while deleting branding preferences: %s", err))
 	} else {
 		utils.UpdateSuccessSummary(utils.BRANDING_PREFERENCES, utils.DELETE)
-		log.Println("Branding preferences deleted successfully.")
+		utils.PrintLog(utils.LogLevelInfo, utils.BRANDING_PREFERENCES, "", "Deleted successfully")
 	}
 }

--- a/iamctl/pkg/branding/customTexts/export.go
+++ b/iamctl/pkg/branding/customTexts/export.go
@@ -32,12 +32,13 @@ func ExportAll(parentDir string, formatString string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, "", "Exporting custom texts...")
 	exportFilePath := filepath.Join(parentDir, utils.CUSTOM_TEXTS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.CUSTOM_TEXTS) || !utils.IsEntitySupportedInOrg(utils.CUSTOM_TEXTS) || utils.IsResourceTypeExcluded(utils.CUSTOM_TEXTS) {
+	if utils.ShouldSkip(utils.CUSTOM_TEXTS) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, "", fmt.Sprintf("Error creating custom texts directory: %s", err))
+			utils.MarkResTypeFailure(utils.CUSTOM_TEXTS)
 			return
 		}
 	}

--- a/iamctl/pkg/branding/customTexts/export.go
+++ b/iamctl/pkg/branding/customTexts/export.go
@@ -21,7 +21,6 @@ package customTexts
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(parentDir string, formatString string) {
 
-	log.Println("Exporting custom texts...")
+	utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, "", "Exporting custom texts...")
 	exportFilePath := filepath.Join(parentDir, utils.CUSTOM_TEXTS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.CUSTOM_TEXTS) || !utils.IsEntitySupportedInOrg(utils.CUSTOM_TEXTS) || utils.IsResourceTypeExcluded(utils.CUSTOM_TEXTS) {
@@ -38,7 +37,7 @@ func ExportAll(parentDir string, formatString string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating custom texts directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, "", fmt.Sprintf("Error creating custom texts directory: %s", err))
 			return
 		}
 	}
@@ -48,19 +47,19 @@ func ExportAll(parentDir string, formatString string) {
 		if utils.IsResourceExcluded(screen, utils.TOOL_CONFIGS.CustomTextConfigs) {
 			continue
 		}
-		log.Println("Exporting custom text for screen:", screen)
+		utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "Exporting")
 		hadLocales, err := exportCustomTextScreen(screen, exportFilePath, formatString)
 
 		if err != nil {
 			utils.UpdateFailureSummary(utils.CUSTOM_TEXTS, screen)
-			log.Printf("Error while exporting custom text for screen: %s. %s", screen, err)
+			utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, screen, fmt.Sprintf("Error while exporting: %s", err))
 		} else {
 			if hadLocales {
 				screensWithLocales = append(screensWithLocales, screen)
 				utils.UpdateSuccessSummary(utils.CUSTOM_TEXTS, utils.EXPORT)
-				log.Println("Custom text exported successfully for screen:", screen)
+				utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "Exported successfully")
 			} else {
-				log.Println("No custom text to export for screen:", screen)
+				utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "No custom text to export")
 			}
 		}
 	}

--- a/iamctl/pkg/branding/customTexts/import.go
+++ b/iamctl/pkg/branding/customTexts/import.go
@@ -32,7 +32,7 @@ func ImportAll(parentDir string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, "", "Importing custom texts...")
 	importFilePath := filepath.Join(parentDir, utils.CUSTOM_TEXTS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.CUSTOM_TEXTS) || !utils.IsEntitySupportedInOrg(utils.CUSTOM_TEXTS) || utils.IsResourceTypeExcluded(utils.CUSTOM_TEXTS) {
+	if utils.ShouldSkip(utils.CUSTOM_TEXTS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -43,11 +43,13 @@ func ImportAll(parentDir string) {
 	deployedTexts, err := getCustomTextList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, "", fmt.Sprintf("Error while retrieving deployed custom text list: %s", err))
+		utils.MarkResTypeFailure(utils.CUSTOM_TEXTS)
 		return
 	}
 	localScreenDirs, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, "", fmt.Sprintf("Error reading custom texts directory: %s", err))
+		utils.MarkResTypeFailure(utils.CUSTOM_TEXTS)
 		return
 	}
 

--- a/iamctl/pkg/branding/customTexts/import.go
+++ b/iamctl/pkg/branding/customTexts/import.go
@@ -21,7 +21,6 @@ package customTexts
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,25 +29,25 @@ import (
 
 func ImportAll(parentDir string) {
 
-	log.Println("Importing custom texts...")
+	utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, "", "Importing custom texts...")
 	importFilePath := filepath.Join(parentDir, utils.CUSTOM_TEXTS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.CUSTOM_TEXTS) || !utils.IsEntitySupportedInOrg(utils.CUSTOM_TEXTS) || utils.IsResourceTypeExcluded(utils.CUSTOM_TEXTS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No custom texts to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, "", "No custom texts to import.")
 		return
 	}
 
 	deployedTexts, err := getCustomTextList()
 	if err != nil {
-		log.Printf("Error while retrieving deployed custom text list: %s", err)
+		utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, "", fmt.Sprintf("Error while retrieving deployed custom text list: %s", err))
 		return
 	}
 	localScreenDirs, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Printf("Error reading custom texts directory: %s", err)
+		utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, "", fmt.Sprintf("Error reading custom texts directory: %s", err))
 		return
 	}
 
@@ -66,7 +65,7 @@ func ImportAll(parentDir string) {
 		if !utils.IsResourceExcluded(screen, utils.TOOL_CONFIGS.CustomTextConfigs) {
 			if err := importCustomTextScreen(screen, screenDir, deployedTexts[screen]); err != nil {
 				utils.UpdateFailureSummary(utils.CUSTOM_TEXTS, screen)
-				log.Printf("Error while importing custom text for screen: %s. %s", screen, err)
+				utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, screen, fmt.Sprintf("Error while importing: %s", err))
 			}
 		}
 	}
@@ -75,9 +74,9 @@ func ImportAll(parentDir string) {
 func importCustomTextScreen(screen, screenDir string, deployedLocales map[string]struct{}) error {
 
 	if len(deployedLocales) == 0 {
-		log.Printf("Importing custom text for screen: %s", screen)
+		utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "Importing")
 	} else {
-		log.Printf("Updating custom text for screen: %s", screen)
+		utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "Updating")
 	}
 
 	localFiles, err := ioutil.ReadDir(screenDir)
@@ -104,10 +103,10 @@ func importCustomTextScreen(screen, screenDir string, deployedLocales map[string
 
 	if len(deployedLocales) == 0 {
 		utils.UpdateSuccessSummary(utils.CUSTOM_TEXTS, utils.IMPORT)
-		log.Printf("Custom text for screen imported successfully")
+		utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "Imported successfully")
 	} else {
 		utils.UpdateSuccessSummary(utils.CUSTOM_TEXTS, utils.UPDATE)
-		log.Printf("Custom text for screen updated successfully")
+		utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "Updated successfully")
 	}
 	return nil
 }
@@ -177,14 +176,14 @@ func removeDeletedDeployedScreens(localScreenDirs []os.FileInfo, deployedTexts m
 			continue
 		}
 		if utils.IsResourceExcluded(screen, utils.TOOL_CONFIGS.CustomTextConfigs) {
-			log.Printf("Custom text for screen %s is excluded from deletion.", screen)
+			utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "Excluded from deletion.")
 			continue
 		}
 
-		log.Printf("Custom text for screen %s not found locally. Deleting all locales", screen)
+		utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, "Not found locally. Deleting all locales.")
 		for locale := range locales {
 			if err := deleteCustomText(screen, locale); err != nil {
-				log.Printf("Error deleting locale %s of screen %s: %s", locale, screen, err)
+				utils.PrintLog(utils.LogLevelError, utils.CUSTOM_TEXTS, screen, fmt.Sprintf("Error deleting locale %s: %s", locale, err))
 				utils.UpdateFailureSummary(utils.CUSTOM_TEXTS, screen+"/"+locale)
 				continue
 			} else {
@@ -206,7 +205,7 @@ func removeDeletedDeployedLocales(screen string, localFiles []os.FileInfo, deplo
 		if _, existsLocally := localLocales[locale]; existsLocally {
 			continue
 		}
-		log.Printf("Locale %s not found locally. Deleting locale.", locale)
+		utils.PrintLog(utils.LogLevelInfo, utils.CUSTOM_TEXTS, screen, fmt.Sprintf("Locale %s not found locally. Deleting.", locale))
 		if err := deleteCustomText(screen, locale); err != nil {
 			return fmt.Errorf("error deleting locale: %s. %w", locale, err)
 		}

--- a/iamctl/pkg/certificates/export.go
+++ b/iamctl/pkg/certificates/export.go
@@ -32,12 +32,13 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "Exporting certificates...")
 	exportFilePath = filepath.Join(exportFilePath, utils.CERTIFICATES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.CERTIFICATES) || !utils.IsEntitySupportedInOrg(utils.CERTIFICATES) || utils.IsResourceTypeExcluded(utils.CERTIFICATES) {
+	if utils.ShouldSkip(utils.CERTIFICATES) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error creating certificates directory: %s", err))
+			utils.MarkResTypeFailure(utils.CERTIFICATES)
 			return
 		}
 	} else {
@@ -49,7 +50,8 @@ func ExportAll(exportFilePath string, format string) {
 
 	certs, err := getCertificateList()
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error when exporting certificates: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error retrieving the deployed certificates list: %s", err))
+		utils.MarkResTypeFailure(utils.CERTIFICATES)
 	} else {
 		for _, cert := range certs {
 			if !utils.IsResourceExcluded(cert.Alias, utils.TOOL_CONFIGS.CertificateConfigs) {

--- a/iamctl/pkg/certificates/export.go
+++ b/iamctl/pkg/certificates/export.go
@@ -21,7 +21,6 @@ package certificates
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting certificates...")
+	utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "Exporting certificates...")
 	exportFilePath = filepath.Join(exportFilePath, utils.CERTIFICATES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.CERTIFICATES) || !utils.IsEntitySupportedInOrg(utils.CERTIFICATES) || utils.IsResourceTypeExcluded(utils.CERTIFICATES) {
@@ -38,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating certificates directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error creating certificates directory: %s", err))
 			return
 		}
 	} else {
@@ -50,19 +49,19 @@ func ExportAll(exportFilePath string, format string) {
 
 	certs, err := getCertificateList()
 	if err != nil {
-		log.Println("Error: when exporting certificates.", err)
+		utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error when exporting certificates: %s", err))
 	} else {
 		for _, cert := range certs {
 			if !utils.IsResourceExcluded(cert.Alias, utils.TOOL_CONFIGS.CertificateConfigs) {
-				log.Println("Exporting certificate: ", cert.Alias)
+				utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, cert.Alias, "Exporting")
 
 				err := exportCertificate(cert.Alias, exportFilePath, format)
 				if err != nil {
 					utils.UpdateFailureSummary(utils.CERTIFICATES, cert.Alias)
-					log.Printf("Error while exporting certificate: %s. %s", cert.Alias, err)
+					utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, cert.Alias, fmt.Sprintf("Error while exporting: %s", err))
 				} else {
 					utils.UpdateSuccessSummary(utils.CERTIFICATES, utils.EXPORT)
-					log.Println("Certificate exported successfully: ", cert.Alias)
+					utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, cert.Alias, "Exported successfully")
 				}
 			}
 		}

--- a/iamctl/pkg/certificates/import.go
+++ b/iamctl/pkg/certificates/import.go
@@ -36,7 +36,7 @@ func ImportAll(inputDirPath string) {
 	}
 	importFilePath := filepath.Join(inputDirPath, utils.CERTIFICATES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.CERTIFICATES) || !utils.IsEntitySupportedInOrg(utils.CERTIFICATES) || utils.IsResourceTypeExcluded(utils.CERTIFICATES) {
+	if utils.ShouldSkip(utils.CERTIFICATES) {
 		return
 	}
 	var files []os.FileInfo
@@ -48,12 +48,14 @@ func ImportAll(inputDirPath string) {
 	existingCertList, err := getCertificateList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error retrieving the deployed certificate list: %s", err))
+		utils.MarkResTypeFailure(utils.CERTIFICATES)
 		return
 	}
 
 	files, err = ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error importing certificates: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error reading certificates directory: %s", err))
+		utils.MarkResTypeFailure(utils.CERTIFICATES)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/certificates/import.go
+++ b/iamctl/pkg/certificates/import.go
@@ -21,7 +21,6 @@ package certificates
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,9 +29,9 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing certificates...")
+	utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "Importing certificates...")
 	if utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
-		log.Println("Importing certificates for super tenant not supported.")
+		utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "Importing certificates for super tenant not supported.")
 		return
 	}
 	importFilePath := filepath.Join(inputDirPath, utils.CERTIFICATES.String())
@@ -42,19 +41,19 @@ func ImportAll(inputDirPath string) {
 	}
 	var files []os.FileInfo
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No certificates to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "No certificates to import.")
 		return
 	}
 
 	existingCertList, err := getCertificateList()
 	if err != nil {
-		log.Println("Error retrieving the deployed certificate list: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error retrieving the deployed certificate list: %s", err))
 		return
 	}
 
 	files, err = ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing certificates: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, "", fmt.Sprintf("Error importing certificates: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -70,7 +69,7 @@ func ImportAll(inputDirPath string) {
 			certExists := isCertificateExists(alias, existingCertList)
 			err := importCertificate(alias, certExists, certFilePath)
 			if err != nil {
-				log.Println("Error importing certificate: ", err)
+				utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, alias, fmt.Sprintf("Error importing certificate: %s", err))
 				utils.UpdateFailureSummary(utils.CERTIFICATES, alias)
 			}
 		}
@@ -96,13 +95,13 @@ func importCertificate(alias string, certExists bool, importFilePath string) err
 		return createCertificate([]byte(modifiedFileData), format, alias)
 	}
 
-	log.Printf("Certificate '%s' already exists. Skipping.\n", alias)
+	utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, alias, "Already exists. Skipping.")
 	return nil
 }
 
 func createCertificate(requestBody []byte, format utils.Format, alias string) error {
 
-	log.Println("Creating new certificate: " + alias)
+	utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, alias, "Creating new certificate")
 
 	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.CERTIFICATES)
 	if err != nil {
@@ -116,7 +115,7 @@ func createCertificate(requestBody []byte, format utils.Format, alias string) er
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.CERTIFICATES, utils.IMPORT)
-	log.Println("Certificate imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, alias, "Imported successfully")
 	return nil
 }
 
@@ -137,14 +136,14 @@ func removeDeletedDeployedCertificates(localFiles []os.FileInfo, deployedCerts [
 			continue
 		}
 		if utils.IsResourceExcluded(cert.Alias, utils.TOOL_CONFIGS.CertificateConfigs) || cert.Alias == utils.SERVER_CONFIGS.TenantDomain {
-			log.Println("Certificate is excluded from deletion:", cert.Alias)
+			utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, cert.Alias, "Excluded from deletion.")
 			continue
 		}
 
-		log.Printf("Certificate: %s not found locally. Deleting certificate.\n", cert.Alias)
+		utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, cert.Alias, "Not found locally. Deleting.")
 		if err := utils.SendDeleteRequest(cert.Alias, utils.CERTIFICATES); err != nil {
 			utils.UpdateFailureSummary(utils.CERTIFICATES, cert.Alias)
-			log.Println("Error deleting certificate:", cert.Alias, err)
+			utils.PrintLog(utils.LogLevelError, utils.CERTIFICATES, cert.Alias, fmt.Sprintf("Error deleting certificate: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.CERTIFICATES, utils.DELETE)
 		}

--- a/iamctl/pkg/certificates/import.go
+++ b/iamctl/pkg/certificates/import.go
@@ -30,15 +30,17 @@ import (
 func ImportAll(inputDirPath string) {
 
 	utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "Importing certificates...")
-	if utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
-		utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "Importing certificates for super tenant not supported.")
-		return
-	}
-	importFilePath := filepath.Join(inputDirPath, utils.CERTIFICATES.String())
-
 	if utils.ShouldSkip(utils.CERTIFICATES) {
 		return
 	}
+
+	if utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
+		utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "Importing certificates for super tenant not supported.")
+		utils.UpdateSkipSummary(utils.CERTIFICATES, "Not supported in super tenant")
+		return
+	}
+
+	importFilePath := filepath.Join(inputDirPath, utils.CERTIFICATES.String())
 	var files []os.FileInfo
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
 		utils.PrintLog(utils.LogLevelInfo, utils.CERTIFICATES, "", "No certificates to import.")

--- a/iamctl/pkg/challengeQuestions/export.go
+++ b/iamctl/pkg/challengeQuestions/export.go
@@ -32,12 +32,13 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, "", "Exporting challenge question sets...")
 	exportFilePath = filepath.Join(exportFilePath, utils.CHALLENGE_QUESTIONS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.CHALLENGE_QUESTIONS) || !utils.IsEntitySupportedInOrg(utils.CHALLENGE_QUESTIONS) || utils.IsResourceTypeExcluded(utils.CHALLENGE_QUESTIONS) {
+	if utils.ShouldSkip(utils.CHALLENGE_QUESTIONS) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error creating challenge questions directory: %s", err))
+			utils.MarkResTypeFailure(utils.CHALLENGE_QUESTIONS)
 			return
 		}
 	} else {
@@ -49,7 +50,8 @@ func ExportAll(exportFilePath string, format string) {
 
 	sets, err := getChallengeSetList()
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error when exporting challenge question sets: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error retrieving the deployed challenge question sets list: %s", err))
+		utils.MarkResTypeFailure(utils.CHALLENGE_QUESTIONS)
 		return
 	}
 

--- a/iamctl/pkg/challengeQuestions/export.go
+++ b/iamctl/pkg/challengeQuestions/export.go
@@ -21,7 +21,6 @@ package challengeQuestions
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting challenge question sets...")
+	utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, "", "Exporting challenge question sets...")
 	exportFilePath = filepath.Join(exportFilePath, utils.CHALLENGE_QUESTIONS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.CHALLENGE_QUESTIONS) || !utils.IsEntitySupportedInOrg(utils.CHALLENGE_QUESTIONS) || utils.IsResourceTypeExcluded(utils.CHALLENGE_QUESTIONS) {
@@ -38,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating challenge questions directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error creating challenge questions directory: %s", err))
 			return
 		}
 	} else {
@@ -50,20 +49,20 @@ func ExportAll(exportFilePath string, format string) {
 
 	sets, err := getChallengeSetList()
 	if err != nil {
-		log.Println("Error: when exporting challenge question sets.", err)
+		utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error when exporting challenge question sets: %s", err))
 		return
 	}
 
 	for _, set := range sets {
 		if !utils.IsResourceExcluded(set.QuestionSetId, utils.TOOL_CONFIGS.ChallengeQuestionConfigs) {
-			log.Println("Exporting challenge question set:", set.QuestionSetId)
+			utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, set.QuestionSetId, "Exporting")
 			err := exportChallengeSet(set.QuestionSetId, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.CHALLENGE_QUESTIONS, set.QuestionSetId)
-				log.Printf("Error while exporting challenge question set: %s. %s", set.QuestionSetId, err)
+				utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, set.QuestionSetId, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				utils.UpdateSuccessSummary(utils.CHALLENGE_QUESTIONS, utils.EXPORT)
-				log.Println("Challenge question set exported successfully:", set.QuestionSetId)
+				utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, set.QuestionSetId, "Exported successfully")
 			}
 		}
 	}

--- a/iamctl/pkg/challengeQuestions/import.go
+++ b/iamctl/pkg/challengeQuestions/import.go
@@ -21,7 +21,6 @@ package challengeQuestions
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,26 +29,26 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing challenge question sets...")
+	utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, "", "Importing challenge question sets...")
 	importFilePath := filepath.Join(inputDirPath, utils.CHALLENGE_QUESTIONS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.CHALLENGE_QUESTIONS) || !utils.IsEntitySupportedInOrg(utils.CHALLENGE_QUESTIONS) || utils.IsResourceTypeExcluded(utils.CHALLENGE_QUESTIONS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No challenge question sets to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, "", "No challenge question sets to import.")
 		return
 	}
 
 	existingSets, err := getChallengeSetList()
 	if err != nil {
-		log.Println("Error retrieving the deployed challenge question set list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error retrieving the deployed challenge question set list: %s", err))
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing challenge question sets:", err)
+		utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error importing challenge question sets: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -65,7 +64,7 @@ func ImportAll(inputDirPath string) {
 			setExists := isChallengeSetExists(setId, existingSets)
 			err := importChallengeSet(setId, setExists, setFilePath)
 			if err != nil {
-				log.Println("Error importing challenge question set:", err)
+				utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, setId, fmt.Sprintf("Error importing challenge question set: %s", err))
 				utils.UpdateFailureSummary(utils.CHALLENGE_QUESTIONS, setId)
 			}
 		}
@@ -95,7 +94,7 @@ func importChallengeSet(setId string, setExists bool, importFilePath string) err
 
 func createChallengeSet(requestBody []byte, format utils.Format, setId string) error {
 
-	log.Println("Creating new challenge question set:", setId)
+	utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, setId, "Creating new challenge question set")
 
 	parsed, err := utils.Deserialize(requestBody, format, utils.CHALLENGE_QUESTIONS)
 	if err != nil {
@@ -113,13 +112,13 @@ func createChallengeSet(requestBody []byte, format utils.Format, setId string) e
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.CHALLENGE_QUESTIONS, utils.IMPORT)
-	log.Println("Challenge question set created successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, setId, "Created successfully")
 	return nil
 }
 
 func updateChallengeSet(setId string, requestBody []byte, format utils.Format) error {
 
-	log.Println("Updating challenge question set:", setId)
+	utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, setId, "Updating challenge question set")
 
 	questionsBytes, err := buildUpdateRequestBody(requestBody, format)
 	if err != nil {
@@ -133,7 +132,7 @@ func updateChallengeSet(setId string, requestBody []byte, format utils.Format) e
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.CHALLENGE_QUESTIONS, utils.UPDATE)
-	log.Println("Challenge question set updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, setId, "Updated successfully")
 	return nil
 }
 
@@ -154,14 +153,14 @@ func removeDeletedDeployedChallengeSets(localFiles []os.FileInfo, deployedSets [
 			continue
 		}
 		if utils.IsResourceExcluded(set.QuestionSetId, utils.TOOL_CONFIGS.ChallengeQuestionConfigs) {
-			log.Println("Challenge question set is excluded from deletion:", set.QuestionSetId)
+			utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, set.QuestionSetId, "Excluded from deletion")
 			continue
 		}
 
-		log.Printf("Challenge question set: %s not found locally. Deleting.\n", set.QuestionSetId)
+		utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, set.QuestionSetId, "Not found locally. Deleting.")
 		if err := utils.SendDeleteRequest(set.QuestionSetId, utils.CHALLENGE_QUESTIONS); err != nil {
 			utils.UpdateFailureSummary(utils.CHALLENGE_QUESTIONS, set.QuestionSetId)
-			log.Println("Error deleting challenge question set:", set.QuestionSetId, err)
+			utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, set.QuestionSetId, fmt.Sprintf("Error deleting challenge question set: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.CHALLENGE_QUESTIONS, utils.DELETE)
 		}

--- a/iamctl/pkg/challengeQuestions/import.go
+++ b/iamctl/pkg/challengeQuestions/import.go
@@ -32,7 +32,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.CHALLENGE_QUESTIONS, "", "Importing challenge question sets...")
 	importFilePath := filepath.Join(inputDirPath, utils.CHALLENGE_QUESTIONS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.CHALLENGE_QUESTIONS) || !utils.IsEntitySupportedInOrg(utils.CHALLENGE_QUESTIONS) || utils.IsResourceTypeExcluded(utils.CHALLENGE_QUESTIONS) {
+	if utils.ShouldSkip(utils.CHALLENGE_QUESTIONS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -43,12 +43,14 @@ func ImportAll(inputDirPath string) {
 	existingSets, err := getChallengeSetList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error retrieving the deployed challenge question set list: %s", err))
+		utils.MarkResTypeFailure(utils.CHALLENGE_QUESTIONS)
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error importing challenge question sets: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.CHALLENGE_QUESTIONS, "", fmt.Sprintf("Error reading challenge questions directory: %s", err))
+		utils.MarkResTypeFailure(utils.CHALLENGE_QUESTIONS)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/claims/claimUtils.go
+++ b/iamctl/pkg/claims/claimUtils.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"path/filepath"
 	"regexp"
 
@@ -214,10 +213,10 @@ func removeStaleClaimsFromLocalDialect() {
 	if !localClaimDialectSummary.Success {
 		return
 	}
-	log.Println("Removing deleted claims from local claim dialect")
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, utils.LOCAL_CLAIM_DIALECT, "Removing deleted claims from local claim dialect")
 
 	if err := removeDeletedDeployedClaims(utils.LOCAL_CLAIM_DIALECT, localClaimDialectSummary.DeployedClaims, localClaimDialectSummary.LocalClaims); err != nil {
-		log.Println("error removing deleted local claims: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.CLAIMS, utils.LOCAL_CLAIM_DIALECT, fmt.Sprintf("Error removing deleted local claims: %s", err))
 		utils.UpdateFailureSummary(utils.CLAIMS, localClaimDialectSummary.DialectURI)
 		return
 	}

--- a/iamctl/pkg/claims/export.go
+++ b/iamctl/pkg/claims/export.go
@@ -34,7 +34,7 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, "", "Exporting claims...")
 	exportFilePath = filepath.Join(exportFilePath, utils.CLAIMS.String())
 
-	if !utils.IsEntitySupportedInOrg(utils.CLAIMS) || utils.IsResourceTypeExcluded(utils.CLAIMS) {
+	if utils.ShouldSkip(utils.CLAIMS) {
 		return
 	}
 
@@ -42,6 +42,7 @@ func ExportAll(exportFilePath string, format string) {
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error creating claims directory: %s", err))
+			utils.MarkResTypeFailure(utils.CLAIMS)
 			return
 		}
 	} else {

--- a/iamctl/pkg/claims/export.go
+++ b/iamctl/pkg/claims/export.go
@@ -21,7 +21,6 @@ package claims
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"mime"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ import (
 func ExportAll(exportFilePath string, format string) {
 
 	// Export all claim dialects with related claims.
-	log.Println("Exporting claims...")
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, "", "Exporting claims...")
 	exportFilePath = filepath.Join(exportFilePath, utils.CLAIMS.String())
 
 	if !utils.IsEntitySupportedInOrg(utils.CLAIMS) || utils.IsResourceTypeExcluded(utils.CLAIMS) {
@@ -42,7 +41,7 @@ func ExportAll(exportFilePath string, format string) {
 	claimDialects, err := getClaimDialectsList()
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating claims directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error creating claims directory: %s", err))
 			return
 		}
 	} else {
@@ -54,11 +53,11 @@ func ExportAll(exportFilePath string, format string) {
 	// Min version requirement for claims export api is removed. CRUD apis used for all versions
 	exportAPIExists := utils.ExportAPIExists(utils.CLAIMS)
 	if err != nil {
-		log.Println("Error while retrieving Claim Dialect list.", err)
+		utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error while retrieving Claim Dialect list: %s", err))
 	} else {
 		for _, dialect := range claimDialects {
 			if !utils.IsResourceExcluded(dialect.DialectURI, utils.TOOL_CONFIGS.ClaimConfigs) {
-				log.Println("Exporting Claim Dialect: ", dialect.DialectURI)
+				utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialect.DialectURI, "Exporting")
 
 				var err error
 				if exportAPIExists {
@@ -69,10 +68,10 @@ func ExportAll(exportFilePath string, format string) {
 
 				if err != nil {
 					utils.UpdateFailureSummary(utils.CLAIMS, dialect.DialectURI)
-					log.Printf("Error while exporting Claim Dialect: %s. %s", dialect.DialectURI, err)
+					utils.PrintLog(utils.LogLevelError, utils.CLAIMS, dialect.DialectURI, fmt.Sprintf("Error while exporting: %s", err))
 				} else {
 					utils.UpdateSuccessSummary(utils.CLAIMS, utils.EXPORT)
-					log.Println("Claim Dialect exported successfully: ", dialect.DialectURI)
+					utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialect.DialectURI, "Exported successfully")
 				}
 			}
 		}

--- a/iamctl/pkg/claims/import.go
+++ b/iamctl/pkg/claims/import.go
@@ -35,7 +35,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, "", "Importing claims...")
 	importFilePath := filepath.Join(inputDirPath, utils.CLAIMS.String())
 
-	if !utils.IsEntitySupportedInOrg(utils.CLAIMS) || utils.IsResourceTypeExcluded(utils.CLAIMS) {
+	if utils.ShouldSkip(utils.CLAIMS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -46,12 +46,14 @@ func ImportAll(inputDirPath string) {
 	existingClaimDialectList, err := getClaimDialectsList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error when retrieving the deployed claim dialect list: %s", err))
+		utils.MarkResTypeFailure(utils.CLAIMS)
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error importing claim dialects: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error reading claim dialects directory: %s", err))
+		utils.MarkResTypeFailure(utils.CLAIMS)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/claims/import.go
+++ b/iamctl/pkg/claims/import.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -33,26 +32,26 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing claims...")
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, "", "Importing claims...")
 	importFilePath := filepath.Join(inputDirPath, utils.CLAIMS.String())
 
 	if !utils.IsEntitySupportedInOrg(utils.CLAIMS) || utils.IsResourceTypeExcluded(utils.CLAIMS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No claim dialects to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, "", "No claim dialects to import.")
 		return
 	}
 
 	existingClaimDialectList, err := getClaimDialectsList()
 	if err != nil {
-		log.Printf("error when retrieving the deployed claim dialect list. %s", err)
+		utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error when retrieving the deployed claim dialect list: %s", err))
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing claim dialects: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error importing claim dialects: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -73,7 +72,7 @@ func ImportAll(inputDirPath string) {
 
 		dialectUri, err := getDialectURIFromFile(claimFilePath)
 		if err != nil {
-			log.Println("error reading dialect URI from file:", err)
+			utils.PrintLog(utils.LogLevelError, utils.CLAIMS, "", fmt.Sprintf("Error reading dialect URI from file: %s", err))
 			continue
 		}
 		dialectId := getClaimDialectId(dialectUri, existingClaimDialectList)
@@ -81,7 +80,7 @@ func ImportAll(inputDirPath string) {
 		if !utils.IsResourceExcluded(dialectUri, utils.TOOL_CONFIGS.ClaimConfigs) {
 			err = importClaimDialect(dialectId, dialectUri, claimFilePath)
 			if err != nil {
-				log.Println("error importing claim dialect:", err)
+				utils.PrintLog(utils.LogLevelError, utils.CLAIMS, dialectUri, fmt.Sprintf("Error importing claim dialect: %s", err))
 				utils.UpdateFailureSummary(utils.CLAIMS, dialectUri)
 			}
 		}
@@ -126,32 +125,32 @@ func importClaimDialect(dialectId, dialectUri, importFilePath string) error {
 
 func importDialect(dialectUri, importFilePath, modifiedFileData string) error {
 
-	log.Println("Creating new claim dialect: " + dialectUri)
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialectUri, "Creating new claim dialect")
 	resp, err := utils.SendImportRequest(importFilePath, modifiedFileData, utils.CLAIMS)
 	if err != nil {
 		return fmt.Errorf("error when importing claim dialect: %s", err)
 	}
 	defer resp.Body.Close()
 	utils.UpdateSuccessSummary(utils.CLAIMS, utils.IMPORT)
-	log.Println("Claim dialect imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialectUri, "Imported successfully")
 	return nil
 }
 
 func updateDialect(dialectId, dialectUri, importFilePath, modifiedFileData string) error {
 
-	log.Println("Updating claim dialect: " + dialectUri)
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialectUri, "Updating claim dialect")
 	err := utils.SendUpdateRequest(dialectId, importFilePath, modifiedFileData, utils.CLAIMS)
 	if err != nil {
 		return fmt.Errorf("error when updating claim dialect: %s", err)
 	}
 	utils.UpdateSuccessSummary(utils.CLAIMS, utils.UPDATE)
-	log.Println("Claim dialect updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialectUri, "Updated successfully")
 	return nil
 }
 
 func importClaimDialectWithCRUD(dialectURI string, claims []map[string]interface{}) error {
 
-	log.Println("Creating new claim dialect: " + dialectURI)
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialectURI, "Creating new claim dialect")
 
 	newDialectId, err := createDialect(dialectURI)
 	if err != nil {
@@ -164,13 +163,13 @@ func importClaimDialectWithCRUD(dialectURI string, claims []map[string]interface
 	}
 
 	utils.UpdateSuccessSummary(utils.CLAIMS, utils.IMPORT)
-	log.Println("Claim dialect imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialectURI, "Imported successfully")
 	return nil
 }
 
 func updateClaimDialectWithCRUD(dialectId, dialectURI string, localClaims []map[string]interface{}) error {
 
-	log.Println("Updating claim dialect: " + dialectURI)
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialectURI, "Updating claim dialect")
 
 	deployedClaims, err := getClaimsList(dialectId)
 	if err != nil {
@@ -198,7 +197,7 @@ func updateClaimDialectWithCRUD(dialectId, dialectURI string, localClaims []map[
 	} else {
 		utils.UpdateSuccessSummary(utils.CLAIMS, utils.UPDATE)
 	}
-	log.Println("Claim dialect updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, dialectURI, "Updated successfully")
 	return nil
 }
 
@@ -293,13 +292,13 @@ func removeDeletedDeployedClaimdialect(localFiles []os.FileInfo, deployedClaimDi
 			continue
 		}
 		if utils.IsResourceExcluded(claimDialect.DialectURI, utils.TOOL_CONFIGS.ClaimConfigs) {
-			log.Printf("Claim dialect: %s is excluded from deletion.\n", claimDialect.DialectURI)
+			utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, claimDialect.DialectURI, "Excluded from deletion.")
 			continue
 		}
-		log.Println("Claim dialect not found locally. Deleting claim dialect: ", claimDialect.DialectURI)
+		utils.PrintLog(utils.LogLevelInfo, utils.CLAIMS, claimDialect.DialectURI, "Not found locally. Deleting.")
 		if err := utils.SendDeleteRequest(claimDialect.Id, utils.CLAIMS); err != nil {
 			utils.UpdateFailureSummary(utils.CLAIMS, claimDialect.DialectURI)
-			log.Println("Error deleting claim dialect: ", err)
+			utils.PrintLog(utils.LogLevelError, utils.CLAIMS, claimDialect.DialectURI, fmt.Sprintf("Error deleting claim dialect: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.CLAIMS, utils.DELETE)
 		}

--- a/iamctl/pkg/emailTemplates/export.go
+++ b/iamctl/pkg/emailTemplates/export.go
@@ -43,12 +43,13 @@ func ExportAllLegacyApi(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, "", "Exporting email templates...")
 	exportFilePath = filepath.Join(exportFilePath, utils.EMAIL_TEMPLATES.String())
 
-	if !utils.IsEntitySupportedInOrg(utils.EMAIL_TEMPLATES) || utils.IsResourceTypeExcluded(utils.EMAIL_TEMPLATES) {
+	if utils.ShouldSkip(utils.EMAIL_TEMPLATES) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error creating email templates directory: %s", err))
+			utils.MarkResTypeFailure(utils.EMAIL_TEMPLATES)
 			return
 		}
 	} else {
@@ -60,7 +61,8 @@ func ExportAllLegacyApi(exportFilePath string, format string) {
 
 	types, err := getEmailTemplateTypeList()
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error when exporting email templates: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error retrieving the deployed email templates list: %s", err))
+		utils.MarkResTypeFailure(utils.EMAIL_TEMPLATES)
 	} else {
 		for _, emailType := range types {
 			if !utils.IsResourceExcluded(emailType.DisplayName, utils.TOOL_CONFIGS.EmailTemplateConfigs) {

--- a/iamctl/pkg/emailTemplates/export.go
+++ b/iamctl/pkg/emailTemplates/export.go
@@ -21,7 +21,6 @@ package emailTemplates
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -41,7 +40,7 @@ func ExportAll(exportFilePath string, format string) {
 
 func ExportAllLegacyApi(exportFilePath string, format string) {
 
-	log.Println("Exporting email templates...")
+	utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, "", "Exporting email templates...")
 	exportFilePath = filepath.Join(exportFilePath, utils.EMAIL_TEMPLATES.String())
 
 	if !utils.IsEntitySupportedInOrg(utils.EMAIL_TEMPLATES) || utils.IsResourceTypeExcluded(utils.EMAIL_TEMPLATES) {
@@ -49,7 +48,7 @@ func ExportAllLegacyApi(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating email templates directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error creating email templates directory: %s", err))
 			return
 		}
 	} else {
@@ -61,18 +60,18 @@ func ExportAllLegacyApi(exportFilePath string, format string) {
 
 	types, err := getEmailTemplateTypeList()
 	if err != nil {
-		log.Println("Error: when exporting email templates.", err)
+		utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error when exporting email templates: %s", err))
 	} else {
 		for _, emailType := range types {
 			if !utils.IsResourceExcluded(emailType.DisplayName, utils.TOOL_CONFIGS.EmailTemplateConfigs) {
-				log.Println("Exporting email template type:", emailType.DisplayName)
+				utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, emailType.DisplayName, "Exporting")
 				err := exportEmailTemplateType(emailType.ID, emailType.DisplayName, exportFilePath, format)
 				if err != nil {
 					utils.UpdateFailureSummary(utils.EMAIL_TEMPLATES, emailType.DisplayName)
-					log.Printf("Error while exporting email template type: %s. %s", emailType.DisplayName, err)
+					utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, emailType.DisplayName, fmt.Sprintf("Error while exporting: %s", err))
 				} else {
 					utils.UpdateSuccessSummary(utils.EMAIL_TEMPLATES, utils.EXPORT)
-					log.Println("Email template type exported successfully:", emailType.DisplayName)
+					utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, emailType.DisplayName, "Exported successfully")
 				}
 			}
 		}

--- a/iamctl/pkg/emailTemplates/import.go
+++ b/iamctl/pkg/emailTemplates/import.go
@@ -21,7 +21,6 @@ package emailTemplates
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -41,26 +40,26 @@ func ImportAll(inputDirPath string) {
 
 func ImportAllLegacyApi(inputDirPath string) {
 
-	log.Println("Importing email templates...")
+	utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, "", "Importing email templates...")
 	importFilePath := filepath.Join(inputDirPath, utils.EMAIL_TEMPLATES.String())
 
 	if !utils.IsEntitySupportedInOrg(utils.EMAIL_TEMPLATES) || utils.IsResourceTypeExcluded(utils.EMAIL_TEMPLATES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No email templates to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, "", "No email templates to import.")
 		return
 	}
 
 	deployedTypes, err := getEmailTemplateTypeList()
 	if err != nil {
-		log.Println("Error retrieving deployed email template types:", err)
+		utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error retrieving deployed email template types: %s", err))
 		return
 	}
 
 	localTypeDirs, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error reading email templates directory:", err)
+		utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error reading email templates directory: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -78,7 +77,7 @@ func ImportAllLegacyApi(inputDirPath string) {
 			err := importEmailTemplateType(localTypePath, displayName, deployedTypes)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.EMAIL_TEMPLATES, displayName)
-				log.Printf("Error importing email template type %s: %s", displayName, err)
+				utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, displayName, fmt.Sprintf("Error importing: %s", err))
 			}
 		}
 	}
@@ -89,14 +88,14 @@ func importEmailTemplateType(localTypePath, displayName string, deployedTypes []
 	var typeId string
 	existingType := isEmailTemplateTypeExists(displayName, deployedTypes)
 	if existingType == nil {
-		log.Println("Creating new email template type:", displayName)
+		utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, displayName, "Creating new email template type")
 		created, err := createEmailTemplateType(displayName)
 		if err != nil {
 			return fmt.Errorf("error creating email template type: %w", err)
 		}
 		typeId = created.ID
 	} else {
-		log.Println("Updating email template type:", displayName)
+		utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, displayName, "Updating email template type")
 		typeId = existingType.ID
 	}
 
@@ -133,10 +132,10 @@ func importEmailTemplateType(localTypePath, displayName string, deployedTypes []
 
 	if existingType != nil {
 		utils.UpdateSuccessSummary(utils.EMAIL_TEMPLATES, utils.UPDATE)
-		log.Println("Email template type updated successfully")
+		utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, displayName, "Updated successfully")
 	} else {
 		utils.UpdateSuccessSummary(utils.EMAIL_TEMPLATES, utils.IMPORT)
-		log.Println("Email template type imported successfully")
+		utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, displayName, "Imported successfully")
 	}
 
 	return nil
@@ -212,13 +211,13 @@ func removeDeletedDeployedTypes(localDirs []os.FileInfo, deployedTypes []emailTe
 			continue
 		}
 		if utils.IsResourceExcluded(deployedType.DisplayName, utils.TOOL_CONFIGS.EmailTemplateConfigs) {
-			log.Printf("Email template type: %s is excluded from deletion.", deployedType.DisplayName)
+			utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, deployedType.DisplayName, "Excluded from deletion.")
 			continue
 		}
-		log.Println("Email template type not found locally. Deleting template type:", deployedType.DisplayName)
+		utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, deployedType.DisplayName, "Not found locally. Deleting template type.")
 		if err := utils.SendDeleteRequest(deployedType.ID, utils.EMAIL_TEMPLATES); err != nil {
 			utils.UpdateFailureSummary(utils.EMAIL_TEMPLATES, deployedType.DisplayName)
-			log.Printf("Error deleting email template type: %s", err)
+			utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, deployedType.DisplayName, fmt.Sprintf("Error deleting email template type: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.EMAIL_TEMPLATES, utils.DELETE)
 		}
@@ -239,7 +238,7 @@ func removeDeletedDeployedTemplates(typeId string, localFiles []os.FileInfo, dep
 
 	for _, template := range deployedTemplates {
 		if _, existsLocally := localIds[template.ID]; !existsLocally {
-			log.Println("Email template not found locally. Deleting template:", template.ID)
+			utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, template.ID, "Not found locally. Deleting template.")
 			if err := utils.SendDeleteRequest(typeId+"/templates/"+template.ID, utils.EMAIL_TEMPLATES); err != nil {
 				return fmt.Errorf("error deleting email template: %w", err)
 			}

--- a/iamctl/pkg/emailTemplates/import.go
+++ b/iamctl/pkg/emailTemplates/import.go
@@ -43,7 +43,7 @@ func ImportAllLegacyApi(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.EMAIL_TEMPLATES, "", "Importing email templates...")
 	importFilePath := filepath.Join(inputDirPath, utils.EMAIL_TEMPLATES.String())
 
-	if !utils.IsEntitySupportedInOrg(utils.EMAIL_TEMPLATES) || utils.IsResourceTypeExcluded(utils.EMAIL_TEMPLATES) {
+	if utils.ShouldSkip(utils.EMAIL_TEMPLATES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -54,12 +54,14 @@ func ImportAllLegacyApi(inputDirPath string) {
 	deployedTypes, err := getEmailTemplateTypeList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error retrieving deployed email template types: %s", err))
+		utils.MarkResTypeFailure(utils.EMAIL_TEMPLATES)
 		return
 	}
 
 	localTypeDirs, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.EMAIL_TEMPLATES, "", fmt.Sprintf("Error reading email templates directory: %s", err))
+		utils.MarkResTypeFailure(utils.EMAIL_TEMPLATES)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/flows/export.go
+++ b/iamctl/pkg/flows/export.go
@@ -32,12 +32,13 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, "", "Exporting flows...")
 	exportFilePath = filepath.Join(exportFilePath, utils.FLOWS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.FLOWS) || !utils.IsEntitySupportedInOrg(utils.FLOWS) || utils.IsResourceTypeExcluded(utils.FLOWS) {
+	if utils.ShouldSkip(utils.FLOWS) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.FLOWS, "", fmt.Sprintf("Error creating flows directory: %s", err))
+			utils.MarkResTypeFailure(utils.FLOWS)
 			return
 		}
 	}

--- a/iamctl/pkg/flows/export.go
+++ b/iamctl/pkg/flows/export.go
@@ -21,7 +21,6 @@ package flows
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting flows...")
+	utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, "", "Exporting flows...")
 	exportFilePath = filepath.Join(exportFilePath, utils.FLOWS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.FLOWS) || !utils.IsEntitySupportedInOrg(utils.FLOWS) || utils.IsResourceTypeExcluded(utils.FLOWS) {
@@ -38,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating flows directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.FLOWS, "", fmt.Sprintf("Error creating flows directory: %s", err))
 			return
 		}
 	}
@@ -46,19 +45,19 @@ func ExportAll(exportFilePath string, format string) {
 	var exportedFlowNames []string
 	for name, id := range flowTypes {
 		if !utils.IsResourceExcluded(name, utils.TOOL_CONFIGS.FlowConfigs) {
-			log.Println("Exporting flow:", name)
+			utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, name, "Exporting")
 
 			exists, err := exportFlow(name, id, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.FLOWS, name)
-				log.Printf("Error while exporting flow: %s. %s", name, err)
+				utils.PrintLog(utils.LogLevelError, utils.FLOWS, name, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				if exists {
 					exportedFlowNames = append(exportedFlowNames, name)
 					utils.UpdateSuccessSummary(utils.FLOWS, utils.EXPORT)
-					log.Println("Flow exported successfully:", name)
+					utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, name, "Exported successfully")
 				} else {
-					log.Printf("Flow: %s is not configured", name)
+					utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, name, "Not configured")
 				}
 			}
 		}

--- a/iamctl/pkg/flows/import.go
+++ b/iamctl/pkg/flows/import.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -31,20 +30,20 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing flows...")
+	utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, "", "Importing flows...")
 	importFilePath := filepath.Join(inputDirPath, utils.FLOWS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.FLOWS) || !utils.IsEntitySupportedInOrg(utils.FLOWS) || utils.IsResourceTypeExcluded(utils.FLOWS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No flows to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, "", "No flows to import.")
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error reading flows directory:", err)
+		utils.PrintLog(utils.LogLevelError, utils.FLOWS, "", fmt.Sprintf("Error reading flows directory: %s", err))
 		return
 	}
 
@@ -56,7 +55,7 @@ func ImportAll(inputDirPath string) {
 		if !utils.IsResourceExcluded(name, utils.TOOL_CONFIGS.FlowConfigs) {
 			id, ok := flowTypes[name]
 			if !ok {
-				log.Printf("Error importing flow: %s. Unknown flow type", name)
+				utils.PrintLog(utils.LogLevelError, utils.FLOWS, name, "Error importing flow: unknown flow type")
 				utils.UpdateFailureSummary(utils.FLOWS, name)
 				continue
 			}
@@ -64,7 +63,7 @@ func ImportAll(inputDirPath string) {
 			err := importFlow(name, id, flowFilePath)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.FLOWS, name)
-				log.Printf("Error importing flow: %s. %s\n", name, err)
+				utils.PrintLog(utils.LogLevelError, utils.FLOWS, name, fmt.Sprintf("Error importing flow: %s", err))
 			}
 		}
 	}
@@ -95,7 +94,7 @@ func importFlow(name, id, importFilePath string) error {
 
 func updateFlow(name, id string, data []byte, format utils.Format) error {
 
-	log.Println("Updating flow:", name)
+	utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, name, "Updating flow")
 
 	dataMap, err := utils.DeserializeToMap(data, format, utils.FLOWS)
 	if err != nil {
@@ -126,7 +125,7 @@ func updateFlow(name, id string, data []byte, format utils.Format) error {
 	}
 
 	utils.UpdateSuccessSummary(utils.FLOWS, utils.UPDATE)
-	log.Println("Flow updated successfully:", name)
+	utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, name, "Updated successfully")
 	return nil
 }
 

--- a/iamctl/pkg/flows/import.go
+++ b/iamctl/pkg/flows/import.go
@@ -33,7 +33,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.FLOWS, "", "Importing flows...")
 	importFilePath := filepath.Join(inputDirPath, utils.FLOWS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.FLOWS) || !utils.IsEntitySupportedInOrg(utils.FLOWS) || utils.IsResourceTypeExcluded(utils.FLOWS) {
+	if utils.ShouldSkip(utils.FLOWS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -44,6 +44,7 @@ func ImportAll(inputDirPath string) {
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.FLOWS, "", fmt.Sprintf("Error reading flows directory: %s", err))
+		utils.MarkResTypeFailure(utils.FLOWS)
 		return
 	}
 

--- a/iamctl/pkg/governanceConnectors/export.go
+++ b/iamctl/pkg/governanceConnectors/export.go
@@ -21,7 +21,6 @@ package governanceConnectors
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting governance connectors...")
+	utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, "", "Exporting governance connectors...")
 	exportFilePath = filepath.Join(exportFilePath, utils.GOVERNANCE_CONNECTORS.String())
 
 	if !utils.IsEntitySupportedInOrg(utils.GOVERNANCE_CONNECTORS) || utils.IsResourceTypeExcluded(utils.GOVERNANCE_CONNECTORS) {
@@ -38,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating governance connectors directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, "", fmt.Sprintf("Error creating governance connectors directory: %s", err))
 			return
 		}
 	} else {
@@ -50,20 +49,20 @@ func ExportAll(exportFilePath string, format string) {
 
 	categories, err := getCategoryList()
 	if err != nil {
-		log.Println("Error retrieving governance connector categories:", err)
+		utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, "", fmt.Sprintf("Error retrieving governance connector categories: %s", err))
 		return
 	}
 	for _, catInfo := range categories {
 		if !utils.IsResourceExcluded(catInfo.Name, utils.TOOL_CONFIGS.GovernanceConnectorConfigs) {
-			log.Println("Exporting governance connector category:", catInfo.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, catInfo.Name, "Exporting")
 
 			err := exportCategory(catInfo.Id, catInfo.Name, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.GOVERNANCE_CONNECTORS, catInfo.Name)
-				log.Printf("Error while exporting governance connector category: %s. %s", catInfo.Name, err)
+				utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, catInfo.Name, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				utils.UpdateSuccessSummary(utils.GOVERNANCE_CONNECTORS, utils.EXPORT)
-				log.Println("Governance connector category exported successfully:", catInfo.Name)
+				utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, catInfo.Name, "Exported successfully")
 
 				if catInfo.Name == utils.USER_ONBOARDING_GOVERNANCE_CATEGORY_NAME {
 					utils.AddToIdentifierMap(utils.GOVERNANCE_CONNECTORS, catInfo.Id, catInfo.Name, utils.EXPORT)
@@ -119,7 +118,7 @@ func exportConnector(connectorId, connectorName, categoryId, categoryDir string,
 		if err := processPasswordExpiryConnector(connectorData, nil); err != nil {
 			return fmt.Errorf("error processing password expiry connector: %w", err)
 		}
-		log.Println("Warn: Group-based password expiry rules are not exported")
+		utils.PrintLog(utils.LogLevelWarn, utils.GOVERNANCE_CONNECTORS, connectorName, "Group-based password expiry rules are not exported")
 	}
 
 	modifiedData, err := utils.ProcessExportedData(connectorData, exportedFileName, format, keywordMapping, utils.GOVERNANCE_CONNECTORS)

--- a/iamctl/pkg/governanceConnectors/export.go
+++ b/iamctl/pkg/governanceConnectors/export.go
@@ -32,12 +32,13 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, "", "Exporting governance connectors...")
 	exportFilePath = filepath.Join(exportFilePath, utils.GOVERNANCE_CONNECTORS.String())
 
-	if !utils.IsEntitySupportedInOrg(utils.GOVERNANCE_CONNECTORS) || utils.IsResourceTypeExcluded(utils.GOVERNANCE_CONNECTORS) {
+	if utils.ShouldSkip(utils.GOVERNANCE_CONNECTORS) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, "", fmt.Sprintf("Error creating governance connectors directory: %s", err))
+			utils.MarkResTypeFailure(utils.GOVERNANCE_CONNECTORS)
 			return
 		}
 	} else {
@@ -50,6 +51,7 @@ func ExportAll(exportFilePath string, format string) {
 	categories, err := getCategoryList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, "", fmt.Sprintf("Error retrieving governance connector categories: %s", err))
+		utils.MarkResTypeFailure(utils.GOVERNANCE_CONNECTORS)
 		return
 	}
 	for _, catInfo := range categories {

--- a/iamctl/pkg/governanceConnectors/governanceConnectorUtils.go
+++ b/iamctl/pkg/governanceConnectors/governanceConnectorUtils.go
@@ -21,7 +21,6 @@ package governanceConnectors
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
@@ -233,7 +232,7 @@ func buildPatchRequestBody(requestBody []byte, format utils.Format, connectorId,
 			if err != nil {
 				return nil, fmt.Errorf("error retrieving deployed rules of password expiry connector: %w", err)
 			}
-			log.Println("Warn: Group-based password expiry rules are removed during import")
+			utils.PrintLog(utils.LogLevelWarn, utils.GOVERNANCE_CONNECTORS, "", "Group-based password expiry rules are removed during import")
 		}
 		if err := processPasswordExpiryConnector(connectorMap, deployedRuleNames); err != nil {
 			return nil, fmt.Errorf("error processing password expiry connector: %w", err)

--- a/iamctl/pkg/governanceConnectors/import.go
+++ b/iamctl/pkg/governanceConnectors/import.go
@@ -32,7 +32,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, "", "Importing governance connectors...")
 	importFilePath := filepath.Join(inputDirPath, utils.GOVERNANCE_CONNECTORS.String())
 
-	if !utils.IsEntitySupportedInOrg(utils.GOVERNANCE_CONNECTORS) || utils.IsResourceTypeExcluded(utils.GOVERNANCE_CONNECTORS) {
+	if utils.ShouldSkip(utils.GOVERNANCE_CONNECTORS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -43,12 +43,14 @@ func ImportAll(inputDirPath string) {
 	deployedCategories, err := getCategoryList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, "", fmt.Sprintf("Error retrieving governance connector categories: %s", err))
+		utils.MarkResTypeFailure(utils.GOVERNANCE_CONNECTORS)
 		return
 	}
 
 	localCategoryDirs, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, "", fmt.Sprintf("Error reading governance connectors directory: %s", err))
+		utils.MarkResTypeFailure(utils.GOVERNANCE_CONNECTORS)
 		return
 	}
 

--- a/iamctl/pkg/governanceConnectors/import.go
+++ b/iamctl/pkg/governanceConnectors/import.go
@@ -21,7 +21,6 @@ package governanceConnectors
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,26 +29,26 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing governance connectors...")
+	utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, "", "Importing governance connectors...")
 	importFilePath := filepath.Join(inputDirPath, utils.GOVERNANCE_CONNECTORS.String())
 
 	if !utils.IsEntitySupportedInOrg(utils.GOVERNANCE_CONNECTORS) || utils.IsResourceTypeExcluded(utils.GOVERNANCE_CONNECTORS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No governance connectors to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, "", "No governance connectors to import.")
 		return
 	}
 
 	deployedCategories, err := getCategoryList()
 	if err != nil {
-		log.Println("Error retrieving governance connector categories:", err)
+		utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, "", fmt.Sprintf("Error retrieving governance connector categories: %s", err))
 		return
 	}
 
 	localCategoryDirs, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error reading governance connectors directory:", err)
+		utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, "", fmt.Sprintf("Error reading governance connectors directory: %s", err))
 		return
 	}
 
@@ -64,7 +63,7 @@ func ImportAll(inputDirPath string) {
 			err := importCategory(localCategoryPath, catName, deployedCategories)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.GOVERNANCE_CONNECTORS, catName)
-				log.Printf("Error importing governance connector category %s: %s", catName, err)
+				utils.PrintLog(utils.LogLevelError, utils.GOVERNANCE_CONNECTORS, catName, fmt.Sprintf("Error importing: %s", err))
 			}
 		}
 	}
@@ -74,7 +73,7 @@ func importCategory(localCategoryPath, catName string, deployedCategories []conn
 
 	catInfo := isCategoryExists(catName, deployedCategories)
 	if catInfo == nil {
-		log.Printf("Governance connector category %s not found on server, skipping.", catName)
+		utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, catName, "Not found on server, skipping.")
 		return nil
 	}
 
@@ -97,7 +96,7 @@ func importCategory(localCategoryPath, catName string, deployedCategories []conn
 
 		conId := getConnectorId(connectorName, deployedConnectors)
 		if conId == "" {
-			log.Printf("Connector %s not found on server, skipping.", connectorName)
+			utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, connectorName, "Not found on server, skipping.")
 			continue
 		}
 
@@ -108,7 +107,7 @@ func importCategory(localCategoryPath, catName string, deployedCategories []conn
 	}
 
 	utils.UpdateSuccessSummary(utils.GOVERNANCE_CONNECTORS, utils.UPDATE)
-	log.Println("Governance connector category imported successfully:", catName)
+	utils.PrintLog(utils.LogLevelInfo, utils.GOVERNANCE_CONNECTORS, catName, "Imported successfully")
 
 	if catName == utils.USER_ONBOARDING_GOVERNANCE_CATEGORY_NAME {
 		utils.AddToIdentifierMap(utils.GOVERNANCE_CONNECTORS, catInfo.Id, catName, utils.IMPORT)

--- a/iamctl/pkg/identityProviders/export.go
+++ b/iamctl/pkg/identityProviders/export.go
@@ -42,6 +42,7 @@ func ExportAll(exportFilePath string, format string) {
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error creating identity providers directory: %s", err))
+			utils.MarkResTypeFailure(utils.IDENTITY_PROVIDERS)
 			return
 		}
 	} else {
@@ -57,7 +58,8 @@ func ExportAll(exportFilePath string, format string) {
 	excludeSecerts := utils.AreSecretsExcluded(utils.TOOL_CONFIGS.IdpConfigs)
 	idps, err := getIdpList()
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error when exporting identity providers: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error retrieving the deployed identity providers list: %s", err))
+		utils.MarkResTypeFailure(utils.IDENTITY_PROVIDERS)
 	} else {
 		for _, idp := range idps {
 			if !utils.IsResourceExcluded(idp.Name, utils.TOOL_CONFIGS.IdpConfigs) {

--- a/iamctl/pkg/identityProviders/export.go
+++ b/iamctl/pkg/identityProviders/export.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"mime"
 	"os"
 	"path/filepath"
@@ -33,7 +32,7 @@ import (
 func ExportAll(exportFilePath string, format string) {
 
 	// Export all identity providers to the IdentityProviders folder.
-	log.Println("Exporting identity providers...")
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, "", "Exporting identity providers...")
 	exportFilePath = filepath.Join(exportFilePath, utils.IDENTITY_PROVIDERS.String())
 	exportAPIExists := utils.ExportAPIExists(utils.IDENTITY_PROVIDERS)
 
@@ -42,7 +41,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating identity providers directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error creating identity providers directory: %s", err))
 			return
 		}
 	} else {
@@ -58,36 +57,36 @@ func ExportAll(exportFilePath string, format string) {
 	excludeSecerts := utils.AreSecretsExcluded(utils.TOOL_CONFIGS.IdpConfigs)
 	idps, err := getIdpList()
 	if err != nil {
-		log.Println("Error: when exporting identity providers.", err)
+		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error when exporting identity providers: %s", err))
 	} else {
 		for _, idp := range idps {
 			if !utils.IsResourceExcluded(idp.Name, utils.TOOL_CONFIGS.IdpConfigs) {
-				log.Println("Exporting identity provider: ", idp.Name)
+				utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idp.Name, "Exporting")
 
 				err := exportIdpWithCRUD(idp.Id, idp.Name, exportFilePath, format, excludeSecerts)
 				if err != nil {
 					utils.UpdateFailureSummary(utils.IDENTITY_PROVIDERS, idp.Name)
-					log.Printf("Error while exporting identity providers: %s. %s", idp.Name, err)
+					utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, idp.Name, fmt.Sprintf("Error while exporting: %s", err))
 				} else {
 					utils.UpdateSuccessSummary(utils.IDENTITY_PROVIDERS, utils.EXPORT)
-					log.Println("Identity provider exported successfully: ", idp.Name)
+					utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idp.Name, "Exported successfully")
 				}
 			}
 		}
 	}
 	if !utils.IsResourceExcluded(utils.RESIDENT_IDP_NAME, utils.TOOL_CONFIGS.IdpConfigs) && exportAPIExists {
-		log.Println("Exporting Resident identity provider")
+		utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, utils.RESIDENT_IDP_NAME, "Exporting Resident identity provider")
 		err := exportIdp(utils.RESIDENT_IDP_NAME, exportFilePath, format, excludeSecerts)
 		if err != nil {
 			utils.UpdateFailureSummary(utils.IDENTITY_PROVIDERS, utils.RESIDENT_IDP_NAME)
-			log.Printf("Error while exporting resident identity provider: %s", err)
+			utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, utils.RESIDENT_IDP_NAME, fmt.Sprintf("Error while exporting resident identity provider: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.IDENTITY_PROVIDERS, utils.EXPORT)
-			log.Println("Resident identity provider exported successfully")
+			utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, utils.RESIDENT_IDP_NAME, "Exported successfully")
 		}
 	}
 	if shouldRemoveOutboundProvisioningRoles() {
-		log.Println("Warn: Outbound provisioning groups of identity providers are not exported")
+		utils.PrintLog(utils.LogLevelWarn, utils.IDENTITY_PROVIDERS, "", "Outbound provisioning groups of identity providers are not exported")
 	}
 }
 

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -75,6 +75,8 @@ var idpPatchSkipKeys = map[string]bool{
 	"templateId":              true,
 }
 
+var customAuthSecretsWarningLogged bool
+
 func getIdpList() ([]identityProvider, error) {
 
 	data, err := utils.SendPaginatedGetListRequest(
@@ -168,8 +170,9 @@ func processFederatedAuthenticators(idpId string, idpStruct idpConfig, idpMap ma
 			return fmt.Errorf("unexpected format for definedBy field of federated authenticator: %s", authId)
 		}
 		if definedBy == "USER" {
-			if !excludeSecrets {
+			if excludeSecrets && !customAuthSecretsWarningLogged {
 				utils.PrintLog(utils.LogLevelWarn, utils.IDENTITY_PROVIDERS, "", "Secrets exclusion cannot be disabled for custom authenticators(service-based). All secrets will be masked.")
+				customAuthSecretsWarningLogged = true
 			}
 			if err := processEndpointAuthProperties(fullAuthMap); err != nil {
 				return fmt.Errorf("error processing endpoint auth properties for authenticator %s: %v", authId, err)

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -21,7 +21,6 @@ package identityproviders
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"regexp"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
@@ -170,7 +169,7 @@ func processFederatedAuthenticators(idpId string, idpStruct idpConfig, idpMap ma
 		}
 		if definedBy == "USER" {
 			if !excludeSecrets {
-				log.Println("Warn: Secrets exclusion cannot be disabled for custom authenticators(service-based). All secrets will be masked.")
+				utils.PrintLog(utils.LogLevelWarn, utils.IDENTITY_PROVIDERS, "", "Secrets exclusion cannot be disabled for custom authenticators(service-based). All secrets will be masked.")
 			}
 			if err := processEndpointAuthProperties(fullAuthMap); err != nil {
 				return fmt.Errorf("error processing endpoint auth properties for authenticator %s: %v", authId, err)

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -170,7 +170,7 @@ func processFederatedAuthenticators(idpId string, idpStruct idpConfig, idpMap ma
 			return fmt.Errorf("unexpected format for definedBy field of federated authenticator: %s", authId)
 		}
 		if definedBy == "USER" {
-			if excludeSecrets && !customAuthSecretsWarningLogged {
+			if !excludeSecrets && !customAuthSecretsWarningLogged {
 				utils.PrintLog(utils.LogLevelWarn, utils.IDENTITY_PROVIDERS, "", "Secrets exclusion cannot be disabled for custom authenticators(service-based). All secrets will be masked.")
 				customAuthSecretsWarningLogged = true
 			}

--- a/iamctl/pkg/identityProviders/import.go
+++ b/iamctl/pkg/identityProviders/import.go
@@ -46,12 +46,14 @@ func ImportAll(inputDirPath string) {
 	existingIdpList, err := getIdpList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error when retrieving the deployed identity provider list. %s", err))
+		utils.MarkResTypeFailure(utils.IDENTITY_PROVIDERS)
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error importing identity providers: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error reading identity providers directory: %s", err))
+		utils.MarkResTypeFailure(utils.IDENTITY_PROVIDERS)
 		return
 	}
 
@@ -352,6 +354,7 @@ func RemoveDeletedDeployedIdps(inputDirPath string) {
 	deployedIdps, err := getIdpList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error when retrieving deployed identity provider list: %s", err))
+		utils.MarkResTypeFailure(utils.IDENTITY_PROVIDERS)
 		return
 	}
 

--- a/iamctl/pkg/identityProviders/import.go
+++ b/iamctl/pkg/identityProviders/import.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path"
 	"path/filepath"
@@ -32,7 +31,7 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing identity providers...")
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, "", "Importing identity providers...")
 	importFilePath := filepath.Join(inputDirPath, utils.IDENTITY_PROVIDERS.String())
 	exportAPIExists := utils.ExportAPIExists(utils.IDENTITY_PROVIDERS)
 
@@ -40,19 +39,19 @@ func ImportAll(inputDirPath string) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No identity providers to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, "", "No identity providers to import.")
 		return
 	}
 
 	existingIdpList, err := getIdpList()
 	if err != nil {
-		log.Printf("error when retrieving the deployed identity provider list. %s", err)
+		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error when retrieving the deployed identity provider list. %s", err))
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing identity providers: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error importing identity providers: %s", err))
 		return
 	}
 
@@ -74,13 +73,13 @@ func ImportAll(inputDirPath string) {
 
 			err := importIdp(idpId, idpName, idpFilePath, exportAPIExists)
 			if err != nil {
-				log.Println("Error importing identity provider: ", err)
+				utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, idpName, fmt.Sprintf("Error importing identity provider: %s", err))
 				utils.UpdateFailureSummary(utils.IDENTITY_PROVIDERS, idpName)
 			}
 		}
 	}
 	if shouldRemoveOutboundProvisioningRoles() {
-		log.Println("Warn: Outbound provisioning groups of identity providers are removed during import")
+		utils.PrintLog(utils.LogLevelWarn, utils.IDENTITY_PROVIDERS, "", "Outbound provisioning groups of identity providers are removed during import")
 	}
 }
 
@@ -111,32 +110,32 @@ func importIdp(idpId string, idpName string, importFilePath string, exportAPIExi
 
 func importIdentityProvider(idpName, importFilePath, modifiedFileData string) error {
 
-	log.Println("Creating new identity provider: " + idpName)
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idpName, "Creating new identity provider")
 	resp, err := utils.SendImportRequest(importFilePath, modifiedFileData, utils.IDENTITY_PROVIDERS)
 	if err != nil {
 		return fmt.Errorf("error when importing identity provider: %s", err)
 	}
 	defer resp.Body.Close()
 	utils.UpdateSuccessSummary(utils.IDENTITY_PROVIDERS, utils.IMPORT)
-	log.Println("Identity provider imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idpName, "Imported successfully")
 	return nil
 }
 
 func updateIdentityProvider(idpId, idpName, importFilePath, modifiedFileData string) error {
 
-	log.Println("Updating identity provider: " + idpName)
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idpName, "Updating identity provider")
 	err := utils.SendUpdateRequest(idpId, importFilePath, modifiedFileData, utils.IDENTITY_PROVIDERS)
 	if err != nil {
 		return fmt.Errorf("error when updating identity provider: %s", err)
 	}
 	utils.UpdateSuccessSummary(utils.IDENTITY_PROVIDERS, utils.UPDATE)
-	log.Println("Identity provider updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idpName, "Updated successfully")
 	return nil
 }
 
 func importIdpWithCRUD(idpName string, requestBody []byte, format utils.Format) error {
 
-	log.Println("Creating new identity provider: " + idpName)
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idpName, "Creating new identity provider")
 
 	idpMap, err := utils.DeserializeToMap(requestBody, format, utils.IDENTITY_PROVIDERS)
 	if err != nil {
@@ -153,13 +152,13 @@ func importIdpWithCRUD(idpName string, requestBody []byte, format utils.Format) 
 	}
 
 	utils.UpdateSuccessSummary(utils.IDENTITY_PROVIDERS, utils.IMPORT)
-	log.Println("Identity provider imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idpName, "Imported successfully")
 	return nil
 }
 
 func updateIdpWithCRUD(idpId, idpName string, requestBody []byte, format utils.Format) error {
 
-	log.Println("Updating identity provider: " + idpName)
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idpName, "Updating identity provider")
 
 	idpMap, err := utils.DeserializeToMap(requestBody, format, utils.IDENTITY_PROVIDERS)
 	if err != nil {
@@ -185,7 +184,7 @@ func updateIdpWithCRUD(idpId, idpName string, requestBody []byte, format utils.F
 	}
 
 	utils.UpdateSuccessSummary(utils.IDENTITY_PROVIDERS, utils.UPDATE)
-	log.Println("Identity provider updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idpName, "Updated successfully")
 	return nil
 }
 
@@ -331,7 +330,7 @@ func updateIdpSubResources(idpId string, idpStruct idpConfig) error {
 
 func RemoveDeletedDeployedIdps(inputDirPath string) {
 
-	log.Println("Removing deleted identity providers...")
+	utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, "", "Removing deleted identity providers...")
 
 	if !utils.TOOL_CONFIGS.AllowDelete {
 		return
@@ -347,12 +346,12 @@ func RemoveDeletedDeployedIdps(inputDirPath string) {
 
 	localFiles, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error reading local identity provider files: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error reading local identity provider files: %s", err))
 		return
 	}
 	deployedIdps, err := getIdpList()
 	if err != nil {
-		log.Printf("error when retrieving deployed identity provider list: %s", err)
+		utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, "", fmt.Sprintf("Error when retrieving deployed identity provider list: %s", err))
 		return
 	}
 
@@ -366,14 +365,14 @@ func RemoveDeletedDeployedIdps(inputDirPath string) {
 			continue
 		}
 		if utils.IsResourceExcluded(idp.Name, utils.TOOL_CONFIGS.IdpConfigs) || idp.Name == utils.RESIDENT_IDP_NAME {
-			log.Println("Identity provider is excluded from deletion: ", idp.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idp.Name, "Excluded from deletion")
 			continue
 		}
 
-		log.Printf("Identity provider: %s not found locally. Deleting idp.\n", idp.Name)
+		utils.PrintLog(utils.LogLevelInfo, utils.IDENTITY_PROVIDERS, idp.Name, "Not found locally. Deleting idp.")
 		if err := utils.SendDeleteRequest(idp.Id, utils.IDENTITY_PROVIDERS); err != nil {
 			utils.UpdateFailureSummary(utils.IDENTITY_PROVIDERS, idp.Name)
-			log.Println("Error deleting idp: ", idp.Name, err)
+			utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, idp.Name, fmt.Sprintf("Error deleting idp: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.IDENTITY_PROVIDERS, utils.DELETE)
 		}

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -37,13 +37,14 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 		utils.PrintLog(utils.LogLevelInfo, resType, "", "Exporting email providers for super tenant not supported.")
 		return
 	}
-	if !utils.IsEntitySupportedInVersion(resType) || !utils.IsEntitySupportedInOrg(resType) || utils.IsResourceTypeExcluded(resType) {
+	if utils.ShouldSkip(resType) {
 		return
 	}
 
 	providers, err := getProviderList(resType)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error while retrieving the %s list: %s", logName, err))
+		utils.MarkResTypeFailure(resType)
 		return
 	}
 
@@ -54,6 +55,7 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error creating %s directory: %s", logName, err))
+			utils.MarkResTypeFailure(resType)
 			return
 		}
 	} else {

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -35,6 +35,7 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 
 	if resType == utils.EMAIL_PROVIDERS && utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
 		utils.PrintLog(utils.LogLevelInfo, resType, "", "Exporting email providers for super tenant not supported.")
+		utils.UpdateSkipSummary(utils.EMAIL_PROVIDERS, "Not supported in super tenant")
 		return
 	}
 	if utils.ShouldSkip(resType) {

--- a/iamctl/pkg/notificationProviders/export.go
+++ b/iamctl/pkg/notificationProviders/export.go
@@ -21,7 +21,6 @@ package notificationProviders
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -31,11 +30,11 @@ import (
 func exportAll(resType utils.ResourceType, exportFilePath string, format string) {
 
 	logName := getProviderLogName(resType)
-	log.Printf("Exporting %s...", logName)
+	utils.PrintLog(utils.LogLevelInfo, resType, "", fmt.Sprintf("Exporting %s...", logName))
 	exportFilePath = filepath.Join(exportFilePath, resType.String())
 
 	if resType == utils.EMAIL_PROVIDERS && utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
-		log.Println("Exporting email providers for super tenant not supported.")
+		utils.PrintLog(utils.LogLevelInfo, resType, "", "Exporting email providers for super tenant not supported.")
 		return
 	}
 	if !utils.IsEntitySupportedInVersion(resType) || !utils.IsEntitySupportedInOrg(resType) || utils.IsResourceTypeExcluded(resType) {
@@ -44,17 +43,17 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 
 	providers, err := getProviderList(resType)
 	if err != nil {
-		log.Printf("Error while retrieving the %s list: %s", logName, err)
+		utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error while retrieving the %s list: %s", logName, err))
 		return
 	}
 
 	if resType == utils.EMAIL_PROVIDERS && !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.EmailProviderConfigs) {
-		log.Println("Warn: Secrets exclusion cannot be disabled for email providers. All secrets will be masked.")
+		utils.PrintLog(utils.LogLevelWarn, resType, "", "Secrets exclusion cannot be disabled for email providers. All secrets will be masked.")
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Printf("Error creating %s directory: %s", logName, err)
+			utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error creating %s directory: %s", logName, err))
 			return
 		}
 	} else {
@@ -65,15 +64,15 @@ func exportAll(resType utils.ResourceType, exportFilePath string, format string)
 
 	for _, provider := range providers {
 		if !utils.IsResourceExcluded(provider.Name, getProviderResourceConfig(resType)) {
-			log.Printf("Exporting %s: %s", logName, provider.Name)
+			utils.PrintLog(utils.LogLevelInfo, resType, provider.Name, fmt.Sprintf("Exporting %s", logName))
 
 			err := exportProvider(resType, logName, provider.Name, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(resType, provider.Name)
-				log.Printf("Error while exporting %s: %s. %s", logName, provider.Name, err)
+				utils.PrintLog(utils.LogLevelError, resType, provider.Name, fmt.Sprintf("Error while exporting %s: %s", logName, err))
 			} else {
 				utils.UpdateSuccessSummary(resType, utils.EXPORT)
-				log.Printf("%s exported successfully: %s", logName, provider.Name)
+				utils.PrintLog(utils.LogLevelInfo, resType, provider.Name, fmt.Sprintf("%s exported successfully", logName))
 			}
 		}
 	}

--- a/iamctl/pkg/notificationProviders/import.go
+++ b/iamctl/pkg/notificationProviders/import.go
@@ -35,6 +35,7 @@ func importAll(resType utils.ResourceType, inputDirPath string) {
 
 	if resType == utils.EMAIL_PROVIDERS && utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
 		utils.PrintLog(utils.LogLevelInfo, resType, "", "Importing email providers for super tenant not supported.")
+		utils.UpdateSkipSummary(utils.EMAIL_PROVIDERS, "Not supported in super tenant")
 		return
 	}
 	if utils.ShouldSkip(resType) {

--- a/iamctl/pkg/notificationProviders/import.go
+++ b/iamctl/pkg/notificationProviders/import.go
@@ -21,7 +21,6 @@ package notificationProviders
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -31,29 +30,29 @@ import (
 func importAll(resType utils.ResourceType, inputDirPath string) {
 
 	logName := getProviderLogName(resType)
-	log.Printf("Importing %s...", logName)
+	utils.PrintLog(utils.LogLevelInfo, resType, "", fmt.Sprintf("Importing %s...", logName))
 	importFilePath := filepath.Join(inputDirPath, resType.String())
 
 	if resType == utils.EMAIL_PROVIDERS && utils.SERVER_CONFIGS.TenantDomain == utils.DEFAULT_TENANT_DOMAIN {
-		log.Println("Importing email providers for super tenant not supported.")
+		utils.PrintLog(utils.LogLevelInfo, resType, "", "Importing email providers for super tenant not supported.")
 		return
 	}
 	if !utils.IsEntitySupportedInVersion(resType) || !utils.IsEntitySupportedInOrg(resType) || utils.IsResourceTypeExcluded(resType) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Printf("No %s to import.", logName)
+		utils.PrintLog(utils.LogLevelInfo, resType, "", fmt.Sprintf("No %s to import.", logName))
 		return
 	}
 
 	existingProviderList, err := getProviderList(resType)
 	if err != nil {
-		log.Printf("Error retrieving the deployed %s list: %s", logName, err)
+		utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error retrieving the deployed %s list: %s", logName, err))
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Printf("Error importing %s: %s", logName, err)
+		utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error importing %s: %s", logName, err))
 		return
 	}
 
@@ -70,7 +69,7 @@ func importAll(resType utils.ResourceType, inputDirPath string) {
 			providerExists := isProviderExists(providerName, existingProviderList)
 			err := importProvider(resType, logName, providerName, providerExists, providerFilePath)
 			if err != nil {
-				log.Printf("Error importing %s: %s", logName, err)
+				utils.PrintLog(utils.LogLevelError, resType, providerName, fmt.Sprintf("Error importing %s: %s", logName, err))
 				utils.UpdateFailureSummary(resType, providerName)
 			}
 		}
@@ -100,7 +99,7 @@ func importProvider(resType utils.ResourceType, logName string, name string, exi
 
 func createProvider(resType utils.ResourceType, requestBody []byte, format utils.Format, name string, logName string) error {
 
-	log.Printf("Creating new %s: %s", logName, name)
+	utils.PrintLog(utils.LogLevelInfo, resType, name, fmt.Sprintf("Creating new %s", logName))
 
 	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, resType)
 	if err != nil {
@@ -114,13 +113,13 @@ func createProvider(resType utils.ResourceType, requestBody []byte, format utils
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(resType, utils.IMPORT)
-	log.Printf("%s created successfully: %s", logName, name)
+	utils.PrintLog(utils.LogLevelInfo, resType, name, fmt.Sprintf("%s created successfully", logName))
 	return nil
 }
 
 func updateProvider(resType utils.ResourceType, name string, requestBody []byte, format utils.Format, logName string) error {
 
-	log.Printf("Updating %s: %s", logName, name)
+	utils.PrintLog(utils.LogLevelInfo, resType, name, fmt.Sprintf("Updating %s", logName))
 
 	updateBody, err := utils.PrepareJSONRequestBody(requestBody, format, resType, "name")
 	if err != nil {
@@ -134,7 +133,7 @@ func updateProvider(resType utils.ResourceType, name string, requestBody []byte,
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(resType, utils.UPDATE)
-	log.Printf("%s updated successfully: %s", logName, name)
+	utils.PrintLog(utils.LogLevelInfo, resType, name, fmt.Sprintf("%s updated successfully", logName))
 	return nil
 }
 
@@ -155,14 +154,14 @@ func removeDeletedDeployedProviders(resType utils.ResourceType, localFiles []os.
 			continue
 		}
 		if utils.IsResourceExcluded(provider.Name, getProviderResourceConfig(resType)) {
-			log.Printf("%s is excluded from deletion: %s", logName, provider.Name)
+			utils.PrintLog(utils.LogLevelInfo, resType, provider.Name, fmt.Sprintf("%s is excluded from deletion", logName))
 			continue
 		}
 
-		log.Printf("%s: %s not found locally. Deleting.\n", logName, provider.Name)
+		utils.PrintLog(utils.LogLevelInfo, resType, provider.Name, fmt.Sprintf("%s not found locally. Deleting.", logName))
 		if err := utils.SendDeleteRequest(provider.Name, resType); err != nil {
 			utils.UpdateFailureSummary(resType, provider.Name)
-			log.Printf("Error deleting %s: %s. %s", logName, provider.Name, err)
+			utils.PrintLog(utils.LogLevelError, resType, provider.Name, fmt.Sprintf("Error deleting %s: %s", logName, err))
 		} else {
 			utils.UpdateSuccessSummary(resType, utils.DELETE)
 		}

--- a/iamctl/pkg/notificationProviders/import.go
+++ b/iamctl/pkg/notificationProviders/import.go
@@ -37,7 +37,7 @@ func importAll(resType utils.ResourceType, inputDirPath string) {
 		utils.PrintLog(utils.LogLevelInfo, resType, "", "Importing email providers for super tenant not supported.")
 		return
 	}
-	if !utils.IsEntitySupportedInVersion(resType) || !utils.IsEntitySupportedInOrg(resType) || utils.IsResourceTypeExcluded(resType) {
+	if utils.ShouldSkip(resType) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -48,11 +48,13 @@ func importAll(resType utils.ResourceType, inputDirPath string) {
 	existingProviderList, err := getProviderList(resType)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error retrieving the deployed %s list: %s", logName, err))
+		utils.MarkResTypeFailure(resType)
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error importing %s: %s", logName, err))
+		utils.PrintLog(utils.LogLevelError, resType, "", fmt.Sprintf("Error reading %s directory: %s", logName, err))
+		utils.MarkResTypeFailure(resType)
 		return
 	}
 

--- a/iamctl/pkg/notificationProviders/notificationProviderUtils.go
+++ b/iamctl/pkg/notificationProviders/notificationProviderUtils.go
@@ -21,7 +21,6 @@ package notificationProviders
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
@@ -141,7 +140,7 @@ func processAuthSecrets(resType utils.ResourceType, data interface{}) (interface
 		}
 
 		if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.SmsProviderConfigs) {
-			log.Printf("Warn: Secrets exclusion cannot be disabled for Custom sms providers. All secrets will be masked.")
+			utils.PrintLog(utils.LogLevelWarn, resType, "", "Secrets exclusion cannot be disabled for Custom sms providers. All secrets will be masked.")
 		}
 		delete(providerMap, "secret")
 

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/export.go
@@ -21,7 +21,6 @@ package applicationNotificationTemplates
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -56,9 +55,9 @@ func ExportTemplateType(rt utils.ResourceType, typeId, displayName, typeDir stri
 		utils.RemoveDeletedLocalDirectories(appsDir, appsWithTemplates)
 		if len(appsWithTemplates) == 0 {
 			if err := os.Remove(appsDir); err != nil {
-				log.Println("Error removing application templates directory:", err)
+				utils.PrintLog(utils.LogLevelError, rt, displayName, fmt.Sprintf("Error removing application templates directory: %s", err))
 			} else {
-				log.Println("Removed the directory:", ApplicationTemplatesDir)
+				utils.PrintLog(utils.LogLevelInfo, rt, displayName, fmt.Sprintf("Removed the directory: %s", ApplicationTemplatesDir))
 			}
 		}
 	}

--- a/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/applicationNotificationTemplates/import.go
@@ -21,7 +21,6 @@ package applicationNotificationTemplates
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -206,7 +205,7 @@ func removeDeletedDeployedAppTemplates(rt utils.ResourceType, typeId, appId, app
 		if _, existsLocally := localLocales[template.Locale]; existsLocally {
 			continue
 		}
-		log.Printf("Application template for application %s not found locally. Deleting: %s", appName, template.Locale)
+		utils.PrintLog(utils.LogLevelInfo, rt, appName, fmt.Sprintf("Application template not found locally. Deleting: %s", template.Locale))
 		if err := utils.SendDeleteRequest(typeId+"/app-templates/"+appId+"/"+template.Locale, rt); err != nil {
 			return fmt.Errorf("error deleting template: %s. %w", template.Locale, err)
 		}

--- a/iamctl/pkg/notificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/export.go
@@ -33,18 +33,20 @@ func ExportAll(rt utils.ResourceType, exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, rt, "", fmt.Sprintf("Exporting %s...", getTemplateLogName(rt)))
 	exportFilePath = filepath.Join(exportFilePath, rt.String())
 
-	if !utils.IsEntitySupportedInVersion(rt) || !utils.IsEntitySupportedInOrg(rt) || utils.IsResourceTypeExcluded(rt) {
+	if utils.ShouldSkip(rt) {
 		return
 	}
 
 	types, err := getTemplateTypeList(rt)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error while retrieving the list: %s", err))
+		utils.MarkResTypeFailure(rt)
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error creating directory: %s", err))
+			utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error creating %s directory: %s", getTemplateLogName(rt), err))
+			utils.MarkResTypeFailure(rt)
 			return
 		}
 	}

--- a/iamctl/pkg/notificationTemplates/export.go
+++ b/iamctl/pkg/notificationTemplates/export.go
@@ -21,7 +21,6 @@ package notificationTemplates
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -31,8 +30,7 @@ import (
 
 func ExportAll(rt utils.ResourceType, exportFilePath string, format string) {
 
-	logName := getTemplateLogName(rt)
-	log.Printf("Exporting %s...", logName)
+	utils.PrintLog(utils.LogLevelInfo, rt, "", fmt.Sprintf("Exporting %s...", getTemplateLogName(rt)))
 	exportFilePath = filepath.Join(exportFilePath, rt.String())
 
 	if !utils.IsEntitySupportedInVersion(rt) || !utils.IsEntitySupportedInOrg(rt) || utils.IsResourceTypeExcluded(rt) {
@@ -41,12 +39,12 @@ func ExportAll(rt utils.ResourceType, exportFilePath string, format string) {
 
 	types, err := getTemplateTypeList(rt)
 	if err != nil {
-		log.Printf("Error while retrieving the %s list: %s", logName, err)
+		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error while retrieving the list: %s", err))
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Printf("Error creating %s directory: %s", logName, err)
+			utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error creating directory: %s", err))
 			return
 		}
 	}
@@ -57,17 +55,17 @@ func ExportAll(rt utils.ResourceType, exportFilePath string, format string) {
 		allTypeNames = append(allTypeNames, templateType.DisplayName)
 
 		if !utils.IsResourceExcluded(templateType.DisplayName, getTemplateResourceConfig(rt)) {
-			log.Printf("Exporting %s type: %s", logName, templateType.DisplayName)
+			utils.PrintLog(utils.LogLevelInfo, rt, templateType.DisplayName, "Exporting")
 			hadTemplates, err := exportTemplateType(rt, templateType.ID, templateType.DisplayName, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(rt, templateType.DisplayName)
-				log.Printf("Error while exporting %s type: %s. %s", logName, templateType.DisplayName, err)
+				utils.PrintLog(utils.LogLevelError, rt, templateType.DisplayName, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				if hadTemplates {
 					typesWithTemplates = append(typesWithTemplates, templateType.DisplayName)
 				}
 				utils.UpdateSuccessSummary(rt, utils.EXPORT)
-				log.Printf("%s type exported successfully: %s", logName, templateType.DisplayName)
+				utils.PrintLog(utils.LogLevelInfo, rt, templateType.DisplayName, "Exported successfully")
 			}
 		}
 	}
@@ -77,7 +75,7 @@ func ExportAll(rt utils.ResourceType, exportFilePath string, format string) {
 	}
 
 	if err := writeTemplateTypesList(exportFilePath, allTypeNames, rt, utils.FormatFromString(format)); err != nil {
-		log.Printf("Error writing %s type list: %s", logName, err)
+		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error writing type list: %s", err))
 		utils.UpdateFailureSummary(rt, "TemplateTypes")
 	}
 }
@@ -116,9 +114,9 @@ func exportTemplateType(rt utils.ResourceType, typeId, displayName, parentDir, f
 	} else if utils.TOOL_CONFIGS.AllowDelete {
 		if _, err := os.Stat(orgDir); err == nil {
 			if err := os.RemoveAll(orgDir); err != nil {
-				log.Println("Error removing organization templates directory:", err)
+				utils.PrintLog(utils.LogLevelError, rt, displayName, fmt.Sprintf("Error removing organization templates directory: %s", err))
 			} else {
-				log.Println("Removed the directory:", orgTemplatesDir)
+				utils.PrintLog(utils.LogLevelInfo, rt, displayName, fmt.Sprintf("Removed the directory: %s", orgTemplatesDir))
 			}
 		}
 	}

--- a/iamctl/pkg/notificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/import.go
@@ -21,7 +21,6 @@ package notificationTemplates
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -32,30 +31,30 @@ import (
 func ImportAll(rt utils.ResourceType, inputDirPath string) {
 
 	logName := getTemplateLogName(rt)
-	log.Printf("Importing %s...", logName)
+	utils.PrintLog(utils.LogLevelInfo, rt, "", fmt.Sprintf("Importing %s...", logName))
 	importFilePath := filepath.Join(inputDirPath, rt.String())
 
 	if !utils.IsEntitySupportedInVersion(rt) || !utils.IsEntitySupportedInOrg(rt) || utils.IsResourceTypeExcluded(rt) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Printf("No %s to import.", logName)
+		utils.PrintLog(utils.LogLevelInfo, rt, "", fmt.Sprintf("No %s to import.", logName))
 		return
 	}
 
 	deployedTypes, err := getTemplateTypeList(rt)
 	if err != nil {
-		log.Printf("Error while retrieving the %s list: %s", logName, err)
+		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error while retrieving the list: %s", err))
 		return
 	}
 	localTypeDirs, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Printf("Error reading %s directory: %s", logName, err)
+		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error reading directory: %s", err))
 		return
 	}
 	exportedTypeNames, err := readLocalTemplateTypeNames(importFilePath, rt)
 	if err != nil {
-		log.Printf("Error reading %s type list: %s", logName, err)
+		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error reading type list: %s", err))
 		utils.UpdateFailureSummary(rt, "TemplateTypes")
 		return
 	}
@@ -75,7 +74,7 @@ func ImportAll(rt utils.ResourceType, inputDirPath string) {
 			err := importTemplateType(rt, localTypePath, displayName, deployedTypes, logName)
 			if err != nil {
 				utils.UpdateFailureSummary(rt, displayName)
-				log.Printf("Error: when importing %s type: %s. %s", logName, displayName, err)
+				utils.PrintLog(utils.LogLevelError, rt, displayName, fmt.Sprintf("Error when importing: %s", err))
 			}
 		}
 	}
@@ -86,14 +85,14 @@ func importTemplateType(rt utils.ResourceType, localTypePath, displayName string
 	var typeId string
 	existingType := getTemplateTypeId(displayName, deployedTypes)
 	if existingType == "" {
-		log.Printf("Creating new %s type: %s", logName, displayName)
+		utils.PrintLog(utils.LogLevelInfo, rt, displayName, fmt.Sprintf("Creating new %s type", logName))
 		createdId, err := createTemplateType(rt, displayName)
 		if err != nil {
 			return fmt.Errorf("error creating template type: %w", err)
 		}
 		typeId = createdId
 	} else {
-		log.Printf("Updating %s type: %s", logName, displayName)
+		utils.PrintLog(utils.LogLevelInfo, rt, displayName, fmt.Sprintf("Updating %s type", logName))
 		typeId = existingType
 	}
 
@@ -140,10 +139,10 @@ func importTemplateType(rt utils.ResourceType, localTypePath, displayName string
 
 	if existingType != "" {
 		utils.UpdateSuccessSummary(rt, utils.UPDATE)
-		log.Printf("Template type updated successfully: %s", displayName)
+		utils.PrintLog(utils.LogLevelInfo, rt, displayName, "Updated successfully")
 	} else {
 		utils.UpdateSuccessSummary(rt, utils.IMPORT)
-		log.Printf("Template type imported successfully: %s", displayName)
+		utils.PrintLog(utils.LogLevelInfo, rt, displayName, "Imported successfully")
 	}
 
 	return nil
@@ -223,22 +222,22 @@ func removeDeletedDeployedTypes(rt utils.ResourceType, localDirs []os.FileInfo, 
 			continue
 		}
 		if utils.IsResourceExcluded(deployedType.DisplayName, getTemplateResourceConfig(rt)) {
-			log.Printf("%s type: %s is excluded from deletion.", logName, deployedType.DisplayName)
+			utils.PrintLog(utils.LogLevelInfo, rt, deployedType.DisplayName, fmt.Sprintf("%s type excluded from deletion.", logName))
 			continue
 		}
 
 		if _, isExported := exportedNames[deployedType.DisplayName]; isExported {
-			log.Printf("%s type not found locally. Resetting: %s", logName, deployedType.DisplayName)
+			utils.PrintLog(utils.LogLevelInfo, rt, deployedType.DisplayName, fmt.Sprintf("%s type not found locally. Resetting.", logName))
 			if err := resetTemplateType(rt, deployedType.ID); err != nil {
 				utils.UpdateFailureSummary(rt, deployedType.DisplayName)
-				log.Printf("Error resetting %s type: %s. %s", logName, deployedType.DisplayName, err)
+				utils.PrintLog(utils.LogLevelError, rt, deployedType.DisplayName, fmt.Sprintf("Error resetting %s type: %s", logName, err))
 				continue
 			}
 		} else {
-			log.Printf("%s type not found locally. Deleting: %s", logName, deployedType.DisplayName)
+			utils.PrintLog(utils.LogLevelInfo, rt, deployedType.DisplayName, fmt.Sprintf("%s type not found locally. Deleting.", logName))
 			if err := utils.SendDeleteRequest(deployedType.ID, rt); err != nil {
 				utils.UpdateFailureSummary(rt, deployedType.DisplayName)
-				log.Printf("Error deleting %s type: %s. %s", logName, deployedType.DisplayName, err)
+				utils.PrintLog(utils.LogLevelError, rt, deployedType.DisplayName, fmt.Sprintf("Error deleting %s type: %s", logName, err))
 				continue
 			}
 		}
@@ -262,7 +261,7 @@ func removeDeletedDeployedTemplates(rt utils.ResourceType, typeId string, localF
 		if _, existsLocally := localLocales[template.Locale]; existsLocally {
 			continue
 		}
-		log.Printf("Template not found locally. Deleting: %s", template.Locale)
+		utils.PrintLog(utils.LogLevelInfo, rt, template.Locale, "Template not found locally. Deleting.")
 		if err := utils.SendDeleteRequest(typeId+"/org-templates/"+template.Locale, rt); err != nil {
 			return fmt.Errorf("error deleting template: %s. %w", template.Locale, err)
 		}

--- a/iamctl/pkg/notificationTemplates/import.go
+++ b/iamctl/pkg/notificationTemplates/import.go
@@ -34,7 +34,7 @@ func ImportAll(rt utils.ResourceType, inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, rt, "", fmt.Sprintf("Importing %s...", logName))
 	importFilePath := filepath.Join(inputDirPath, rt.String())
 
-	if !utils.IsEntitySupportedInVersion(rt) || !utils.IsEntitySupportedInOrg(rt) || utils.IsResourceTypeExcluded(rt) {
+	if utils.ShouldSkip(rt) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -45,11 +45,13 @@ func ImportAll(rt utils.ResourceType, inputDirPath string) {
 	deployedTypes, err := getTemplateTypeList(rt)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error while retrieving the list: %s", err))
+		utils.MarkResTypeFailure(rt)
 		return
 	}
 	localTypeDirs, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error reading directory: %s", err))
+		utils.PrintLog(utils.LogLevelError, rt, "", fmt.Sprintf("Error reading %s directory: %s", logName, err))
+		utils.MarkResTypeFailure(rt)
 		return
 	}
 	exportedTypeNames, err := readLocalTemplateTypeNames(importFilePath, rt)

--- a/iamctl/pkg/oidcScopes/export.go
+++ b/iamctl/pkg/oidcScopes/export.go
@@ -32,12 +32,13 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, "", "Exporting OIDC scopes...")
 	exportFilePath = filepath.Join(exportFilePath, utils.OIDC_SCOPES.String())
 
-	if !utils.IsEntitySupportedInOrg(utils.OIDC_SCOPES) || utils.IsResourceTypeExcluded(utils.OIDC_SCOPES) {
+	if utils.ShouldSkip(utils.OIDC_SCOPES) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error creating OIDC scopes directory: %s", err))
+			utils.MarkResTypeFailure(utils.OIDC_SCOPES)
 			return
 		}
 	} else {
@@ -49,7 +50,8 @@ func ExportAll(exportFilePath string, format string) {
 
 	scopes, err := getOidcScopeList()
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error when exporting OIDC scopes: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error retrieving the deployed OIDC scopes list: %s", err))
+		utils.MarkResTypeFailure(utils.OIDC_SCOPES)
 	} else {
 		for _, scope := range scopes {
 			if !utils.IsResourceExcluded(scope.Name, utils.TOOL_CONFIGS.OidcScopeConfigs) {

--- a/iamctl/pkg/oidcScopes/export.go
+++ b/iamctl/pkg/oidcScopes/export.go
@@ -21,7 +21,6 @@ package oidcScopes
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting OIDC scopes...")
+	utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, "", "Exporting OIDC scopes...")
 	exportFilePath = filepath.Join(exportFilePath, utils.OIDC_SCOPES.String())
 
 	if !utils.IsEntitySupportedInOrg(utils.OIDC_SCOPES) || utils.IsResourceTypeExcluded(utils.OIDC_SCOPES) {
@@ -38,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating OIDC scopes directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error creating OIDC scopes directory: %s", err))
 			return
 		}
 	} else {
@@ -50,19 +49,19 @@ func ExportAll(exportFilePath string, format string) {
 
 	scopes, err := getOidcScopeList()
 	if err != nil {
-		log.Println("Error: when exporting OIDC scopes.", err)
+		utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error when exporting OIDC scopes: %s", err))
 	} else {
 		for _, scope := range scopes {
 			if !utils.IsResourceExcluded(scope.Name, utils.TOOL_CONFIGS.OidcScopeConfigs) {
-				log.Println("Exporting OIDC scope: ", scope.Name)
+				utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, scope.Name, "Exporting")
 
 				err := exportOidcScope(scope.Name, exportFilePath, format)
 				if err != nil {
 					utils.UpdateFailureSummary(utils.OIDC_SCOPES, scope.Name)
-					log.Printf("Error while exporting OIDC scope: %s. %s", scope.Name, err)
+					utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, scope.Name, fmt.Sprintf("Error while exporting: %s", err))
 				} else {
 					utils.UpdateSuccessSummary(utils.OIDC_SCOPES, utils.EXPORT)
-					log.Println("OIDC scope exported successfully: ", scope.Name)
+					utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, scope.Name, "Exported successfully")
 				}
 			}
 		}

--- a/iamctl/pkg/oidcScopes/import.go
+++ b/iamctl/pkg/oidcScopes/import.go
@@ -32,7 +32,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, "", "Importing OIDC scopes...")
 	importFilePath := filepath.Join(inputDirPath, utils.OIDC_SCOPES.String())
 
-	if !utils.IsEntitySupportedInOrg(utils.OIDC_SCOPES) || utils.IsResourceTypeExcluded(utils.OIDC_SCOPES) {
+	if utils.ShouldSkip(utils.OIDC_SCOPES) {
 		return
 	}
 	var files []os.FileInfo
@@ -44,12 +44,14 @@ func ImportAll(inputDirPath string) {
 	existingScopeList, err := getOidcScopeList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error retrieving the deployed OIDC scope list: %s", err))
+		utils.MarkResTypeFailure(utils.OIDC_SCOPES)
 		return
 	}
 
 	files, err = ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error importing OIDC scopes: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error reading OIDC scopes directory: %s", err))
+		utils.MarkResTypeFailure(utils.OIDC_SCOPES)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/oidcScopes/import.go
+++ b/iamctl/pkg/oidcScopes/import.go
@@ -21,7 +21,6 @@ package oidcScopes
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing OIDC scopes...")
+	utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, "", "Importing OIDC scopes...")
 	importFilePath := filepath.Join(inputDirPath, utils.OIDC_SCOPES.String())
 
 	if !utils.IsEntitySupportedInOrg(utils.OIDC_SCOPES) || utils.IsResourceTypeExcluded(utils.OIDC_SCOPES) {
@@ -38,19 +37,19 @@ func ImportAll(inputDirPath string) {
 	}
 	var files []os.FileInfo
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No OIDC scopes to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, "", "No OIDC scopes to import.")
 		return
 	}
 
 	existingScopeList, err := getOidcScopeList()
 	if err != nil {
-		log.Println("Error retrieving the deployed OIDC scope lists: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error retrieving the deployed OIDC scope list: %s", err))
 		return
 	}
 
 	files, err = ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing OIDC scopes: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, "", fmt.Sprintf("Error importing OIDC scopes: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -66,7 +65,7 @@ func ImportAll(inputDirPath string) {
 			scopeExists := isScopeExists(scopeName, existingScopeList)
 			err := importOidcScope(scopeName, scopeExists, scopeFilePath)
 			if err != nil {
-				log.Println("Error importing OIDC scope: ", err)
+				utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, scopeName, fmt.Sprintf("Error importing OIDC scope: %s", err))
 				utils.UpdateFailureSummary(utils.OIDC_SCOPES, scopeName)
 			}
 		}
@@ -96,7 +95,7 @@ func importOidcScope(scopeName string, scopeExists bool, importFilePath string) 
 
 func importScope(requestBody []byte, format utils.Format, scopeName string) error {
 
-	log.Println("Creating new OIDC scope: " + scopeName)
+	utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, scopeName, "Creating new OIDC scope")
 
 	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.OIDC_SCOPES)
 	if err != nil {
@@ -110,13 +109,13 @@ func importScope(requestBody []byte, format utils.Format, scopeName string) erro
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.OIDC_SCOPES, utils.IMPORT)
-	log.Println("OIDC scope imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, scopeName, "Imported successfully")
 	return nil
 }
 
 func updateScope(scopeId string, requestBody []byte, format utils.Format, scopeName string) error {
 
-	log.Println("Updating OIDC scope: " + scopeName)
+	utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, scopeName, "Updating OIDC scope")
 
 	updateBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.OIDC_SCOPES, "name")
 	if err != nil {
@@ -130,7 +129,7 @@ func updateScope(scopeId string, requestBody []byte, format utils.Format, scopeN
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.OIDC_SCOPES, utils.UPDATE)
-	log.Println("OIDC scope updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, scopeName, "Updated successfully")
 	return nil
 }
 
@@ -151,14 +150,14 @@ func removeDeletedDeployedScopes(localFiles []os.FileInfo, deployedScopes []oidc
 			continue
 		}
 		if utils.IsResourceExcluded(scope.Name, utils.TOOL_CONFIGS.OidcScopeConfigs) {
-			log.Println("OIDC scope is excluded from deletion:", scope.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, scope.Name, "Excluded from deletion.")
 			continue
 		}
 
-		log.Printf("OIDC scope: %s not found locally. Deleting scope.\n", scope.Name)
+		utils.PrintLog(utils.LogLevelInfo, utils.OIDC_SCOPES, scope.Name, "Not found locally. Deleting scope.")
 		if err := utils.SendDeleteRequest(scope.Name, utils.OIDC_SCOPES); err != nil {
 			utils.UpdateFailureSummary(utils.OIDC_SCOPES, scope.Name)
-			log.Println("Error deleting OIDC scope:", scope.Name, err)
+			utils.PrintLog(utils.LogLevelError, utils.OIDC_SCOPES, scope.Name, fmt.Sprintf("Error deleting OIDC scope: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.OIDC_SCOPES, utils.DELETE)
 		}

--- a/iamctl/pkg/organizations/export.go
+++ b/iamctl/pkg/organizations/export.go
@@ -32,18 +32,20 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, "", "Exporting organizations...")
 	exportFilePath = filepath.Join(exportFilePath, utils.ORGANIZATIONS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.ORGANIZATIONS) || !utils.IsEntitySupportedInOrg(utils.ORGANIZATIONS) || utils.IsResourceTypeExcluded(utils.ORGANIZATIONS) {
+	if utils.ShouldSkip(utils.ORGANIZATIONS) {
 		return
 	}
 	orgs, err := getOrganizationList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", fmt.Sprintf("Error retrieving organizations list: %s", err))
+		utils.MarkResTypeFailure(utils.ORGANIZATIONS)
 		return
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", fmt.Sprintf("Error creating organizations directory: %s", err))
+			utils.MarkResTypeFailure(utils.ORGANIZATIONS)
 			return
 		}
 	} else {

--- a/iamctl/pkg/organizations/export.go
+++ b/iamctl/pkg/organizations/export.go
@@ -21,7 +21,6 @@ package organizations
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting organizations...")
+	utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, "", "Exporting organizations...")
 	exportFilePath = filepath.Join(exportFilePath, utils.ORGANIZATIONS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.ORGANIZATIONS) || !utils.IsEntitySupportedInOrg(utils.ORGANIZATIONS) || utils.IsResourceTypeExcluded(utils.ORGANIZATIONS) {
@@ -38,13 +37,13 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	orgs, err := getOrganizationList()
 	if err != nil {
-		log.Println("Error retrieving organizations list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", fmt.Sprintf("Error retrieving organizations list: %s", err))
 		return
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating organizations directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", fmt.Sprintf("Error creating organizations directory: %s", err))
 			return
 		}
 	} else {
@@ -57,15 +56,15 @@ func ExportAll(exportFilePath string, format string) {
 	for _, org := range orgs {
 		resourceName := getOrgResourceName(org)
 		if !utils.IsResourceExcluded(resourceName, utils.TOOL_CONFIGS.OrganizationConfigs) {
-			log.Println("Exporting organization: ", resourceName)
+			utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, resourceName, "Exporting")
 
 			err := exportOrganization(org.Id, resourceName, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.ORGANIZATIONS, resourceName)
-				log.Printf("Error while exporting organization: %s. %s", resourceName, err)
+				utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, resourceName, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.EXPORT)
-				log.Println("Organization exported successfully: ", resourceName)
+				utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, resourceName, "Exported successfully")
 			}
 		}
 	}

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -33,7 +33,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, "", "Importing organizations...")
 	importFilePath := filepath.Join(inputDirPath, utils.ORGANIZATIONS.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.ORGANIZATIONS) || !utils.IsEntitySupportedInOrg(utils.ORGANIZATIONS) || utils.IsResourceTypeExcluded(utils.ORGANIZATIONS) {
+	if utils.ShouldSkip(utils.ORGANIZATIONS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -44,16 +44,19 @@ func ImportAll(inputDirPath string) {
 	existingList, err := getOrganizationList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", fmt.Sprintf("Error retrieving the deployed organization list: %s", err))
+		utils.MarkResTypeFailure(utils.ORGANIZATIONS)
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", fmt.Sprintf("Error reading local organization files: %s", err))
+		utils.MarkResTypeFailure(utils.ORGANIZATIONS)
 		return
 	}
 	curOrgId, err = GetCurrentOrganizationId()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", "Error while retrieving current organization ID")
+		utils.MarkResTypeFailure(utils.ORGANIZATIONS)
 		return
 	}
 

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -22,7 +22,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -31,30 +30,30 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing organizations...")
+	utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, "", "Importing organizations...")
 	importFilePath := filepath.Join(inputDirPath, utils.ORGANIZATIONS.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.ORGANIZATIONS) || !utils.IsEntitySupportedInOrg(utils.ORGANIZATIONS) || utils.IsResourceTypeExcluded(utils.ORGANIZATIONS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No organizations to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, "", "No organizations to import.")
 		return
 	}
 
 	existingList, err := getOrganizationList()
 	if err != nil {
-		log.Println("Error retrieving the deployed organization list: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", fmt.Sprintf("Error retrieving the deployed organization list: %s", err))
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error reading local organization files: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", fmt.Sprintf("Error reading local organization files: %s", err))
 		return
 	}
 	curOrgId, err = GetCurrentOrganizationId()
 	if err != nil {
-		log.Println("error while retrieving current organization ID")
+		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", "Error while retrieving current organization ID")
 		return
 	}
 
@@ -71,7 +70,7 @@ func ImportAll(inputDirPath string) {
 			orgId := getOrgId(resourceName, existingList)
 			err := importOrganization(resourceName, orgId, orgFilePath)
 			if err != nil {
-				log.Println("Error importing organization: ", err)
+				utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, resourceName, fmt.Sprintf("Error importing organization: %s", err))
 				utils.UpdateFailureSummary(utils.ORGANIZATIONS, resourceName)
 			}
 		}
@@ -101,7 +100,7 @@ func importOrganization(resourceName, orgId, importFilePath string) error {
 
 func createOrganization(requestBody []byte, format utils.Format, resourceName string) error {
 
-	log.Println("Creating new organization: " + resourceName)
+	utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, resourceName, "Creating new organization")
 
 	jsonBody, status, err := prepareOrganizationPostBody(requestBody, format, curOrgId)
 	if err != nil {
@@ -128,13 +127,13 @@ func createOrganization(requestBody []byte, format utils.Format, resourceName st
 	}
 
 	utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.IMPORT)
-	log.Println("Organization created successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, resourceName, "Created successfully")
 	return nil
 }
 
 func updateOrganization(orgId string, requestBody []byte, format utils.Format, resourceName string) error {
 
-	log.Println("Updating organization: " + resourceName)
+	utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, resourceName, "Updating organization")
 
 	updateBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.ORGANIZATIONS,
 		"id", "orgHandle", "type", "parent", "permissions", "created", "lastModified", "hasChildren", "ancestorPath")
@@ -149,7 +148,7 @@ func updateOrganization(orgId string, requestBody []byte, format utils.Format, r
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.UPDATE)
-	log.Println("Organization updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, resourceName, "Updated successfully")
 	return nil
 }
 
@@ -171,14 +170,14 @@ func removeDeletedDeployedOrganizations(localFiles []os.FileInfo, deployedOrgs [
 			continue
 		}
 		if utils.IsResourceExcluded(resourceName, utils.TOOL_CONFIGS.OrganizationConfigs) {
-			log.Println("Organization is excluded from deletion:", resourceName)
+			utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, resourceName, "Excluded from deletion")
 			continue
 		}
 
-		log.Printf("Organization: %s not found locally. Deleting organization.\n", resourceName)
+		utils.PrintLog(utils.LogLevelInfo, utils.ORGANIZATIONS, resourceName, "Not found locally. Deleting organization.")
 		if err := utils.SendDeleteRequest(org.Id, utils.ORGANIZATIONS); err != nil {
 			utils.UpdateFailureSummary(utils.ORGANIZATIONS, resourceName)
-			log.Println("Error deleting organization:", resourceName, err)
+			utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, resourceName, fmt.Sprintf("Error deleting organization: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.ORGANIZATIONS, utils.DELETE)
 		}

--- a/iamctl/pkg/roles/export.go
+++ b/iamctl/pkg/roles/export.go
@@ -21,7 +21,6 @@ package roles
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting roles...")
+	utils.PrintLog(utils.LogLevelInfo, utils.ROLES, "", "Exporting roles...")
 	exportFilePath = filepath.Join(exportFilePath, utils.ROLES.String())
 	setRolesV2ApiExists()
 
@@ -39,13 +38,13 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	roles, err := getRoleList()
 	if err != nil {
-		log.Println("Error: when exporting roles.", err)
+		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error when exporting roles: %s", err))
 		return
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating roles directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error creating roles directory: %s", err))
 			return
 		}
 	} else {
@@ -57,16 +56,16 @@ func ExportAll(exportFilePath string, format string) {
 
 	for _, r := range roles {
 		if !utils.IsResourceExcluded(r.DisplayName, utils.TOOL_CONFIGS.RoleConfigs) {
-			log.Println("Exporting role:", r.DisplayName)
+			utils.PrintLog(utils.LogLevelInfo, utils.ROLES, r.DisplayName, "Exporting")
 
 			err := exportRole(r, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.ROLES, r.DisplayName)
-				log.Printf("Error while exporting role: %s. %s", r.DisplayName, err)
+				utils.PrintLog(utils.LogLevelError, utils.ROLES, r.DisplayName, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				utils.AddToIdentifierMap(utils.ROLES, r.Id, r.DisplayName, utils.EXPORT)
 				utils.UpdateSuccessSummary(utils.ROLES, utils.EXPORT)
-				log.Println("Role exported successfully:", r.DisplayName)
+				utils.PrintLog(utils.LogLevelInfo, utils.ROLES, r.DisplayName, "Exported successfully")
 			}
 		}
 	}

--- a/iamctl/pkg/roles/export.go
+++ b/iamctl/pkg/roles/export.go
@@ -33,18 +33,20 @@ func ExportAll(exportFilePath string, format string) {
 	exportFilePath = filepath.Join(exportFilePath, utils.ROLES.String())
 	setRolesV2ApiExists()
 
-	if !utils.IsEntitySupportedInOrg(utils.ROLES) || utils.IsResourceTypeExcluded(utils.ROLES) {
+	if utils.ShouldSkip(utils.ROLES) {
 		return
 	}
 	roles, err := getRoleList()
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error when exporting roles: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error retrieving the deployed roles list: %s", err))
+		utils.MarkResTypeFailure(utils.ROLES)
 		return
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error creating roles directory: %s", err))
+			utils.MarkResTypeFailure(utils.ROLES)
 			return
 		}
 	} else {

--- a/iamctl/pkg/roles/import.go
+++ b/iamctl/pkg/roles/import.go
@@ -33,7 +33,7 @@ func ImportAll(inputDirPath string) {
 	importFilePath := filepath.Join(inputDirPath, utils.ROLES.String())
 	setRolesV2ApiExists()
 
-	if !utils.IsEntitySupportedInOrg(utils.ROLES) || utils.IsResourceTypeExcluded(utils.ROLES) {
+	if utils.ShouldSkip(utils.ROLES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -44,12 +44,14 @@ func ImportAll(inputDirPath string) {
 	existingRoleList, err := getRoleList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error retrieving the deployed role list: %s", err))
+		utils.MarkResTypeFailure(utils.ROLES)
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error importing roles: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error reading roles directory: %s", err))
+		utils.MarkResTypeFailure(utils.ROLES)
 		return
 	}
 

--- a/iamctl/pkg/roles/import.go
+++ b/iamctl/pkg/roles/import.go
@@ -21,7 +21,6 @@ package roles
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing roles...")
+	utils.PrintLog(utils.LogLevelInfo, utils.ROLES, "", "Importing roles...")
 	importFilePath := filepath.Join(inputDirPath, utils.ROLES.String())
 	setRolesV2ApiExists()
 
@@ -38,19 +37,19 @@ func ImportAll(inputDirPath string) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No roles to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.ROLES, "", "No roles to import.")
 		return
 	}
 
 	existingRoleList, err := getRoleList()
 	if err != nil {
-		log.Println("Error retrieving the deployed role list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error retrieving the deployed role list: %s", err))
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing roles:", err)
+		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error importing roles: %s", err))
 		return
 	}
 
@@ -67,7 +66,7 @@ func ImportAll(inputDirPath string) {
 			roleId := getRoleId(displayName, existingRoleList)
 			err := importRole(displayName, roleId, roleFilePath)
 			if err != nil {
-				log.Println("Error importing role:", err)
+				utils.PrintLog(utils.LogLevelError, utils.ROLES, displayName, fmt.Sprintf("Error importing role: %s", err))
 				utils.UpdateFailureSummary(utils.ROLES, displayName)
 			}
 		}
@@ -77,7 +76,7 @@ func ImportAll(inputDirPath string) {
 func importRole(displayName string, roleId string, importFilePath string) error {
 
 	if displayName == utils.ADMIN_ROLE || (utils.RolesV2ApiExists && (displayName == utils.ADMINISTRATOR_ROLE || displayName == utils.IMPERSONATOR_ROLE)) {
-		log.Printf("Role: %s is a system role. Skipping import.", displayName)
+		utils.PrintLog(utils.LogLevelInfo, utils.ROLES, displayName, "System role. Skipping import.")
 		if roleId != "" {
 			utils.AddToIdentifierMap(utils.ROLES, roleId, displayName, utils.IMPORT)
 		}
@@ -105,7 +104,7 @@ func importRole(displayName string, roleId string, importFilePath string) error 
 
 func createRole(requestBody []byte, format utils.Format, displayName string) error {
 
-	log.Println("Creating new role:", displayName)
+	utils.PrintLog(utils.LogLevelInfo, utils.ROLES, displayName, "Creating new role")
 
 	roleMap, err := utils.DeserializeToMap(requestBody, format, utils.ROLES, "id")
 	if err != nil {
@@ -138,13 +137,13 @@ func createRole(requestBody []byte, format utils.Format, displayName string) err
 	utils.AddToIdentifierMap(utils.ROLES, created.Id, created.DisplayName, utils.IMPORT)
 
 	utils.UpdateSuccessSummary(utils.ROLES, utils.IMPORT)
-	log.Println("Role created successfully:", displayName)
+	utils.PrintLog(utils.LogLevelInfo, utils.ROLES, displayName, "Created successfully")
 	return nil
 }
 
 func updateRole(roleId string, requestBody []byte, format utils.Format, displayName string) error {
 
-	log.Println("Updating role:", displayName)
+	utils.PrintLog(utils.LogLevelInfo, utils.ROLES, displayName, "Updating role")
 
 	patchBody, err := buildRolePermissionsPatchBody(requestBody, format)
 	if err != nil {
@@ -160,7 +159,7 @@ func updateRole(roleId string, requestBody []byte, format utils.Format, displayN
 	utils.AddToIdentifierMap(utils.ROLES, roleId, displayName, utils.IMPORT)
 
 	utils.UpdateSuccessSummary(utils.ROLES, utils.UPDATE)
-	log.Println("Role updated successfully:", displayName)
+	utils.PrintLog(utils.LogLevelInfo, utils.ROLES, displayName, "Updated successfully")
 	return nil
 }
 
@@ -182,18 +181,18 @@ func removeDeletedDeployedRoles(localFiles []os.FileInfo, deployedRoles []role) 
 			continue
 		}
 		if utils.IsResourceExcluded(r.DisplayName, utils.TOOL_CONFIGS.RoleConfigs) || r.DisplayName == utils.ADMIN_ROLE {
-			log.Println("Role is excluded from deletion:", r.DisplayName)
+			utils.PrintLog(utils.LogLevelInfo, utils.ROLES, r.DisplayName, "Excluded from deletion.")
 			continue
 		}
 		if utils.RolesV2ApiExists && (r.DisplayName == utils.ADMINISTRATOR_ROLE || r.DisplayName == utils.IMPERSONATOR_ROLE) {
-			log.Println("Role is excluded from deletion:", r.DisplayName)
+			utils.PrintLog(utils.LogLevelInfo, utils.ROLES, r.DisplayName, "Excluded from deletion.")
 			continue
 		}
 
-		log.Printf("Role: %s not found locally. Deleting role.\n", r.DisplayName)
+		utils.PrintLog(utils.LogLevelInfo, utils.ROLES, r.DisplayName, "Not found locally. Deleting role.")
 		if err := utils.SendDeleteRequest(r.Id, utils.ROLES); err != nil {
 			utils.UpdateFailureSummary(utils.ROLES, r.DisplayName)
-			log.Println("Error deleting role:", r.DisplayName, err)
+			utils.PrintLog(utils.LogLevelError, utils.ROLES, r.DisplayName, fmt.Sprintf("Error deleting role: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.ROLES, utils.DELETE)
 		}

--- a/iamctl/pkg/scriptLibraries/export.go
+++ b/iamctl/pkg/scriptLibraries/export.go
@@ -32,12 +32,13 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, "", "Exporting script libraries...")
 	exportFilePath = filepath.Join(exportFilePath, utils.SCRIPT_LIBRARIES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.SCRIPT_LIBRARIES) || !utils.IsEntitySupportedInOrg(utils.SCRIPT_LIBRARIES) || utils.IsResourceTypeExcluded(utils.SCRIPT_LIBRARIES) {
+	if utils.ShouldSkip(utils.SCRIPT_LIBRARIES) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error creating script libraries directory: %s", err))
+			utils.MarkResTypeFailure(utils.SCRIPT_LIBRARIES)
 			return
 		}
 	} else {
@@ -49,7 +50,8 @@ func ExportAll(exportFilePath string, format string) {
 
 	libraries, err := getScriptLibraryList()
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error when exporting script libraries: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error retrieving the deployed script libraries list: %s", err))
+		utils.MarkResTypeFailure(utils.SCRIPT_LIBRARIES)
 	} else {
 		for _, library := range libraries {
 			if !utils.IsResourceExcluded(library.Name, utils.TOOL_CONFIGS.ScriptLibraryConfigs) {

--- a/iamctl/pkg/scriptLibraries/export.go
+++ b/iamctl/pkg/scriptLibraries/export.go
@@ -21,7 +21,6 @@ package scriptLibraries
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting script libraries...")
+	utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, "", "Exporting script libraries...")
 	exportFilePath = filepath.Join(exportFilePath, utils.SCRIPT_LIBRARIES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.SCRIPT_LIBRARIES) || !utils.IsEntitySupportedInOrg(utils.SCRIPT_LIBRARIES) || utils.IsResourceTypeExcluded(utils.SCRIPT_LIBRARIES) {
@@ -38,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating script libraries directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error creating script libraries directory: %s", err))
 			return
 		}
 	} else {
@@ -50,19 +49,19 @@ func ExportAll(exportFilePath string, format string) {
 
 	libraries, err := getScriptLibraryList()
 	if err != nil {
-		log.Println("Error: when exporting script libraries.", err)
+		utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error when exporting script libraries: %s", err))
 	} else {
 		for _, library := range libraries {
 			if !utils.IsResourceExcluded(library.Name, utils.TOOL_CONFIGS.ScriptLibraryConfigs) {
-				log.Println("Exporting script library: ", library.Name)
+				utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, library.Name, "Exporting")
 
 				err := exportScriptLibrary(library.Name, exportFilePath, format)
 				if err != nil {
 					utils.UpdateFailureSummary(utils.SCRIPT_LIBRARIES, library.Name)
-					log.Printf("Error while exporting script library: %s. %s", library.Name, err)
+					utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, library.Name, fmt.Sprintf("Error while exporting: %s", err))
 				} else {
 					utils.UpdateSuccessSummary(utils.SCRIPT_LIBRARIES, utils.EXPORT)
-					log.Println("Script library exported successfully: ", library.Name)
+					utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, library.Name, "Exported successfully")
 				}
 			}
 		}

--- a/iamctl/pkg/scriptLibraries/import.go
+++ b/iamctl/pkg/scriptLibraries/import.go
@@ -32,7 +32,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, "", "Importing script libraries...")
 	importFilePath := filepath.Join(inputDirPath, utils.SCRIPT_LIBRARIES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.SCRIPT_LIBRARIES) || !utils.IsEntitySupportedInOrg(utils.SCRIPT_LIBRARIES) || utils.IsResourceTypeExcluded(utils.SCRIPT_LIBRARIES) {
+	if utils.ShouldSkip(utils.SCRIPT_LIBRARIES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -43,12 +43,14 @@ func ImportAll(inputDirPath string) {
 	existingList, err := getScriptLibraryList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error retrieving the deployed script library list: %s", err))
+		utils.MarkResTypeFailure(utils.SCRIPT_LIBRARIES)
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error importing script libraries: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error reading script libraries directory: %s", err))
+		utils.MarkResTypeFailure(utils.SCRIPT_LIBRARIES)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/scriptLibraries/import.go
+++ b/iamctl/pkg/scriptLibraries/import.go
@@ -21,7 +21,6 @@ package scriptLibraries
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,26 +29,26 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing script libraries...")
+	utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, "", "Importing script libraries...")
 	importFilePath := filepath.Join(inputDirPath, utils.SCRIPT_LIBRARIES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.SCRIPT_LIBRARIES) || !utils.IsEntitySupportedInOrg(utils.SCRIPT_LIBRARIES) || utils.IsResourceTypeExcluded(utils.SCRIPT_LIBRARIES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No script libraries to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, "", "No script libraries to import.")
 		return
 	}
 
 	existingList, err := getScriptLibraryList()
 	if err != nil {
-		log.Println("Error retrieving the deployed script library list: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error retrieving the deployed script library list: %s", err))
 		return
 	}
 
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing script libraries: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, "", fmt.Sprintf("Error importing script libraries: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -65,7 +64,7 @@ func ImportAll(inputDirPath string) {
 			libraryExists := isScriptLibraryExists(libraryName, existingList)
 			err := importScriptLibrary(libraryName, libraryExists, libraryFilePath)
 			if err != nil {
-				log.Println("Error importing script library: ", err)
+				utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, libraryName, fmt.Sprintf("Error importing script library: %s", err))
 				utils.UpdateFailureSummary(utils.SCRIPT_LIBRARIES, libraryName)
 			}
 		}
@@ -95,7 +94,7 @@ func importScriptLibrary(libraryName string, libraryExists bool, importFilePath 
 
 func createScriptLibrary(name string, data []byte, format utils.Format) error {
 
-	log.Println("Creating new script library: " + name)
+	utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, name, "Creating new script library")
 
 	body, contentType, err := utils.PrepareMultipartFormBody(data, format, utils.SCRIPT_LIBRARIES)
 	if err != nil {
@@ -109,13 +108,13 @@ func createScriptLibrary(name string, data []byte, format utils.Format) error {
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.SCRIPT_LIBRARIES, utils.IMPORT)
-	log.Println("Script library created successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, name, "Created successfully")
 	return nil
 }
 
 func updateScriptLibrary(name string, data []byte, format utils.Format) error {
 
-	log.Println("Updating script library: " + name)
+	utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, name, "Updating script library")
 
 	body, contentType, err := utils.PrepareMultipartFormBody(data, format, utils.SCRIPT_LIBRARIES, "name")
 	if err != nil {
@@ -129,7 +128,7 @@ func updateScriptLibrary(name string, data []byte, format utils.Format) error {
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.SCRIPT_LIBRARIES, utils.UPDATE)
-	log.Println("Script library updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, name, "Updated successfully")
 	return nil
 }
 
@@ -150,14 +149,14 @@ func removeDeletedDeployedScriptLibraries(localFiles []os.FileInfo, deployedLibr
 			continue
 		}
 		if utils.IsResourceExcluded(library.Name, utils.TOOL_CONFIGS.ScriptLibraryConfigs) {
-			log.Println("Script library is excluded from deletion:", library.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, library.Name, "Excluded from deletion.")
 			continue
 		}
 
-		log.Printf("Script library: %s not found locally. Deleting library.\n", library.Name)
+		utils.PrintLog(utils.LogLevelInfo, utils.SCRIPT_LIBRARIES, library.Name, "Not found locally. Deleting library.")
 		if err := utils.SendDeleteRequest(library.Name, utils.SCRIPT_LIBRARIES); err != nil {
 			utils.UpdateFailureSummary(utils.SCRIPT_LIBRARIES, library.Name)
-			log.Println("Error deleting script library:", library.Name, err)
+			utils.PrintLog(utils.LogLevelError, utils.SCRIPT_LIBRARIES, library.Name, fmt.Sprintf("Error deleting script library: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.SCRIPT_LIBRARIES, utils.DELETE)
 		}

--- a/iamctl/pkg/userStores/export.go
+++ b/iamctl/pkg/userStores/export.go
@@ -41,6 +41,7 @@ func ExportAll(exportFilePath string, format string) {
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error creating user stores directory: %s", err))
+			utils.MarkResTypeFailure(utils.USERSTORES)
 			return
 		}
 	} else {
@@ -52,7 +53,8 @@ func ExportAll(exportFilePath string, format string) {
 	exportAPIExists := utils.ExportAPIExists(utils.USERSTORES)
 	userstores, err := getUserStoreList()
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error when exporting user stores: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error retrieving the deployed user stores list: %s", err))
+		utils.MarkResTypeFailure(utils.USERSTORES)
 	} else {
 		if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.UserStoreConfigs) {
 			utils.PrintLog(utils.LogLevelWarn, utils.USERSTORES, "", "Secrets exclusion cannot be disabled for user stores. All secrets will be masked.")

--- a/iamctl/pkg/userStores/export.go
+++ b/iamctl/pkg/userStores/export.go
@@ -21,7 +21,6 @@ package userstores
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"mime"
 	"os"
 	"path/filepath"
@@ -33,7 +32,7 @@ import (
 func ExportAll(exportFilePath string, format string) {
 
 	// Export all userstores to the UserStores folder.
-	log.Println("Exporting user stores...")
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, "", "Exporting user stores...")
 	exportFilePath = filepath.Join(exportFilePath, utils.USERSTORES.String())
 
 	if utils.IsResourceTypeExcluded(utils.USERSTORES) {
@@ -41,7 +40,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating user stores directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error creating user stores directory: %s", err))
 			return
 		}
 	} else {
@@ -53,14 +52,14 @@ func ExportAll(exportFilePath string, format string) {
 	exportAPIExists := utils.ExportAPIExists(utils.USERSTORES)
 	userstores, err := getUserStoreList()
 	if err != nil {
-		log.Println("Error: when exporting user stores.", err)
+		utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error when exporting user stores: %s", err))
 	} else {
 		if !utils.AreSecretsExcluded(utils.TOOL_CONFIGS.UserStoreConfigs) {
-			log.Println("Warn: Secrets exclusion cannot be disabled for user stores. All secrets will be masked.")
+			utils.PrintLog(utils.LogLevelWarn, utils.USERSTORES, "", "Secrets exclusion cannot be disabled for user stores. All secrets will be masked.")
 		}
 		for _, userstore := range userstores {
 			if !utils.IsResourceExcluded(userstore.Name, utils.TOOL_CONFIGS.UserStoreConfigs) {
-				log.Println("Exporting user store: ", userstore.Name)
+				utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userstore.Name, "Exporting")
 
 				if exportAPIExists {
 					err = exportUserStore(userstore.Id, exportFilePath, format)
@@ -70,16 +69,16 @@ func ExportAll(exportFilePath string, format string) {
 
 				if err != nil {
 					utils.UpdateFailureSummary(utils.USERSTORES, userstore.Name)
-					log.Printf("Error while exporting user store: %s. %s", userstore.Name, err)
+					utils.PrintLog(utils.LogLevelError, utils.USERSTORES, userstore.Name, fmt.Sprintf("Error while exporting: %s", err))
 				} else {
 					utils.UpdateSuccessSummary(utils.USERSTORES, utils.EXPORT)
-					log.Println("User store exported successfully: ", userstore.Name)
+					utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userstore.Name, "Exported successfully")
 				}
 			}
 		}
 	}
 	if (utils.IsResourceTypeExcluded(utils.CLAIMS) || utils.IsResourceExcluded(utils.LOCAL_CLAIM_DIALECT_URI, utils.TOOL_CONFIGS.ClaimConfigs)) && exportAPIExists {
-		log.Println("Warn: Local claim dialect is excluded from export. Export local claims to persist claim attribute mappings of user stores.")
+		utils.PrintLog(utils.LogLevelWarn, utils.USERSTORES, "", "Local claim dialect is excluded from export. Export local claims to persist claim attribute mappings of user stores.")
 	}
 }
 

--- a/iamctl/pkg/userStores/import.go
+++ b/iamctl/pkg/userStores/import.go
@@ -41,7 +41,8 @@ func ImportAll(inputDirPath string) {
 	} else {
 		files, err = ioutil.ReadDir(importFilePath)
 		if err != nil {
-			utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error importing user stores: %s", err))
+			utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error reading user stores directory: %s", err))
+			utils.MarkResTypeFailure(utils.USERSTORES)
 			return
 		}
 		if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/userStores/import.go
+++ b/iamctl/pkg/userStores/import.go
@@ -21,7 +21,6 @@ package userstores
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing user stores...")
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, "", "Importing user stores...")
 	importFilePath := filepath.Join(inputDirPath, utils.USERSTORES.String())
 
 	if utils.IsResourceTypeExcluded(utils.USERSTORES) {
@@ -38,11 +37,11 @@ func ImportAll(inputDirPath string) {
 	}
 	var files []os.FileInfo
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No user stores to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, "", "No user stores to import.")
 	} else {
 		files, err = ioutil.ReadDir(importFilePath)
 		if err != nil {
-			log.Println("Error importing user stores: ", err)
+			utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error importing user stores: %s", err))
 			return
 		}
 		if utils.TOOL_CONFIGS.AllowDelete {
@@ -59,17 +58,17 @@ func ImportAll(inputDirPath string) {
 		if !utils.IsResourceExcluded(userStoreName, utils.TOOL_CONFIGS.UserStoreConfigs) {
 			userStoreId, err := getUserStoreId(userStoreName)
 			if err != nil {
-				log.Printf("Invalid file configurations for user store: %s. %s", userStoreName, err)
+				utils.PrintLog(utils.LogLevelError, utils.USERSTORES, userStoreName, fmt.Sprintf("Invalid file configurations: %s", err))
 			} else {
 				err := importUserStore(userStoreId, userStoreName, userStoreFilePath, exportAPIexists)
 				if err != nil {
-					log.Println("Error importing user store: ", err)
+					utils.PrintLog(utils.LogLevelError, utils.USERSTORES, userStoreName, fmt.Sprintf("Error importing user store: %s", err))
 				}
 			}
 		}
 	}
 	if (utils.IsResourceTypeExcluded(utils.CLAIMS) || utils.IsResourceExcluded(utils.LOCAL_CLAIM_DIALECT_URI, utils.TOOL_CONFIGS.ClaimConfigs)) && exportAPIexists {
-		log.Println("Warn: Local claim dialect is excluded from import. Import local claims to persist claim attribute mappings of user stores.")
+		utils.PrintLog(utils.LogLevelWarn, utils.USERSTORES, "", "Local claim dialect is excluded from import. Import local claims to persist claim attribute mappings of user stores.")
 	}
 }
 
@@ -77,7 +76,7 @@ func importUserStore(userStoreId, userStoreName, userStoreFilePath string, expor
 
 	// AGENT and DEFAULT user stores are not allowed to be modified in Asgardeo
 	if utils.SERVER_CONFIGS.ServerVersion == "" && (userStoreName == utils.AGENT_USERSTORE || userStoreName == utils.DEFAULT_USERSTORE) {
-		log.Printf("User store: %s is a system user store. Skipping import.", userStoreName)
+		utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "System user store. Skipping import.")
 		return nil
 	}
 	fileBytes, err := ioutil.ReadFile(userStoreFilePath)
@@ -110,7 +109,7 @@ func importUserStore(userStoreId, userStoreName, userStoreFilePath string, expor
 
 func importUserStoreOperation(userStoreName, userStoreFilePath, modifiedFileData string) error {
 
-	log.Println("Creating new user store: " + userStoreName)
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "Creating new user store")
 	resp, err := utils.SendImportRequest(userStoreFilePath, modifiedFileData, utils.USERSTORES)
 	if err != nil {
 		utils.UpdateFailureSummary(utils.USERSTORES, userStoreName)
@@ -118,26 +117,26 @@ func importUserStoreOperation(userStoreName, userStoreFilePath, modifiedFileData
 	}
 	defer resp.Body.Close()
 	utils.UpdateSuccessSummary(utils.USERSTORES, utils.IMPORT)
-	log.Println("User store imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "Imported successfully")
 	return nil
 }
 
 func updateUserStoreOperation(userStoreId, userStoreName, userStoreFilePath, modifiedFileData string) error {
 
-	log.Println("Updating user store: " + userStoreName)
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "Updating user store")
 	err := utils.SendUpdateRequest(userStoreId, userStoreFilePath, modifiedFileData, utils.USERSTORES)
 	if err != nil {
 		utils.UpdateFailureSummary(utils.USERSTORES, userStoreName)
 		return fmt.Errorf("error when updating user store: %s", err)
 	}
 	utils.UpdateSuccessSummary(utils.USERSTORES, utils.UPDATE)
-	log.Println("User store updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "Updated successfully")
 	return nil
 }
 
 func importUserStoreWithCRUD(userStoreName string, requestBody []byte, format utils.Format) error {
 
-	log.Println("Creating new user store: " + userStoreName)
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "Creating new user store")
 
 	jsonBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.USERSTORES, "typeName", "className")
 	if err != nil {
@@ -150,13 +149,13 @@ func importUserStoreWithCRUD(userStoreName string, requestBody []byte, format ut
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.USERSTORES, utils.IMPORT)
-	log.Println("User store imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "Imported successfully")
 	return nil
 }
 
 func updateUserStoreWithCRUD(userStoreId, userStoreName string, requestBody []byte, format utils.Format) error {
 
-	log.Println("Updating user store: " + userStoreName)
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "Updating user store")
 
 	updateBody, err := utils.PrepareJSONRequestBody(requestBody, format, utils.USERSTORES, "typeName", "className")
 	if err != nil {
@@ -169,7 +168,7 @@ func updateUserStoreWithCRUD(userStoreId, userStoreName string, requestBody []by
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.USERSTORES, utils.UPDATE)
-	log.Println("User store updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userStoreName, "Updated successfully")
 	return nil
 }
 
@@ -178,7 +177,7 @@ func removeDeletedDeployedUserstores(localFiles []os.FileInfo) {
 	// Remove deployed user stores that do not exist locally.
 	deployedUserstores, err := getUserStoreList()
 	if err != nil {
-		log.Println("Error retrieving deployed user stores: ", err)
+		utils.PrintLog(utils.LogLevelError, utils.USERSTORES, "", fmt.Sprintf("Error retrieving deployed user stores: %s", err))
 		return
 	}
 deployedResourcess:
@@ -190,18 +189,18 @@ deployedResourcess:
 		}
 		// DEFAULT is a Asgardeo only system user store
 		if (utils.SERVER_CONFIGS.ServerVersion == "" && userstore.Name == utils.DEFAULT_USERSTORE) || userstore.Name == utils.AGENT_USERSTORE {
-			log.Printf("User store: %s is a system user store. Skipping deletion.", userstore.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userstore.Name, "System user store. Skipping deletion.")
 			continue
 		}
 		if utils.IsResourceExcluded(userstore.Name, utils.TOOL_CONFIGS.UserStoreConfigs) {
-			log.Printf("Userstore: %s is excluded from deletion.\n", userstore.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userstore.Name, "Excluded from deletion.")
 			continue
 		}
-		log.Println("User store not found locally. Deleting user store: ", userstore.Name)
+		utils.PrintLog(utils.LogLevelInfo, utils.USERSTORES, userstore.Name, "Not found locally. Deleting user store.")
 		err := utils.SendDeleteRequest(userstore.Id, utils.USERSTORES)
 		if err != nil {
 			utils.UpdateFailureSummary(utils.USERSTORES, userstore.Name)
-			log.Println("Error deleting user store: ", err)
+			utils.PrintLog(utils.LogLevelError, utils.USERSTORES, userstore.Name, fmt.Sprintf("Error deleting user store: %s", err))
 		}
 		utils.UpdateSuccessSummary(utils.USERSTORES, utils.DELETE)
 	}

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -158,7 +158,12 @@ func SendExportRequest(resourceId, fileType string, resourceType ResourceType, e
 	statusCode := resp.StatusCode
 	if statusCode == 200 {
 		return resp, nil
-	} else if error, ok := ErrorCodes[statusCode]; ok {
+	}
+
+	PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", req.Method, req.URL.String()))
+	debugBody, _ := ioutil.ReadAll(resp.Body)
+	PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", statusCode, string(debugBody)))
+	if error, ok := ErrorCodes[statusCode]; ok {
 		return resp, fmt.Errorf("error while exporting resource: %s", error)
 	}
 	return resp, fmt.Errorf("unexpected error while exporting the resource with status code: %s", strconv.FormatInt(int64(statusCode), 10))
@@ -199,7 +204,13 @@ func SendImportRequest(importFilePath, fileData string, resourceType ResourceTyp
 		return nil, fmt.Errorf("error when creating the import request: %s", err)
 	}
 
-	request, err := http.NewRequest("POST", reqUrl, body)
+	var capturedImportBody bytes.Buffer
+	var importBodyReader io.Reader = body
+	if TOOL_CONFIGS.Logs.LogRequestPayloads {
+		importBodyReader = io.TeeReader(body, &capturedImportBody)
+	}
+
+	request, err := http.NewRequest("POST", reqUrl, importBodyReader)
 	if err != nil {
 		return nil, fmt.Errorf("error when creating the import request: %s", err)
 	}
@@ -222,11 +233,17 @@ func SendImportRequest(importFilePath, fileData string, resourceType ResourceTyp
 	statusCode := resp.StatusCode
 	if statusCode == 201 {
 		return resp, nil
-	} else if error, ok := ErrorCodes[statusCode]; ok {
-		resp.Body.Close()
+	}
+	debugBody, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", request.Method, request.URL.String()))
+	if TOOL_CONFIGS.Logs.LogRequestPayloads {
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Request body: %s", capturedImportBody.String()))
+	}
+	PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", statusCode, string(debugBody)))
+	if error, ok := ErrorCodes[statusCode]; ok {
 		return nil, fmt.Errorf("error response for the import request: %s", error)
 	}
-	resp.Body.Close()
 	return nil, fmt.Errorf("unexpected error when importing resource: %s", resp.Status)
 }
 
@@ -266,7 +283,13 @@ func SendUpdateRequest(resourceId, importFilePath, fileData string, resourceType
 		return fmt.Errorf("error when creating the import request: %s", err)
 	}
 
-	request, err := http.NewRequest("PUT", formattedReqUrl, body)
+	var capturedUpdateBody bytes.Buffer
+	var updateBodyReader io.Reader = body
+	if TOOL_CONFIGS.Logs.LogRequestPayloads {
+		updateBodyReader = io.TeeReader(body, &capturedUpdateBody)
+	}
+
+	request, err := http.NewRequest("PUT", formattedReqUrl, updateBodyReader)
 	if err != nil {
 		return fmt.Errorf("error when creating the import request: %s", err)
 	}
@@ -292,7 +315,15 @@ func SendUpdateRequest(resourceId, importFilePath, fileData string, resourceType
 		return nil
 	} else if statusCode == 400 && resourceType == CLAIMS {
 		return handleClaimImportErrorResponse(resp)
-	} else if error, ok := ErrorCodes[statusCode]; ok {
+	}
+	debugBody, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", request.Method, request.URL.String()))
+	if TOOL_CONFIGS.Logs.LogRequestPayloads {
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Request body: %s", capturedUpdateBody.String()))
+	}
+	PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", statusCode, string(debugBody)))
+	if error, ok := ErrorCodes[statusCode]; ok {
 		return fmt.Errorf("error response for the import request: %s", error)
 	}
 	return fmt.Errorf("unexpected error when importing resource: %s", resp.Status)
@@ -330,7 +361,12 @@ func SendDeleteRequest(resourceId string, resourceType ResourceType, opts ...Sen
 	statusCode := resp.StatusCode
 	if statusCode == 204 {
 		return nil
-	} else if error, ok := ErrorCodes[statusCode]; ok {
+	}
+	debugBody, _ := ioutil.ReadAll(resp.Body)
+	resp.Body.Close()
+	PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", request.Method, request.URL.String()))
+	PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", statusCode, string(debugBody)))
+	if error, ok := ErrorCodes[statusCode]; ok {
 		return fmt.Errorf("error response for the delete request: %s", error)
 	}
 	return fmt.Errorf("unexpected error when deleting resource: %s", resp.Status)
@@ -406,6 +442,11 @@ func SendGetRequest(resourceType ResourceType, resourceId string, opts ...SendOp
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		if !(request.Method == "GET" && resp.StatusCode == 404) {
+			debugBody, _ := ioutil.ReadAll(resp.Body)
+			PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", request.Method, request.URL.String()))
+			PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", resp.StatusCode, string(debugBody)))
+		}
 		if errMsg, ok := ErrorCodes[resp.StatusCode]; ok {
 			return nil, fmt.Errorf("error response for the GET request: %s", errMsg)
 		}
@@ -447,7 +488,13 @@ func SendPostRequest(resourceType ResourceType, requestBody []byte, opts ...Send
 	}
 
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
+		debugBody, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", request.Method, request.URL.String()))
+		if TOOL_CONFIGS.Logs.LogRequestPayloads {
+			PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Request body: %s", string(requestBody)))
+		}
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", resp.StatusCode, string(debugBody)))
 		if errMsg, ok := ErrorCodes[resp.StatusCode]; ok {
 			return nil, fmt.Errorf("error response for the POST request: %s", errMsg)
 		}
@@ -484,7 +531,13 @@ func SendPutRequest(resourceType ResourceType, resourceId string, requestBody []
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNoContent {
+		debugBody, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", request.Method, request.URL.String()))
+		if TOOL_CONFIGS.Logs.LogRequestPayloads {
+			PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Request body: %s", string(requestBody)))
+		}
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", resp.StatusCode, string(debugBody)))
 		if errMsg, ok := ErrorCodes[resp.StatusCode]; ok {
 			return nil, fmt.Errorf("error response for the PUT request: %s", errMsg)
 		}
@@ -519,7 +572,13 @@ func SendPatchRequest(resourceType ResourceType, resourceId string, requestBody 
 	}
 
 	if resp.StatusCode != http.StatusOK {
+		debugBody, _ := ioutil.ReadAll(resp.Body)
 		resp.Body.Close()
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", request.Method, request.URL.String()))
+		if TOOL_CONFIGS.Logs.LogRequestPayloads {
+			PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Request body: %s", string(requestBody)))
+		}
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", resp.StatusCode, string(debugBody)))
 		if errMsg, ok := ErrorCodes[resp.StatusCode]; ok {
 			return nil, fmt.Errorf("error response for the PATCH request: %s", errMsg)
 		}
@@ -562,6 +621,9 @@ func SendGetListRequest(resourceType ResourceType, opts ...SendOption) ([]byte, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		debugBody, _ := ioutil.ReadAll(resp.Body)
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", req.Method, req.URL.String()))
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", resp.StatusCode, string(debugBody)))
 		if errMsg, ok := ErrorCodes[resp.StatusCode]; ok {
 			return nil, fmt.Errorf("error response for the GET list request. Error: %s", errMsg)
 		}
@@ -676,6 +738,17 @@ func SendCustomRequest(method, reqURL string, body []byte, contentType string) (
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error sending %s request: %w", method, err)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		debugBody, _ := ioutil.ReadAll(resp.Body)
+		resp.Body.Close()
+		resp.Body = ioutil.NopCloser(bytes.NewReader(debugBody))
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("%s %s", req.Method, req.URL.String()))
+		if TOOL_CONFIGS.Logs.LogRequestPayloads {
+			PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Request body: %s", string(body)))
+		}
+		PrintLog(LogLevelDebug, NoResource, "", fmt.Sprintf("Response [%d]: %s", resp.StatusCode, string(debugBody)))
 	}
 	return resp, nil
 }

--- a/iamctl/pkg/utils/apiUtils.go
+++ b/iamctl/pkg/utils/apiUtils.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"mime"
 	"mime/multipart"
 	"net/http"
@@ -797,7 +796,7 @@ func addQueryParams(reqURL string, resourceType ResourceType, operation string) 
 
 	url, err := url.Parse(reqURL)
 	if err != nil {
-		log.Printf("Failed to parse URL: %s. Unable to add query parameters.", err)
+		PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Failed to parse URL: %s. Unable to add query parameters.", err))
 		return reqURL
 	}
 

--- a/iamctl/pkg/utils/constants.go
+++ b/iamctl/pkg/utils/constants.go
@@ -140,6 +140,19 @@ const USER_ONBOARDING_GOVERNANCE_CATEGORY_ID = "VXNlciBPbmJvYXJkaW5n"
 const OAUTH2 = "oauth2"
 const ALL_ITEMS = "all_items" // Wildcard to match all elements in an array
 
+// Log levels
+type LogLevel int
+
+const (
+	LogLevelDebug LogLevel = iota // 0 — most verbose
+	LogLevelInfo                  // 1 — default
+	LogLevelWarn                  // 2
+	LogLevelError                 // 3 — least verbose
+)
+
+// NoResource is used with PrintLog when there is no resource type context.
+const NoResource ResourceType = ""
+
 // Resource types that are supported in sub-organizations
 var entitySupportedInSubOrg = map[ResourceType]bool{
 	APPLICATIONS:       true,

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -81,7 +81,7 @@ func ProcessExportedContent(exportedFileName string, exportedFileContent []byte,
 	// Process exported content
 	modifiedData, err := ProcessExportedData(exportedData, exportedFileName, format, keywordMapping, resourceType)
 	if err != nil {
-		PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error when processing with keywords. Using original exported content. %s", err))
+		PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error when processing with keywords. Using exported content. %s", err))
 		modifiedData = exportedData
 	}
 
@@ -263,8 +263,6 @@ func ModifyFieldsWithKeywords(exportedFileData interface{}, localFileData interf
 				PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Keyword added at %s field", location))
 			} else {
 				PrintLog(LogLevelWarn, NoResource, "", fmt.Sprintf("Keywords at %s field in the local file will be replaced by exported content.", location))
-				PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Local Value with Keyword Replaced: %s", localReplacedValue))
-				PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Exported Value: %s", exportedValue))
 			}
 		} else {
 			ReplaceValue(exportedFileData, location, localValue)

--- a/iamctl/pkg/utils/keywordUtils.go
+++ b/iamctl/pkg/utils/keywordUtils.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -38,7 +37,7 @@ func ReplaceKeywords(fileContent string, keywordMapping map[string]interface{}) 
 		if value, ok := value.(string); ok {
 			fileContent = strings.ReplaceAll(fileContent, "{{"+keyword+"}}", value)
 		} else {
-			log.Printf("Error: keyword value for %s is not a string", keyword)
+			PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("keyword value for %s is not a string", keyword))
 		}
 	}
 	return fileContent
@@ -48,14 +47,14 @@ func ProcessExportedData(exportedData interface{}, localFilePath string, format 
 
 	localFileContent, err := ioutil.ReadFile(localFilePath)
 	if err != nil {
-		log.Printf("Local file not found at %s. Creating new file.", localFilePath)
+		PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Local file not found at %s. Creating new file.", localFilePath))
 		return exportedData, nil
 	}
 
 	// Replace ESVs in the exported file according to the keyword placeholders added in the local file.
 	modifiedData, err := AddLocalKeywords(exportedData, format, localFileContent, keywordMapping, resourceType)
 	if err != nil {
-		log.Println("Error processing keywords. Using exported content.", err)
+		PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error processing keywords. Using exported content. %s", err))
 		return exportedData, nil
 	}
 
@@ -82,7 +81,7 @@ func ProcessExportedContent(exportedFileName string, exportedFileContent []byte,
 	// Process exported content
 	modifiedData, err := ProcessExportedData(exportedData, exportedFileName, format, keywordMapping, resourceType)
 	if err != nil {
-		log.Println("Error when processing with keywords. Using original exported content. ", err)
+		PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error when processing with keywords. Using original exported content. %s", err))
 		modifiedData = exportedData
 	}
 
@@ -159,7 +158,7 @@ func GetKeywordLocations(fileData interface{}, path []string, keywordMapping map
 				}
 				arrayElementPath, err := resolvePathWithIdentifiers(arrayName, val, arrayIdentifiers)
 				if err != nil {
-					log.Printf("Error: cannot resolve path for the field %s. %s.\n", strings.Join(path, "."), err)
+					PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("cannot resolve path for the field %s. %s.", strings.Join(path, "."), err))
 					break
 				}
 				newPath := append(path, arrayElementPath)
@@ -223,7 +222,7 @@ func resolvePathWithIdentifiers(arrayName string, element interface{}, identifie
 	if !ok {
 		elementMap, ok = element.(map[string]interface{})
 		if !ok {
-			log.Printf("Error: cannot convert %T to a map", element)
+			PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("cannot convert %T to a map", element))
 		}
 	}
 	identifier := identifiers[arrayName]
@@ -261,15 +260,15 @@ func ModifyFieldsWithKeywords(exportedFileData interface{}, localFileData interf
 		if exportedValue != localReplacedValue {
 			if exportedValue == strings.ReplaceAll(SENSITIVE_FIELD_MASK, "'", "") {
 				ReplaceValue(exportedFileData, location, localValue)
-				log.Printf("Info: Keyword added at %s field\n", location)
+				PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Keyword added at %s field", location))
 			} else {
-				log.Printf("Warning: Keywords at %s field in the local file will be replaced by exported content.", location)
-				log.Println("Info: Local Value with Keyword Replaced: ", localReplacedValue)
-				log.Println("Info: Exported Value: ", exportedValue)
+				PrintLog(LogLevelWarn, NoResource, "", fmt.Sprintf("Keywords at %s field in the local file will be replaced by exported content.", location))
+				PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Local Value with Keyword Replaced: %s", localReplacedValue))
+				PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Exported Value: %s", exportedValue))
 			}
 		} else {
 			ReplaceValue(exportedFileData, location, localValue)
-			log.Printf("Info: Keyword added at %s field\n", location)
+			PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Keyword added at %s field", location))
 		}
 	}
 	return exportedFileData
@@ -347,7 +346,7 @@ func ReplaceRawValue(data interface{}, pathString string, replacement interface{
 			currentKey := path[0]
 			index, err := GetArrayIndex(v, currentKey)
 			if err != nil {
-				log.Printf("Error: when resolving array index for element %s.", currentKey)
+				PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("when resolving array index for element %s.", currentKey))
 				return data
 			}
 			if len(v) > index {

--- a/iamctl/pkg/utils/logUtils.go
+++ b/iamctl/pkg/utils/logUtils.go
@@ -51,6 +51,7 @@ var (
 	ResTypeSummaryMap map[ResourceType]ResourceTypeSummary
 	Warnings          []string
 	ResTypeStartTimes = make(map[ResourceType]time.Time)
+	StartTime         time.Time
 )
 
 var CURRENT_LOG_LEVEL LogLevel = LogLevelInfo
@@ -94,10 +95,9 @@ func MarkResTypeEnd(resourceType ResourceType) {
 	if !ok {
 		return
 	}
-
 	InitializeResTypeSummaryMap()
 	summary := getOrInitSummary(resourceType)
-	summary.Duration = time.Since(startTime)
+	summary.Duration = time.Since(startTime).Round(time.Millisecond)
 	ResTypeSummaryMap[resourceType] = summary
 }
 
@@ -211,6 +211,9 @@ func PrintSummary(Operation string) {
 	fmt.Printf("Successful Resource Types: %d\n", successCount)
 	fmt.Printf("Skipped Resource Types: %d\n", len(skippedTypes))
 	fmt.Printf("Failed Resource Types: %d\n", len(failedTypes))
+	if !StartTime.IsZero() {
+		fmt.Printf("Total Execution Time: %s\n", time.Since(StartTime).Round(time.Millisecond))
+	}
 	if len(skippedTypes) > 0 {
 		fmt.Println("========================================")
 		fmt.Println("Skipped Resource Types")
@@ -266,7 +269,7 @@ func PrintExportSummary() {
 			PrintFailedResources(summary)
 		}
 		if summary.Duration > 0 && summary.SuccessfulExport > 0 {
-			fmt.Printf("Time taken: %s\n", summary.Duration.Round(time.Millisecond))
+			fmt.Printf("Execution time: %s\n", summary.Duration.Round(time.Millisecond))
 		}
 	}
 	fmt.Println("----------------------------------------")
@@ -295,7 +298,7 @@ func PrintImportSummary() {
 			printNewSecretApplications(summary)
 		}
 		if summary.Duration > 0 && summary.SuccessfulImport+summary.SuccessfulUpdate > 0 {
-			fmt.Printf("Time taken: %s\n", summary.Duration.Round(time.Millisecond))
+			fmt.Printf("Execution time: %s\n", summary.Duration.Round(time.Millisecond))
 		}
 	}
 }

--- a/iamctl/pkg/utils/logUtils.go
+++ b/iamctl/pkg/utils/logUtils.go
@@ -20,6 +20,7 @@ package utils
 
 import (
 	"fmt"
+	"log"
 )
 
 type Summary struct {
@@ -43,6 +44,16 @@ var (
 	SummaryData       Summary
 	ResourceSummaries map[string]ResourceSummary
 )
+
+func PrintLog(level LogLevel, resourceType ResourceType, resourceName string, msg string) {
+	if resourceType == NoResource {
+		log.Println(msg)
+	} else if resourceName == "" {
+		log.Printf("%s - %s", resourceType, msg)
+	} else {
+		log.Printf("%s - %s - %s", resourceType, resourceName, msg)
+	}
+}
 
 func PrintSummary(Operation string) {
 

--- a/iamctl/pkg/utils/logUtils.go
+++ b/iamctl/pkg/utils/logUtils.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log"
 	"strings"
+	"time"
 )
 
 type Summary struct {
@@ -30,20 +31,26 @@ type Summary struct {
 	TotalRequests        int
 }
 
-type ResourceSummary struct {
-	ResourceType                string
+type ResourceTypeSummary struct {
+	ResourceType                ResourceType
 	SuccessfulExport            int
 	SuccessfulImport            int
 	SuccessfulUpdate            int
-	Failed                      int
-	Deleted                     int
+	FailedCount                 int
+	DeletedCount                int
 	SecretGeneratedApplications []string
 	FailedResources             []string
+	Skipped                     bool
+	SkipReason                  string
+	Failed                      bool
+	Duration                    time.Duration
 }
 
 var (
-	SummaryData       Summary
-	ResourceSummaries map[string]ResourceSummary
+	AggregatedSummary Summary
+	ResTypeSummaryMap map[ResourceType]ResourceTypeSummary
+	Warnings          []string
+	ResTypeStartTimes = make(map[ResourceType]time.Time)
 )
 
 var CURRENT_LOG_LEVEL LogLevel = LogLevelInfo
@@ -76,6 +83,83 @@ func levelPrefix(level LogLevel) string {
 	}
 }
 
+func MarkResTypeStart(resourceType ResourceType) {
+
+	ResTypeStartTimes[resourceType] = time.Now()
+}
+
+func MarkResTypeEnd(resourceType ResourceType) {
+
+	startTime, ok := ResTypeStartTimes[resourceType]
+	if !ok {
+		return
+	}
+
+	InitializeResTypeSummaryMap()
+	summary := getOrInitSummary(resourceType)
+	summary.Duration = time.Since(startTime)
+	ResTypeSummaryMap[resourceType] = summary
+}
+
+func UpdateSkipSummary(resourceType ResourceType, reason string) {
+
+	InitializeResTypeSummaryMap()
+	summary := getOrInitSummary(resourceType)
+	summary.Skipped = true
+	summary.SkipReason = reason
+	ResTypeSummaryMap[resourceType] = summary
+}
+
+func MarkResTypeFailure(resourceType ResourceType) {
+
+	InitializeResTypeSummaryMap()
+	summary := getOrInitSummary(resourceType)
+	summary.Failed = true
+	ResTypeSummaryMap[resourceType] = summary
+}
+
+func AddNewSecretIndicatorToSummary(appName string) {
+
+	InitializeResTypeSummaryMap()
+	summary := getOrInitSummary(APPLICATIONS)
+	summary.SecretGeneratedApplications = append(summary.SecretGeneratedApplications, appName)
+	ResTypeSummaryMap[APPLICATIONS] = summary
+}
+
+func UpdateSuccessSummary(resourceType ResourceType, operation string) {
+
+	InitializeResTypeSummaryMap()
+
+	AggregatedSummary.TotalRequests++
+	AggregatedSummary.SuccessfulOperations++
+
+	summary := getOrInitSummary(resourceType)
+	switch operation {
+	case EXPORT:
+		summary.SuccessfulExport++
+	case IMPORT:
+		summary.SuccessfulImport++
+	case UPDATE:
+		summary.SuccessfulUpdate++
+	case DELETE:
+		summary.DeletedCount++
+	}
+	ResTypeSummaryMap[resourceType] = summary
+}
+
+func UpdateFailureSummary(resourceType ResourceType, resourceName string) {
+
+	InitializeResTypeSummaryMap()
+
+	AggregatedSummary.TotalRequests++
+	AggregatedSummary.FailedOperations++
+
+	summary := getOrInitSummary(resourceType)
+	summary.FailedCount++
+	summary.FailedResources = append(summary.FailedResources, resourceName)
+	ResTypeSummaryMap[resourceType] = summary
+}
+
 func PrintLog(level LogLevel, resourceType ResourceType, resourceName string, msg string) {
 
 	var body string
@@ -88,9 +172,8 @@ func PrintLog(level LogLevel, resourceType ResourceType, resourceName string, ms
 	}
 
 	if level == LogLevelWarn {
-		GlobalWarnings = append(GlobalWarnings, body)
+		Warnings = append(Warnings, body)
 	}
-
 	if level < CURRENT_LOG_LEVEL {
 		return
 	}
@@ -99,41 +182,91 @@ func PrintLog(level LogLevel, resourceType ResourceType, resourceName string, ms
 
 func PrintSummary(Operation string) {
 
-	InitializeResourceSummary()
+	InitializeResTypeSummaryMap()
+
+	type skippedEntry struct {
+		name   string
+		reason string
+	}
+	var successCount int
+	var skippedTypes []skippedEntry
+	var failedTypes []string
+
+	for rt, summary := range ResTypeSummaryMap {
+		if summary.Skipped {
+			skippedTypes = append(skippedTypes, skippedEntry{rt.String(), summary.SkipReason})
+		} else if summary.Failed || summary.FailedCount > 0 {
+			failedTypes = append(failedTypes, rt.String())
+		} else {
+			successCount++
+		}
+	}
 
 	fmt.Println("========================================")
 	fmt.Println("Total Summary:")
 	fmt.Println("========================================")
-	fmt.Printf("Total Requests: %d\n", SummaryData.TotalRequests)
-	fmt.Printf("Successful Operations: %d\n", SummaryData.SuccessfulOperations)
-	fmt.Printf("Failed Operations: %d\n", SummaryData.FailedOperations)
+	fmt.Printf("Total Operations: %d\n", AggregatedSummary.TotalRequests)
+	fmt.Printf("Successful Operations: %d\n", AggregatedSummary.SuccessfulOperations)
+	fmt.Printf("Failed Operations: %d\n", AggregatedSummary.FailedOperations)
+	fmt.Printf("Successful Resource Types: %d\n", successCount)
+	fmt.Printf("Skipped Resource Types: %d\n", len(skippedTypes))
+	fmt.Printf("Failed Resource Types: %d\n", len(failedTypes))
+	if len(skippedTypes) > 0 {
+		fmt.Println("========================================")
+		fmt.Println("Skipped Resource Types")
+		fmt.Println("========================================")
+		for _, s := range skippedTypes {
+			fmt.Printf("%s - %s\n", s.name, s.reason)
+		}
+	}
+	if len(failedTypes) > 0 {
+		fmt.Println("========================================")
+		fmt.Println("Failed Resource Types")
+		fmt.Println("========================================")
+		for _, f := range failedTypes {
+			fmt.Printf("%s\n", f)
+		}
+	}
 
+	fmt.Println("========================================")
+	fmt.Println("Per Resource Breakdown")
+	fmt.Println("========================================")
 	if Operation == IMPORT {
 		PrintImportSummary()
 	} else if Operation == EXPORT {
 		PrintExportSummary()
 	}
 
-	if len(GlobalWarnings) > 0 {
-		fmt.Println("----------------------------------------")
-		fmt.Println("Warnings:")
-		for _, w := range GlobalWarnings {
-			fmt.Printf("- %s\n", w)
-		}
+	if len(Warnings) > 0 {
 		fmt.Println("========================================")
+		fmt.Println("Warnings")
+		fmt.Println("========================================")
+		for _, w := range Warnings {
+			fmt.Printf("%s\n", w)
+		}
 	}
+	fmt.Println("========================================")
 }
 
 func PrintExportSummary() {
 
-	for _, summary := range ResourceSummaries {
-		fmt.Println("----------------------------------------")
+	first := true
+	for _, summary := range ResTypeSummaryMap {
+		if summary.SuccessfulExport+summary.FailedCount == 0 {
+			continue
+		}
+		if !first {
+			fmt.Println("----------------------------------------")
+		}
+		first = false
 		fmt.Printf("%s\n", summary.ResourceType)
 		fmt.Println("----------------------------------------")
 		fmt.Printf("Successful Exports: %d\n", summary.SuccessfulExport)
-
-		if summary.Failed > 0 {
+		if summary.FailedCount > 0 {
 			PrintFailedResources(summary)
+		}
+		if summary.Duration > 0 && summary.SuccessfulExport > 0 {
+			fmt.Printf("Time taken: %s\n", summary.Duration.Round(time.Millisecond))
 		}
 	}
 	fmt.Println("----------------------------------------")
@@ -141,27 +274,36 @@ func PrintExportSummary() {
 
 func PrintImportSummary() {
 
-	for _, summary := range ResourceSummaries {
-		fmt.Println("----------------------------------------")
+	first := true
+	for _, summary := range ResTypeSummaryMap {
+		if summary.SuccessfulImport+summary.SuccessfulUpdate+summary.DeletedCount+summary.FailedCount == 0 {
+			continue
+		}
+		if !first {
+			fmt.Println("----------------------------------------")
+		}
+		first = false
 		fmt.Printf("%s\n", summary.ResourceType)
 		fmt.Println("----------------------------------------")
 		fmt.Printf("Successful Imports: %d\n", summary.SuccessfulImport)
 		fmt.Printf("Successful Updates: %d\n", summary.SuccessfulUpdate)
-		fmt.Printf("Deleted: %d\n", summary.Deleted)
-		if summary.Failed > 0 {
+		fmt.Printf("Deleted: %d\n", summary.DeletedCount)
+		if summary.FailedCount > 0 {
 			PrintFailedResources(summary)
 		}
-		if summary.ResourceType == APPLICATIONS.String() {
+		if summary.ResourceType == APPLICATIONS {
 			printNewSecretApplications(summary)
 		}
+		if summary.Duration > 0 && summary.SuccessfulImport+summary.SuccessfulUpdate > 0 {
+			fmt.Printf("Time taken: %s\n", summary.Duration.Round(time.Millisecond))
+		}
 	}
-	fmt.Println("----------------------------------------")
 }
 
-func PrintFailedResources(summary ResourceSummary) {
+func PrintFailedResources(summary ResourceTypeSummary) {
 
 	fmt.Println("....................")
-	fmt.Printf("Failures:  %d\n", summary.Failed)
+	fmt.Printf("Failures:  %d\n", summary.FailedCount)
 	fmt.Println("....................")
 	for i, resourceName := range summary.FailedResources {
 		if i != len(summary.FailedResources)-1 {
@@ -170,11 +312,10 @@ func PrintFailedResources(summary ResourceSummary) {
 			fmt.Print(resourceName)
 		}
 	}
-
 	fmt.Println()
 }
 
-func printNewSecretApplications(summary ResourceSummary) {
+func printNewSecretApplications(summary ResourceTypeSummary) {
 
 	if len(summary.SecretGeneratedApplications) > 0 {
 		fmt.Println("....................")
@@ -190,67 +331,18 @@ func printNewSecretApplications(summary ResourceSummary) {
 	}
 }
 
-func AddNewSecretIndicatorToSummary(appName string) {
+func InitializeResTypeSummaryMap() {
 
-	InitializeResourceSummary()
-
-	summary, ok := ResourceSummaries[APPLICATIONS.String()]
-	if !ok {
-		summary = ResourceSummary{
-			ResourceType: APPLICATIONS.String(),
-		}
+	if ResTypeSummaryMap == nil {
+		ResTypeSummaryMap = make(map[ResourceType]ResourceTypeSummary)
 	}
-	summary.SecretGeneratedApplications = append(summary.SecretGeneratedApplications, appName)
-	ResourceSummaries[APPLICATIONS.String()] = summary
 }
 
-func UpdateSuccessSummary(resourceType ResourceType, operation string) {
+func getOrInitSummary(resourceType ResourceType) ResourceTypeSummary {
 
-	InitializeResourceSummary()
-
-	SummaryData.TotalRequests++
-	SummaryData.SuccessfulOperations++
-
-	summary, ok := ResourceSummaries[resourceType.String()]
-	if !ok {
-		summary = ResourceSummary{
-			ResourceType: resourceType.String(),
-		}
+	summary, exists := ResTypeSummaryMap[resourceType]
+	if !exists {
+		return ResourceTypeSummary{ResourceType: resourceType}
 	}
-	switch operation {
-	case EXPORT:
-		summary.SuccessfulExport++
-	case IMPORT:
-		summary.SuccessfulImport++
-	case UPDATE:
-		summary.SuccessfulUpdate++
-	case DELETE:
-		summary.Deleted++
-	}
-	ResourceSummaries[resourceType.String()] = summary
-}
-
-func UpdateFailureSummary(resourceType ResourceType, resourceName string) {
-
-	InitializeResourceSummary()
-
-	SummaryData.TotalRequests++
-	SummaryData.FailedOperations++
-
-	summary, ok := ResourceSummaries[resourceType.String()]
-	if !ok {
-		summary = ResourceSummary{
-			ResourceType: resourceType.String(),
-		}
-	}
-	summary.Failed++
-	summary.FailedResources = append(summary.FailedResources, resourceName)
-	ResourceSummaries[resourceType.String()] = summary
-}
-
-func InitializeResourceSummary() {
-
-	if ResourceSummaries == nil {
-		ResourceSummaries = make(map[string]ResourceSummary)
-	}
+	return summary
 }

--- a/iamctl/pkg/utils/logUtils.go
+++ b/iamctl/pkg/utils/logUtils.go
@@ -21,6 +21,7 @@ package utils
 import (
 	"fmt"
 	"log"
+	"strings"
 )
 
 type Summary struct {
@@ -45,13 +46,49 @@ var (
 	ResourceSummaries map[string]ResourceSummary
 )
 
+var CURRENT_LOG_LEVEL LogLevel = LogLevelInfo
+
+func resolveLogLevel(levelStr string) LogLevel {
+
+	switch strings.ToUpper(strings.TrimSpace(levelStr)) {
+	case "DEBUG":
+		return LogLevelDebug
+	case "WARN":
+		return LogLevelWarn
+	case "ERROR":
+		return LogLevelError
+	default:
+		return LogLevelInfo
+	}
+}
+
+func levelPrefix(level LogLevel) string {
+
+	switch level {
+	case LogLevelDebug:
+		return "DEBUG:"
+	case LogLevelWarn:
+		return "WARN:"
+	case LogLevelError:
+		return "ERROR:"
+	default:
+		return "INFO:"
+	}
+}
+
 func PrintLog(level LogLevel, resourceType ResourceType, resourceName string, msg string) {
+
+	if level < CURRENT_LOG_LEVEL {
+		return
+	}
+	prefix := levelPrefix(level)
+
 	if resourceType == NoResource {
-		log.Println(msg)
+		log.Printf("%s %s", prefix, msg)
 	} else if resourceName == "" {
-		log.Printf("%s - %s", resourceType, msg)
+		log.Printf("%s %s - %s", prefix, resourceType, msg)
 	} else {
-		log.Printf("%s - %s - %s", resourceType, resourceName, msg)
+		log.Printf("%s %s - %s - %s", prefix, resourceType, resourceName, msg)
 	}
 }
 

--- a/iamctl/pkg/utils/logUtils.go
+++ b/iamctl/pkg/utils/logUtils.go
@@ -265,11 +265,11 @@ func PrintExportSummary() {
 		fmt.Printf("%s\n", summary.ResourceType)
 		fmt.Println("----------------------------------------")
 		fmt.Printf("Successful Exports: %d\n", summary.SuccessfulExport)
-		if summary.FailedCount > 0 {
-			PrintFailedResources(summary)
-		}
 		if summary.Duration > 0 && summary.SuccessfulExport > 0 {
 			fmt.Printf("Execution time: %s\n", summary.Duration.Round(time.Millisecond))
+		}
+		if summary.FailedCount > 0 {
+			PrintFailedResources(summary)
 		}
 	}
 	fmt.Println("----------------------------------------")
@@ -291,14 +291,14 @@ func PrintImportSummary() {
 		fmt.Printf("Successful Imports: %d\n", summary.SuccessfulImport)
 		fmt.Printf("Successful Updates: %d\n", summary.SuccessfulUpdate)
 		fmt.Printf("Deleted: %d\n", summary.DeletedCount)
+		if summary.Duration > 0 && summary.SuccessfulImport+summary.SuccessfulUpdate > 0 {
+			fmt.Printf("Execution time: %s\n", summary.Duration.Round(time.Millisecond))
+		}
 		if summary.FailedCount > 0 {
 			PrintFailedResources(summary)
 		}
 		if summary.ResourceType == APPLICATIONS {
 			printNewSecretApplications(summary)
-		}
-		if summary.Duration > 0 && summary.SuccessfulImport+summary.SuccessfulUpdate > 0 {
-			fmt.Printf("Execution time: %s\n", summary.Duration.Round(time.Millisecond))
 		}
 	}
 }

--- a/iamctl/pkg/utils/logUtils.go
+++ b/iamctl/pkg/utils/logUtils.go
@@ -78,18 +78,23 @@ func levelPrefix(level LogLevel) string {
 
 func PrintLog(level LogLevel, resourceType ResourceType, resourceName string, msg string) {
 
+	var body string
+	if resourceType == NoResource {
+		body = msg
+	} else if resourceName == "" {
+		body = fmt.Sprintf("%s - %s", resourceType, msg)
+	} else {
+		body = fmt.Sprintf("%s - %s - %s", resourceType, resourceName, msg)
+	}
+
+	if level == LogLevelWarn {
+		GlobalWarnings = append(GlobalWarnings, body)
+	}
+
 	if level < CURRENT_LOG_LEVEL {
 		return
 	}
-	prefix := levelPrefix(level)
-
-	if resourceType == NoResource {
-		log.Printf("%s %s", prefix, msg)
-	} else if resourceName == "" {
-		log.Printf("%s %s - %s", prefix, resourceType, msg)
-	} else {
-		log.Printf("%s %s - %s - %s", prefix, resourceType, resourceName, msg)
-	}
+	log.Printf("%s %s", levelPrefix(level), body)
 }
 
 func PrintSummary(Operation string) {
@@ -107,6 +112,15 @@ func PrintSummary(Operation string) {
 		PrintImportSummary()
 	} else if Operation == EXPORT {
 		PrintExportSummary()
+	}
+
+	if len(GlobalWarnings) > 0 {
+		fmt.Println("----------------------------------------")
+		fmt.Println("Warnings:")
+		for _, w := range GlobalWarnings {
+			fmt.Printf("- %s\n", w)
+		}
+		fmt.Println("========================================")
 	}
 }
 

--- a/iamctl/pkg/utils/resourceProperties.go
+++ b/iamctl/pkg/utils/resourceProperties.go
@@ -19,8 +19,8 @@
 package utils
 
 import (
+	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -40,7 +40,7 @@ func IsResourceExcluded(resourceName string, resourceConfigs map[string]interfac
 				return false
 			}
 		}
-		log.Println("Excluded resource: " + resourceName)
+		PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Excluded resource: %s", resourceName))
 		return true
 	} else {
 		// Exclude resources added to EXCLUDE config.
@@ -48,7 +48,7 @@ func IsResourceExcluded(resourceName string, resourceConfigs map[string]interfac
 		if ok {
 			for _, resource := range resourcesToExclude {
 				if resource.(string) == resourceName {
-					log.Println("Excluded resource: " + resourceName)
+					PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Excluded resource: %s", resourceName))
 					return true
 				}
 			}
@@ -66,13 +66,13 @@ func IsResourceTypeExcluded(resourceType ResourceType) bool {
 				return false
 			}
 		}
-		log.Println("Skipping Excluded resource: " + resourceType)
+		PrintLog(LogLevelInfo, resourceType, "", "Skipping excluded resource type")
 		return true
 	} else if len(TOOL_CONFIGS.Exclude) > 0 {
 		// Exclude resource types added to EXCLUDE config.
 		for _, resource := range TOOL_CONFIGS.Exclude {
 			if resource == resourceType.String() {
-				log.Println("Skipping Excluded resource: " + resourceType)
+				PrintLog(LogLevelInfo, resourceType, "", "Skipping excluded resource type")
 				return true
 			}
 		}
@@ -88,7 +88,7 @@ func IsEntitySupportedInOrg(resourceType ResourceType) bool {
 	if entitySupportedInSubOrg[resourceType] {
 		return true
 	}
-	log.Printf("Skipping %s: Not supported for sub organizations", resourceType)
+	PrintLog(LogLevelWarn, resourceType, "", "Not supported for sub organizations")
 	return false
 }
 
@@ -135,7 +135,7 @@ func RemoveDeletedLocalDirectories(parentDir string, deployedDirNames []string) 
 
 	localEntries, err := ioutil.ReadDir(parentDir)
 	if err != nil {
-		log.Println("Error loading directory:", err)
+		PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error loading directory: %s", err))
 		return
 	}
 
@@ -146,9 +146,9 @@ func RemoveDeletedLocalDirectories(parentDir string, deployedDirNames []string) 
 		if _, exists := deployedNames[entry.Name()]; !exists {
 			dirPath := filepath.Join(parentDir, entry.Name())
 			if err := os.RemoveAll(dirPath); err != nil {
-				log.Printf("Error when removing the directory %s: %s", entry.Name(), err)
+				PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error when removing the directory %s: %s", entry.Name(), err))
 			} else {
-				log.Println("Removed the directory:", entry.Name())
+				PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Removed the directory: %s", entry.Name()))
 			}
 		}
 	}
@@ -159,7 +159,7 @@ func RemoveDeletedLocalResources(filePath string, deployedResourceNames []string
 	// Remove local files of resources that do not exist in the remote during export.
 	files, err := ioutil.ReadDir(filePath)
 	if err != nil {
-		log.Println("Error loading local files: ", err)
+		PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error loading local files: %s", err))
 		return
 	}
 
@@ -171,9 +171,9 @@ func RemoveDeletedLocalResources(filePath string, deployedResourceNames []string
 		if !Contains(deployedResourceNames, GetFileInfo(fileName).ResourceName) {
 			err := os.Remove(filepath.Join(filePath, fileName))
 			if err != nil {
-				log.Println("Error when removing the file: ", fileName, err)
+				PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error when removing the file: %s %s", fileName, err))
 			} else {
-				log.Println("Removed the file:", fileName)
+				PrintLog(LogLevelInfo, NoResource, "", fmt.Sprintf("Removed the file: %s", fileName))
 			}
 		}
 	}

--- a/iamctl/pkg/utils/resourceProperties.go
+++ b/iamctl/pkg/utils/resourceProperties.go
@@ -88,7 +88,24 @@ func IsEntitySupportedInOrg(resourceType ResourceType) bool {
 	if entitySupportedInSubOrg[resourceType] {
 		return true
 	}
-	PrintLog(LogLevelWarn, resourceType, "", "Not supported for sub organizations")
+	PrintLog(LogLevelInfo, resourceType, "", "Not supported for sub organizations")
+	return false
+}
+
+func ShouldSkip(resourceType ResourceType) bool {
+
+	if !IsEntitySupportedInVersion(resourceType) {
+		UpdateSkipSummary(resourceType, "Not supported in server version")
+		return true
+	}
+	if !IsEntitySupportedInOrg(resourceType) {
+		UpdateSkipSummary(resourceType, "Not supported in sub-organizations")
+		return true
+	}
+	if IsResourceTypeExcluded(resourceType) {
+		UpdateSkipSummary(resourceType, "Excluded via tool configs")
+		return true
+	}
 	return false
 }
 

--- a/iamctl/pkg/utils/resourceReferenceUtils.go
+++ b/iamctl/pkg/utils/resourceReferenceUtils.go
@@ -20,7 +20,6 @@ package utils
 
 import (
 	"fmt"
-	"log"
 	"strings"
 )
 
@@ -32,7 +31,7 @@ func ExtractAndRegisterIdentifier(resourceType ResourceType, resourceData interf
 
 	resourceMeta, exists := RESOURCE_IDENTIFIER_METADATA[resourceType]
 	if !exists {
-		log.Println("Warn: No identifier metadata found for resource type. Skipping resource identifier map entry.")
+		PrintLog(LogLevelWarn, NoResource, "", "No identifier metadata found for resource type. Skipping resource identifier map entry.")
 		return
 	}
 
@@ -40,7 +39,7 @@ func ExtractAndRegisterIdentifier(resourceType ResourceType, resourceData interf
 	uniqueValue := GetValue(resourceData, resourceMeta.UniqueValuePath)
 
 	if idValue == "" || uniqueValue == "" {
-		log.Println("Warn: Could not extract identifier or unique value. Skipping resource identifier map entry.")
+		PrintLog(LogLevelWarn, NoResource, "", "Could not extract identifier or unique value. Skipping resource identifier map entry.")
 		return
 	}
 

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -22,6 +22,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -119,11 +120,11 @@ func LoadConfigs(envConfigPath string) (baseDir string) {
 func loadServerConfigs(envConfigPath string) (baseDir string, toolConfigPath string, keywordConfigPath string) {
 
 	if envConfigPath == "" {
-		log.Println("Loading configs from environment variables.")
+		PrintLog(LogLevelInfo, NoResource, "", "Loading configs from environment variables.")
 		toolConfigPath, keywordConfigPath = loadConfigsFromEnvVar()
 		baseDir = filepath.Dir(filepath.Dir(filepath.Dir(toolConfigPath)))
 	} else {
-		log.Println("Loading configs from config files.")
+		PrintLog(LogLevelInfo, NoResource, "", "Loading configs from config files.")
 		baseDir = filepath.Dir(filepath.Dir(envConfigPath))
 		serverConfigFile := filepath.Join(envConfigPath, SERVER_CONFIG_FILE)
 		toolConfigPath = filepath.Join(envConfigPath, TOOL_CONFIG_FILE)
@@ -137,14 +138,14 @@ func loadServerConfigs(envConfigPath string) (baseDir string, toolConfigPath str
 	if SERVER_CONFIGS.ServerVersion != "" {
 		_, err := ParseVersion(SERVER_CONFIGS.ServerVersion)
 		if err != nil {
-			log.Println("Warn: Server version is not properly configured. Configure the server version properly to avoid failures.")
-			log.Printf("Error parsing server version: %s. Error: %s", SERVER_CONFIGS.ServerVersion, err)
+			PrintLog(LogLevelWarn, NoResource, "", "Server version is not properly configured. Configure the server version properly to avoid failures.")
+			PrintLog(LogLevelError, NoResource, "", fmt.Sprintf("Error parsing server version: %s. Error: %s", SERVER_CONFIGS.ServerVersion, err))
 		}
 	}
 
 	// Get access token.
 	SERVER_CONFIGS.Token = getAccessToken(SERVER_CONFIGS)
-	log.Println("Access Token received successfully.")
+	PrintLog(LogLevelInfo, NoResource, "", "Access Token received successfully.")
 
 	return baseDir, toolConfigPath, keywordConfigPath
 }
@@ -181,7 +182,7 @@ func loadServerConfigsFromFile(configFilePath string) (serverConfigs ServerConfi
 	if err != nil {
 		log.Fatalln(err)
 	}
-	log.Println("Server configs loaded succesfully from the config file.")
+	PrintLog(LogLevelInfo, NoResource, "", "Server configs loaded succesfully from the config file.")
 	return serverConfigs
 }
 
@@ -202,7 +203,7 @@ func loadToolConfigsFromFile(configFilePath string) (toolConfigs ToolConfigs) {
 		log.Fatalln("Tool configs are not in the correct format. Please check the config file.", err)
 	}
 
-	log.Println("Tool configs loaded successfully from the config file.")
+	PrintLog(LogLevelInfo, NoResource, "", "Tool configs loaded successfully from the config file.")
 	return toolConfigs
 }
 
@@ -225,7 +226,7 @@ func loadKeywordConfigsFromFile(configFilePath string) (keywordConfigs KeywordCo
 		log.Fatalln("Keyword configs are not in the correct format. Please check the config file.", err)
 	}
 
-	log.Println("Keyword configs loaded successfully from the config file.")
+	PrintLog(LogLevelInfo, NoResource, "", "Keyword configs loaded successfully from the config file.")
 	return keywordConfigs
 }
 
@@ -278,7 +279,7 @@ func getAccessToken(config ServerConfigs) string {
 		log.Fatalln(err2)
 	}
 	if IsSubOrganization() {
-		log.Println("Getting access token for Organization: " + SERVER_CONFIGS.Organization)
+		PrintLog(LogLevelInfo, NoResource, "", "Getting access token for Organization: "+SERVER_CONFIGS.Organization)
 		return switchAccessToken(config, response.AccessToken)
 	}
 	return response.AccessToken
@@ -340,7 +341,7 @@ func sanitizeServerConfigs() {
 
 	// Set tenant domain if not defined in the config file.
 	if SERVER_CONFIGS.TenantDomain == "" {
-		log.Println("Tenant domain not defined. Defaulting to: carbon.super")
+		PrintLog(LogLevelInfo, NoResource, "", "Tenant domain not defined. Defaulting to: carbon.super")
 		SERVER_CONFIGS.TenantDomain = DEFAULT_TENANT_DOMAIN
 	}
 }

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -32,6 +32,11 @@ import (
 	"strings"
 )
 
+type LogsConfig struct {
+	LogLevel           string `json:"LOG_LEVEL"`
+	LogRequestPayloads bool   `json:"LOG_REQUEST_PAYLOADS"`
+}
+
 type oAuthResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
@@ -77,6 +82,7 @@ type ToolConfigs struct {
 	BrandingPreferenceConfigs  map[string]interface{} `json:"BRANDING_PREFERENCES"`
 	CustomTextConfigs          map[string]interface{} `json:"CUSTOM_TEXTS"`
 	FlowConfigs                map[string]interface{} `json:"FLOWS"`
+	Logs                       LogsConfig             `json:"LOGS"`
 }
 
 type KeywordConfigs struct {
@@ -113,6 +119,7 @@ func LoadConfigs(envConfigPath string) (baseDir string) {
 
 	baseDir, toolConfigFile, keywordConfigPath := loadServerConfigs(envConfigPath)
 	TOOL_CONFIGS = loadToolConfigsFromFile(toolConfigFile)
+	CURRENT_LOG_LEVEL = resolveLogLevel(TOOL_CONFIGS.Logs.LogLevel)
 	KEYWORD_CONFIGS = loadKeywordConfigsFromFile(keywordConfigPath)
 	return baseDir
 }

--- a/iamctl/pkg/utils/versionUtils.go
+++ b/iamctl/pkg/utils/versionUtils.go
@@ -20,7 +20,6 @@ package utils
 
 import (
 	"fmt"
-	"log"
 	"strconv"
 	"strings"
 )
@@ -48,7 +47,7 @@ func IsEntitySupportedInVersion(resourceType ResourceType) bool {
 		if err != nil {
 			return true
 		} else if comparison > 0 {
-			log.Printf("Skipping %s: Supported up to IS version %s", resourceType, maxVersion)
+			PrintLog(LogLevelWarn, resourceType, "", fmt.Sprintf("Skipping: Supported up to IS version %s", maxVersion))
 			return false
 		}
 	}
@@ -61,7 +60,7 @@ func IsEntitySupportedInVersion(resourceType ResourceType) bool {
 		if err != nil {
 			return true
 		} else if comparison < 0 {
-			log.Printf("Skipping %s: Supported from IS version %s or higher", resourceType, minVersion)
+			PrintLog(LogLevelWarn, resourceType, "", fmt.Sprintf("Skipping: Supported from IS version %s or higher", minVersion))
 			return false
 		}
 	}

--- a/iamctl/pkg/utils/versionUtils.go
+++ b/iamctl/pkg/utils/versionUtils.go
@@ -47,7 +47,7 @@ func IsEntitySupportedInVersion(resourceType ResourceType) bool {
 		if err != nil {
 			return true
 		} else if comparison > 0 {
-			PrintLog(LogLevelWarn, resourceType, "", fmt.Sprintf("Skipping: Supported up to IS version %s", maxVersion))
+			PrintLog(LogLevelInfo, resourceType, "", fmt.Sprintf("Skipping: Supported up to IS version %s", maxVersion))
 			return false
 		}
 	}
@@ -60,7 +60,7 @@ func IsEntitySupportedInVersion(resourceType ResourceType) bool {
 		if err != nil {
 			return true
 		} else if comparison < 0 {
-			PrintLog(LogLevelWarn, resourceType, "", fmt.Sprintf("Skipping: Supported from IS version %s or higher", minVersion))
+			PrintLog(LogLevelInfo, resourceType, "", fmt.Sprintf("Skipping: Supported from IS version %s or higher", minVersion))
 			return false
 		}
 	}

--- a/iamctl/pkg/validationRules/export.go
+++ b/iamctl/pkg/validationRules/export.go
@@ -21,7 +21,6 @@ package validationRules
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting validation rules...")
+	utils.PrintLog(utils.LogLevelInfo, utils.VALIDATION_RULES, "", "Exporting validation rules...")
 	exportFilePath = filepath.Join(exportFilePath, utils.VALIDATION_RULES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.VALIDATION_RULES) || !utils.IsEntitySupportedInOrg(utils.VALIDATION_RULES) || utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
@@ -38,7 +37,7 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating validation rules directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.VALIDATION_RULES, "", fmt.Sprintf("Error creating validation rules directory: %s", err))
 			return
 		}
 	}
@@ -46,10 +45,10 @@ func ExportAll(exportFilePath string, format string) {
 	err := exportValidationRules(exportFilePath, format)
 	if err != nil {
 		utils.UpdateFailureSummary(utils.VALIDATION_RULES, resourceFileName)
-		log.Printf("Error while exporting validation rules: %s", err)
+		utils.PrintLog(utils.LogLevelError, utils.VALIDATION_RULES, "", fmt.Sprintf("Error while exporting validation rules: %s", err))
 	} else {
 		utils.UpdateSuccessSummary(utils.VALIDATION_RULES, utils.EXPORT)
-		log.Println("Validation rules exported successfully.")
+		utils.PrintLog(utils.LogLevelInfo, utils.VALIDATION_RULES, "", "Exported successfully")
 	}
 }
 

--- a/iamctl/pkg/validationRules/export.go
+++ b/iamctl/pkg/validationRules/export.go
@@ -32,12 +32,13 @@ func ExportAll(exportFilePath string, format string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.VALIDATION_RULES, "", "Exporting validation rules...")
 	exportFilePath = filepath.Join(exportFilePath, utils.VALIDATION_RULES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.VALIDATION_RULES) || !utils.IsEntitySupportedInOrg(utils.VALIDATION_RULES) || utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
+	if utils.ShouldSkip(utils.VALIDATION_RULES) {
 		return
 	}
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.VALIDATION_RULES, "", fmt.Sprintf("Error creating validation rules directory: %s", err))
+			utils.MarkResTypeFailure(utils.VALIDATION_RULES)
 			return
 		}
 	}

--- a/iamctl/pkg/validationRules/import.go
+++ b/iamctl/pkg/validationRules/import.go
@@ -32,7 +32,7 @@ func ImportAll(inputDirPath string) {
 	utils.PrintLog(utils.LogLevelInfo, utils.VALIDATION_RULES, "", "Importing validation rules...")
 	importFilePath := filepath.Join(inputDirPath, utils.VALIDATION_RULES.String())
 
-	if !utils.IsEntitySupportedInVersion(utils.VALIDATION_RULES) || !utils.IsEntitySupportedInOrg(utils.VALIDATION_RULES) || utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
+	if utils.ShouldSkip(utils.VALIDATION_RULES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {

--- a/iamctl/pkg/validationRules/import.go
+++ b/iamctl/pkg/validationRules/import.go
@@ -21,7 +21,6 @@ package validationRules
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,14 +29,14 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing validation rules...")
+	utils.PrintLog(utils.LogLevelInfo, utils.VALIDATION_RULES, "", "Importing validation rules...")
 	importFilePath := filepath.Join(inputDirPath, utils.VALIDATION_RULES.String())
 
 	if !utils.IsEntitySupportedInVersion(utils.VALIDATION_RULES) || !utils.IsEntitySupportedInOrg(utils.VALIDATION_RULES) || utils.IsResourceTypeExcluded(utils.VALIDATION_RULES) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No validation rules to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.VALIDATION_RULES, "", "No validation rules to import.")
 		return
 	}
 	filePath, err := getValidationRulesFilePath(importFilePath)
@@ -47,7 +46,7 @@ func ImportAll(inputDirPath string) {
 	}
 	if err != nil {
 		utils.UpdateFailureSummary(utils.VALIDATION_RULES, resourceFileName)
-		log.Println("Error importing validation rules:", err)
+		utils.PrintLog(utils.LogLevelError, utils.VALIDATION_RULES, "", fmt.Sprintf("Error importing validation rules: %s", err))
 	}
 }
 
@@ -70,7 +69,7 @@ func importValidationRules(filePath string) error {
 
 func updateValidationRules(requestBody []byte, format utils.Format) error {
 
-	log.Println("Updating validation rules.")
+	utils.PrintLog(utils.LogLevelInfo, utils.VALIDATION_RULES, "", "Updating validation rules")
 
 	jsonBody, err := prepareValidationRulesRequestBody(requestBody, format)
 	if err != nil {
@@ -84,6 +83,6 @@ func updateValidationRules(requestBody []byte, format utils.Format) error {
 	defer resp.Body.Close()
 
 	utils.UpdateSuccessSummary(utils.VALIDATION_RULES, utils.UPDATE)
-	log.Println("Validation rules updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.VALIDATION_RULES, "", "Updated successfully")
 	return nil
 }

--- a/iamctl/pkg/workflows/export.go
+++ b/iamctl/pkg/workflows/export.go
@@ -21,7 +21,6 @@ package workflows
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ExportAll(exportFilePath string, format string) {
 
-	log.Println("Exporting workflows...")
+	utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, "", "Exporting workflows...")
 	exportFilePath = filepath.Join(exportFilePath, utils.WORKFLOWS.String())
 	setWorkflowVersionConfigs()
 
@@ -39,13 +38,13 @@ func ExportAll(exportFilePath string, format string) {
 	}
 	workflows, err := getWorkflowList()
 	if err != nil {
-		log.Println("Error: when retrieving workflow list.", err)
+		utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error when retrieving workflow list: %s", err))
 		return
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
-			log.Println("Error creating workflows directory:", err)
+			utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error creating workflows directory: %s", err))
 			return
 		}
 	} else {
@@ -60,18 +59,18 @@ func ExportAll(exportFilePath string, format string) {
 
 	for _, wf := range workflows {
 		if !utils.IsResourceExcluded(wf.Name, utils.TOOL_CONFIGS.WorkflowConfigs) {
-			log.Println("Exporting workflow:", wf.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, wf.Name, "Exporting")
 			err := exportWorkflow(wf.ID, wf.Name, exportFilePath, format)
 			if err != nil {
 				utils.UpdateFailureSummary(utils.WORKFLOWS, wf.Name)
-				log.Printf("Error while exporting workflow: %s. %s", wf.Name, err)
+				utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, wf.Name, fmt.Sprintf("Error while exporting: %s", err))
 			} else {
 				if assocSharingSupported {
 					utils.UpdateSuccessSummary(utils.WORKFLOWS, utils.EXPORT)
 				} else {
 					successCount++
 				}
-				log.Println("Workflow exported successfully:", wf.Name)
+				utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, wf.Name, "Exported successfully")
 			}
 		}
 	}
@@ -80,13 +79,13 @@ func ExportAll(exportFilePath string, format string) {
 		err = writeWorkflowAssociationsList(exportFilePath, format)
 		updateWorkflowExportSummary(err == nil, successCount)
 		if err != nil {
-			log.Println("Error writing workflow associations list:", err)
+			utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error writing workflow associations list: %s", err))
 		}
 	}
 
-	log.Println("Warn: Users associated with workflow steps are not exported")
+	utils.PrintLog(utils.LogLevelWarn, utils.WORKFLOWS, "", "Users associated with workflow steps are not exported")
 	if assocRulesSupported {
-		log.Println("Warn: Workflow association rules are not exported")
+		utils.PrintLog(utils.LogLevelWarn, utils.WORKFLOWS, "", "Workflow association rules are not exported")
 	}
 }
 

--- a/iamctl/pkg/workflows/export.go
+++ b/iamctl/pkg/workflows/export.go
@@ -33,18 +33,20 @@ func ExportAll(exportFilePath string, format string) {
 	exportFilePath = filepath.Join(exportFilePath, utils.WORKFLOWS.String())
 	setWorkflowVersionConfigs()
 
-	if !utils.IsEntitySupportedInVersion(utils.WORKFLOWS) || !utils.IsEntitySupportedInOrg(utils.WORKFLOWS) || utils.IsResourceTypeExcluded(utils.WORKFLOWS) {
+	if utils.ShouldSkip(utils.WORKFLOWS) {
 		return
 	}
 	workflows, err := getWorkflowList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error when retrieving workflow list: %s", err))
+		utils.MarkResTypeFailure(utils.WORKFLOWS)
 		return
 	}
 
 	if _, err := os.Stat(exportFilePath); os.IsNotExist(err) {
 		if err := os.MkdirAll(exportFilePath, 0700); err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error creating workflows directory: %s", err))
+			utils.MarkResTypeFailure(utils.WORKFLOWS)
 			return
 		}
 	} else {

--- a/iamctl/pkg/workflows/import.go
+++ b/iamctl/pkg/workflows/import.go
@@ -33,7 +33,7 @@ func ImportAll(inputDirPath string) {
 	importFilePath := filepath.Join(inputDirPath, utils.WORKFLOWS.String())
 	setWorkflowVersionConfigs()
 
-	if !utils.IsEntitySupportedInVersion(utils.WORKFLOWS) || !utils.IsEntitySupportedInOrg(utils.WORKFLOWS) || utils.IsResourceTypeExcluded(utils.WORKFLOWS) {
+	if utils.ShouldSkip(utils.WORKFLOWS) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
@@ -44,11 +44,13 @@ func ImportAll(inputDirPath string) {
 	existingWorkflows, err := getWorkflowList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error retrieving the deployed workflow list: %s", err))
+		utils.MarkResTypeFailure(utils.WORKFLOWS)
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error importing workflows: %s", err))
+		utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error reading workflows directory: %s", err))
+		utils.MarkResTypeFailure(utils.WORKFLOWS)
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/workflows/import.go
+++ b/iamctl/pkg/workflows/import.go
@@ -21,7 +21,6 @@ package workflows
 import (
 	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"path/filepath"
 
@@ -30,7 +29,7 @@ import (
 
 func ImportAll(inputDirPath string) {
 
-	log.Println("Importing workflows...")
+	utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, "", "Importing workflows...")
 	importFilePath := filepath.Join(inputDirPath, utils.WORKFLOWS.String())
 	setWorkflowVersionConfigs()
 
@@ -38,18 +37,18 @@ func ImportAll(inputDirPath string) {
 		return
 	}
 	if _, err := os.Stat(importFilePath); os.IsNotExist(err) {
-		log.Println("No workflows to import.")
+		utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, "", "No workflows to import.")
 		return
 	}
 
 	existingWorkflows, err := getWorkflowList()
 	if err != nil {
-		log.Println("Error retrieving the deployed workflow list:", err)
+		utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error retrieving the deployed workflow list: %s", err))
 		return
 	}
 	files, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
-		log.Println("Error importing workflows:", err)
+		utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error importing workflows: %s", err))
 		return
 	}
 	if utils.TOOL_CONFIGS.AllowDelete {
@@ -61,7 +60,7 @@ func ImportAll(inputDirPath string) {
 	if !assocSharingSupported {
 		existingAssoc, err = getWorkflowAssociationsList()
 		if err != nil {
-			log.Println("Error retrieving the deployed workflow association list:", err)
+			utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error retrieving the deployed workflow association list: %s", err))
 			utils.UpdateFailureSummary(utils.WORKFLOWS, utils.WORKFLOW_ASSOCIATIONS.String())
 			return
 		}
@@ -69,7 +68,7 @@ func ImportAll(inputDirPath string) {
 		if utils.TOOL_CONFIGS.AllowDelete {
 			localAssoc, err := readLocalAssociationNames(importFilePath)
 			if err != nil {
-				log.Println("Error reading local workflow association list:", err)
+				utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, "", fmt.Sprintf("Error reading local workflow association list: %s", err))
 				utils.UpdateFailureSummary(utils.WORKFLOWS, utils.WORKFLOW_ASSOCIATIONS.String())
 				return
 			}
@@ -86,7 +85,7 @@ func ImportAll(inputDirPath string) {
 			continue
 		}
 		if _, failed := failedWorkflows[workflowName]; failed {
-			log.Printf("Skipping workflow %s: deleting stale workflow associations failed", workflowName)
+			utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, workflowName, "Skipping workflow: deleting stale workflow associations failed")
 			utils.UpdateFailureSummary(utils.WORKFLOWS, workflowName)
 			continue
 		}
@@ -94,12 +93,12 @@ func ImportAll(inputDirPath string) {
 		if !utils.IsResourceExcluded(workflowName, utils.TOOL_CONFIGS.WorkflowConfigs) {
 			workflowId := getWorkflowId(workflowName, existingWorkflows)
 			if err := importWorkflow(workflowName, workflowId, wfFilePath, existingAssoc); err != nil {
-				log.Println("Error importing workflow:", err)
+				utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, workflowName, fmt.Sprintf("Error importing workflow: %s", err))
 				utils.UpdateFailureSummary(utils.WORKFLOWS, workflowName)
 			}
 		}
 	}
-	log.Println("Warn: Users associated with workflow steps are removed during import")
+	utils.PrintLog(utils.LogLevelWarn, utils.WORKFLOWS, "", "Users associated with workflow steps are removed during import")
 }
 
 func importWorkflow(workflowName string, workflowId string, importFilePath string, existingAssoc []workflowAssociation) error {
@@ -129,7 +128,7 @@ func importWorkflow(workflowName string, workflowId string, importFilePath strin
 
 func createWorkflow(requestBody []byte, workflowName string, associations []map[string]interface{}, existingAssoc []workflowAssociation) error {
 
-	log.Println("Creating new workflow:", workflowName)
+	utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, workflowName, "Creating new workflow")
 
 	resp, err := utils.SendPostRequest(utils.WORKFLOWS, requestBody)
 	if err != nil {
@@ -146,13 +145,13 @@ func createWorkflow(requestBody []byte, workflowName string, associations []map[
 	}
 
 	utils.UpdateSuccessSummary(utils.WORKFLOWS, utils.IMPORT)
-	log.Println("Workflow imported successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, workflowName, "Imported successfully")
 	return nil
 }
 
 func updateWorkflow(workflowId string, requestBody []byte, workflowName string, associations []map[string]interface{}, existingAssoc []workflowAssociation) error {
 
-	log.Println("Updating workflow:", workflowName)
+	utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, workflowName, "Updating workflow")
 
 	resp, err := utils.SendPutRequest(utils.WORKFLOWS, workflowId, requestBody)
 	if err != nil {
@@ -165,7 +164,7 @@ func updateWorkflow(workflowId string, requestBody []byte, workflowName string, 
 	}
 
 	utils.UpdateSuccessSummary(utils.WORKFLOWS, utils.UPDATE)
-	log.Println("Workflow updated successfully.")
+	utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, workflowName, "Updated successfully")
 	return nil
 }
 
@@ -252,14 +251,14 @@ func removeDeletedDeployedWorkflows(localFiles []os.FileInfo, deployedWorkflows 
 			continue
 		}
 		if utils.IsResourceExcluded(wf.Name, utils.TOOL_CONFIGS.WorkflowConfigs) {
-			log.Println("Workflow is excluded from deletion:", wf.Name)
+			utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, wf.Name, "Excluded from deletion.")
 			continue
 		}
 
-		log.Printf("Workflow: %s not found locally. Deleting workflow.\n", wf.Name)
+		utils.PrintLog(utils.LogLevelInfo, utils.WORKFLOWS, wf.Name, "Not found locally. Deleting workflow.")
 		if err := utils.SendDeleteRequest(wf.ID, utils.WORKFLOWS); err != nil {
 			utils.UpdateFailureSummary(utils.WORKFLOWS, wf.Name)
-			log.Println("Error deleting workflow:", wf.Name, err)
+			utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, wf.Name, fmt.Sprintf("Error deleting workflow: %s", err))
 		} else {
 			utils.UpdateSuccessSummary(utils.WORKFLOWS, utils.DELETE)
 		}
@@ -288,7 +287,7 @@ func removeDeletedDeployedWfAssociations(localNames []string, deployedAssociatio
 			if assocSharingSupported {
 				return nil, fmt.Errorf("error deleting workflow association: %s. %w", assoc.Name, err)
 			} else {
-				log.Printf("Error deleting workflow association %s of workflow %s: %v", assoc.Name, assoc.WorkflowName, err)
+				utils.PrintLog(utils.LogLevelError, utils.WORKFLOWS, assoc.WorkflowName, fmt.Sprintf("Error deleting workflow association %s: %s", assoc.Name, err))
 				failedWorkflows[assoc.WorkflowName] = struct{}{}
 			}
 		}


### PR DESCRIPTION
## Purpose

Replace the codebase's ~480 unstructured `log.Println`/`log.Printf` calls with a unified `PrintLog` utility that carries resource type and name context, supports configurable log-level filtering, collects aggregated warnings, and prints a structured per-resource-type summary at the end of every export/import run.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662

## Goals

- Migrate all log calls to `PrintLog` with resource type/name context in a single pass
- Add `LOGS` config block with `LOG_LEVEL` (DEBUG/INFO/WARN/ERROR) and `LOG_REQUEST_PAYLOADS` fields
- Print a structured end-of-run summary: total counts, per-resource-type breakdown with timing, skipped/failed types, and aggregated warnings
- Log API failures at DEBUG level (including request payloads when `LOG_REQUEST_PAYLOADS: true`)
- Track resources unsupported in super tenant in the skip summary

## Approach

### Log migration

Introduced `PrintLog(level LogLevel, resourceType ResourceType, resourceName string, msg string)` in `pkg/utils/logUtils.go`. All `log.Println`/`log.Printf` calls across 50+ files were migrated in one pass. `log.Fatalln` calls are not touched. Messages already carrying `"Warn:"` / `"Info:"` / `"Error:"` prefixes had those prefixes stripped, the `LogLevel` constant now carries the severity.

Log format: `Timestamp LEVEL: ResourceType - ResourceName - message` (fields omitted when not applicable).

### Log level config and filtering

Added `LogsConfig` struct to `ToolConfigs`:

```json
"LOGS": {
  "LOG_LEVEL": "INFO",
  "LOG_REQUEST_PAYLOADS": false
}
```

`CURRENT_LOG_LEVEL` is resolved from config immediately after `LoadConfigs`. `PrintLog` drops any message whose level is below the current level. WARN messages are always appended to a `Warnings` slice regardless of the current level, so they surface in the end-of-run summary even when filtered from stdout.

### `ShouldSkip` consolidation

Added `ShouldSkip(resourceType ResourceType) bool` in `resourceProperties.go` which checks version support, org support, and exclusion config in one call. All export/import files replaced their three-condition guards with a single `utils.ShouldSkip(...)` call. Skip reason is recorded in `ResTypeSummaryMap` for the summary.

Certificates and notification providers had a fourth super-tenant guard that was handled separately; those now call `UpdateSkipSummary` with reason `"Not supported in super tenant"` so they appear correctly in the summary.

### Per-resource-type summary and timing

`logUtils.go` now owns all summary state:

- `ResTypeSummaryMap` — keyed by resource type, tracks success/failure/delete counts, skip reason, duration
- `MarkResTypeStart` / `MarkResTypeEnd` — called at the top and bottom of each `ExportAll`/`ImportAll` function to record wall-clock time
- `StartTime` — set in the CLI entry points (`exportAll.go`, `importAll.go`) for total execution time
- `PrintSummary(operation)` — prints total counts, skipped types, failed types, per-resource breakdown, and warnings

### Debug API logging

On any non-2xx response, all HTTP helpers (`SendGetRequest`, `SendExportRequest`, `SendImportRequest`, `SendUpdateRequest`, `SendDeleteRequest`) now log the method+URL and response body at DEBUG level. GET 404 is excluded (it is used for existence checks and is not an error). When `LOG_REQUEST_PAYLOADS: true`, POST/PUT request bodies are read and logged at DEBUG level.

### Custom authenticator secret masking warning

The warning `"Secrets exclusion cannot be disabled for custom authenticators"` was deduplicated with a `customAuthSecretsWarningLogged` package-level flag so it appears at most once per run.

## Key files changed

| File | Change |
|------|--------|
| `pkg/utils/constants.go` | Add `LogLevel` type + constants, `NoResource` constant |
| `pkg/utils/logUtils.go` | Owns `PrintLog`, all summary state, `PrintSummary`, timing helpers (merged from `summaryUtils.go`) |
| `pkg/utils/setup.go` | Add `LogsConfig` struct + `Logs` field; resolve `CURRENT_LOG_LEVEL` after config load |
| `pkg/utils/resourceProperties.go` | Add `ShouldSkip`; migrate log calls |
| `pkg/utils/apiUtils.go` | DEBUG logging on non-2xx for all HTTP helpers; request payload logging behind flag |
| `pkg/identityProviders/idpUtils.go` | Deduplicate custom auth secrets masking warning condition with package-level flag |
| `pkg/certificates/import.go` | Add super-tenant skip path to summary |
| `pkg/notificationProviders/export.go` + `import.go` | Add super-tenant skip path to summary |
| All `pkg/*/export.go`, `pkg/*/import.go` | `log.*` → `PrintLog`; 3-condition guards → `ShouldSkip`; `MarkResTypeStart`/`MarkResTypeEnd` calls |

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable logging levels (Debug, Info, Warn, Error) for better control over output verbosity.
  * Per-resource type progress tracking during import/export operations with start/end markers and timing information.

* **Improvements**
  * Enhanced logging across all resource types with structured, context-aware messages.
  * Improved error messages with better diagnostic details for failed operations.
  * Added logging configuration option to control request payload logging for debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->