### PR TITLE
Extend Application management to support IS versions above 6.1 and fix related bugs

### DIFF
--- a/iamctl/pkg/actions/import.go
+++ b/iamctl/pkg/actions/import.go
@@ -45,10 +45,12 @@ func ImportAll(inputDirPath string) {
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error retrieving action types list: %s", err))
 		utils.MarkResTypeFailure(utils.ACTIONS)
+		return
 	}
 	typeFolders, err := ioutil.ReadDir(importFilePath)
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ACTIONS, "", fmt.Sprintf("Error reading action type directories: %s", err))
+		utils.MarkResTypeFailure(utils.ACTIONS)
 		return
 	}
 

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/claims"
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/roles"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
@@ -62,6 +63,8 @@ type AuthConfig struct {
 		} `yaml:"inboundAuthenticationRequestConfigs" json:"inboundAuthenticationRequestConfigs"`
 	} `yaml:"inboundAuthenticationConfig" json:"inboundAuthenticationConfig"`
 }
+
+var deployedRoleNameMap map[string]string
 
 func getDeployedAppNames(apps []Application) []string {
 
@@ -460,6 +463,60 @@ func removeRoleClaimUri(appMap map[string]interface{}) error {
 	return nil
 }
 
+func filterAssociatedApplicationRoles(appMap map[string]interface{}) error {
+
+	assocRolesRaw, exists := appMap["associatedRoles"]
+	if !exists {
+		return nil
+	}
+	assocRoles, ok := assocRolesRaw.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for associatedRoles")
+	}
+	rolesRaw, exists := assocRoles["roles"]
+	if !exists {
+		return nil
+	}
+	rolesList, ok := rolesRaw.([]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for roles in associatedRoles")
+	}
+
+	filtered := make([]interface{}, 0, len(rolesList))
+	for _, item := range rolesList {
+		roleMap, ok := item.(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("unexpected format for role in associatedRoles")
+		}
+		name, ok := roleMap["name"].(string)
+		if !ok {
+			return fmt.Errorf("unexpected format for role name in associatedRoles")
+		}
+		deployedId, exists := deployedRoleNameMap[name]
+		if !exists {
+			continue
+		}
+		roleMap["id"] = deployedId
+		filtered = append(filtered, roleMap)
+	}
+	assocRoles["roles"] = filtered
+	return nil
+}
+
+func removeAssociatedApplicationRoles(appMap map[string]interface{}) error {
+
+	assocRolesRaw, exists := appMap["associatedRoles"]
+	if !exists {
+		return nil
+	}
+	assocRoles, ok := assocRolesRaw.(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for associatedRoles")
+	}
+	delete(assocRoles, "roles")
+	return nil
+}
+
 func removeAdditionalSpProperties(appMap map[string]interface{}) error {
 
 	advConf, ok := appMap["advancedConfigurations"].(map[string]interface{})
@@ -467,5 +524,18 @@ func removeAdditionalSpProperties(appMap map[string]interface{}) error {
 		return fmt.Errorf("unexpected format for advancedConfigurations")
 	}
 	delete(advConf, "additionalSpProperties")
+	return nil
+}
+
+func InitDeployedRoleIds() error {
+
+	roleList, err := roles.GetRoleList()
+	if err != nil {
+		return fmt.Errorf("error retrieving role list: %w", err)
+	}
+	deployedRoleNameMap = make(map[string]string, len(roleList))
+	for _, r := range roleList {
+		deployedRoleNameMap[r.DisplayName] = r.Id
+	}
 	return nil
 }

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -431,3 +431,13 @@ func injectDeployedReadOnlyFields(appId, protocolPath string, localConfig map[st
 	}
 	return nil
 }
+
+func removeAdditionalSpProperties(appMap map[string]interface{}) error {
+
+	advConf, ok := appMap["advancedConfigurations"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for advancedConfigurations")
+	}
+	delete(advConf, "additionalSpProperties")
+	return nil
+}

--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/claims"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
@@ -428,6 +429,33 @@ func injectDeployedReadOnlyFields(appId, protocolPath string, localConfig map[st
 			return fmt.Errorf("realm not found in deployed passive-sts config")
 		}
 		localConfig["realm"] = realm
+	}
+	return nil
+}
+
+func removeRoleClaimUri(appMap map[string]interface{}) error {
+
+	if !claims.RoleClaimUnsupported() {
+		return nil
+	}
+	claimConfMap, ok := appMap["claimConfiguration"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for claimConfiguration")
+	}
+	role, ok := claimConfMap["role"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for role in claimConfiguration")
+	}
+	claim, ok := role["claim"].(map[string]interface{})
+	if !ok {
+		return fmt.Errorf("unexpected format for claim in role")
+	}
+	uri, ok := claim["uri"].(string)
+	if !ok {
+		return fmt.Errorf("unexpected format for uri in role claim")
+	}
+	if uri == "http://wso2.org/claims/role" {
+		claim["uri"] = ""
 	}
 	return nil
 }

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -107,8 +107,8 @@ func ExportAll(exportFilePath string, format string) {
 		}
 	}
 
-	if utils.IsResourceTypeExcluded(utils.ROLES) && exportAPIExists {
-		utils.PrintLog(utils.LogLevelWarn, utils.APPLICATIONS, "", "Roles are excluded from export. Export Roles to persist Role audiences of applications.")
+	if utils.IsResourceTypeExcluded(utils.ROLES) {
+		utils.PrintLog(utils.LogLevelWarn, utils.APPLICATIONS, "", "Roles are excluded from export. Export roles to propagate new application roles.")
 	}
 }
 

--- a/iamctl/pkg/applications/export.go
+++ b/iamctl/pkg/applications/export.go
@@ -189,6 +189,9 @@ func exportAppWithCRUD(appId, appName, outputDirPath, formatString string, exclu
 		return fmt.Errorf("error when writing exported content to file: %w", err)
 	}
 
+	if err := applicationAuthorizedApis.ExportAPIs(appId, appName, outputDirPath, formatString); err != nil {
+		return fmt.Errorf("error exporting authorized APIs: %w", err)
+	}
 	return nil
 }
 

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -314,6 +314,9 @@ func patchApplication(appId string, appMap map[string]interface{}) error {
 	if err := removeAdditionalSpProperties(appMap); err != nil {
 		return fmt.Errorf("error removing additional sp properties: %w", err)
 	}
+	if err := removeRoleClaimUri(appMap); err != nil {
+		return fmt.Errorf("error clearing role claim uri: %w", err)
+	}
 
 	body, err := json.Marshal(appMap)
 	if err != nil {

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -308,6 +308,12 @@ func updateResidentApp(appMap map[string]interface{}) error {
 func patchApplication(appId string, appMap map[string]interface{}) error {
 
 	delete(appMap, "inboundProtocolConfiguration")
+	delete(appMap, "clientId")
+	delete(appMap, "isManagementApp")
+	delete(appMap, "realm")
+	if err := removeAdditionalSpProperties(appMap); err != nil {
+		return fmt.Errorf("error removing additional sp properties: %w", err)
+	}
 
 	body, err := json.Marshal(appMap)
 	if err != nil {

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -53,6 +53,11 @@ func ImportAll(inputDirPath string) {
 			return
 		}
 	}
+	if err := InitDeployedRoleIds(); err != nil {
+		utils.PrintLog(utils.LogLevelError, utils.APPLICATIONS, "", fmt.Sprintf("Error retrieving roles list: %s", err))
+		utils.MarkResTypeFailure(utils.APPLICATIONS)
+		return
+	}
 
 	deployedApps, err := getAppList()
 	if err != nil {
@@ -88,8 +93,8 @@ func ImportAll(inputDirPath string) {
 		}
 	}
 
-	if utils.IsResourceTypeExcluded(utils.ROLES) && exportAPIExists {
-		utils.PrintLog(utils.LogLevelWarn, utils.APPLICATIONS, "", "Roles are excluded from import. Import Roles to persist Role audiences of applications.")
+	if utils.IsResourceTypeExcluded(utils.ROLES) {
+		utils.PrintLog(utils.LogLevelWarn, utils.APPLICATIONS, "", "Roles are excluded from import. Import Roles to propagate new application roles.")
 	}
 }
 
@@ -219,6 +224,9 @@ func importAppWithCRUD(appName string, appMap map[string]interface{}) (string, e
 	if err := removeRoleClaimUri(appMap); err != nil {
 		return "", fmt.Errorf("error clearing role claim uri: %w", err)
 	}
+	if err := removeAssociatedApplicationRoles(appMap); err != nil {
+		return "", fmt.Errorf("error removing associated application roles: %w", err)
+	}
 
 	body, err := json.Marshal(appMap)
 	if err != nil {
@@ -260,6 +268,9 @@ func updateAppWithCRUD(appId, appName string, appMap map[string]interface{}) err
 		return fmt.Errorf("error processing inbound protocols: %w", err)
 	}
 
+	if err := filterAssociatedApplicationRoles(appMap); err != nil {
+		return fmt.Errorf("error filtering associated application roles: %w", err)
+	}
 	if err := patchApplication(appId, appMap); err != nil {
 		return fmt.Errorf("error updating application: %w", err)
 	}

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -114,40 +114,43 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 		return fmt.Errorf("unsupported file format for application: %w", err)
 	}
 
+	var finalAppId string
+
 	if exportAPIExists && appName != utils.RESIDENT_APP {
 		modifiedFileData = string(removeAssociatedRoles([]byte(modifiedFileData)))
-		var finalAppId string
 		if appId == "" {
 			finalAppId, err = importApplication(appName, importFilePath, modifiedFileData, format)
 		} else {
 			err = updateApplication(appId, appName, importFilePath, modifiedFileData, format)
 			finalAppId = appId
 		}
+	} else {
+		var appMap map[string]interface{}
+		appMap, err = utils.DeserializeToMap([]byte(modifiedFileData), format, utils.APPLICATIONS)
 		if err != nil {
-			return err
+			return fmt.Errorf("error deserializing application: %w", err)
 		}
 
-		err := applicationAuthorizedApis.ImportAPIs(finalAppId, appName, filepath.Dir(importFilePath))
-		if err != nil {
-			return fmt.Errorf("error importing authorized APIs: %w", err)
+		if appName == utils.RESIDENT_APP {
+			return updateResidentApp(appMap)
 		}
-		return nil
+
+		delete(appMap, "id")
+		if appId == "" {
+			finalAppId, err = importAppWithCRUD(appName, appMap)
+		} else {
+			err = updateAppWithCRUD(appId, appName, appMap)
+			finalAppId = appId
+		}
 	}
 
-	appMap, err := utils.DeserializeToMap([]byte(modifiedFileData), format, utils.APPLICATIONS)
 	if err != nil {
-		return fmt.Errorf("error deserializing application: %w", err)
+		return err
 	}
-
-	if appName == utils.RESIDENT_APP {
-		return updateResidentApp(appMap)
+	if err := applicationAuthorizedApis.ImportAPIs(finalAppId, appName, filepath.Dir(importFilePath)); err != nil {
+		return fmt.Errorf("error importing authorized APIs: %w", err)
 	}
-
-	delete(appMap, "id")
-	if appId == "" {
-		return importAppWithCRUD(appName, appMap)
-	}
-	return updateAppWithCRUD(appId, appName, appMap)
+	return nil
 }
 
 func importApplication(appName, importFilePath, modifiedFileData string, format utils.Format) (appId string, err error) {
@@ -200,23 +203,23 @@ func updateApplication(appId, appName, importFilePath, modifiedFileData string, 
 	return nil
 }
 
-func importAppWithCRUD(appName string, appMap map[string]interface{}) error {
+func importAppWithCRUD(appName string, appMap map[string]interface{}) (string, error) {
 
 	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Creating new application")
 
 	newSecretCreated, err := processInboundProtocolsForPost(appMap)
 	if err != nil {
-		return fmt.Errorf("error processing inbound protocols: %w", err)
+		return "", fmt.Errorf("error processing inbound protocols: %w", err)
 	}
 
 	body, err := json.Marshal(appMap)
 	if err != nil {
-		return fmt.Errorf("error marshalling application: %w", err)
+		return "", fmt.Errorf("error marshalling application: %w", err)
 	}
 
 	resp, err := utils.SendPostRequest(utils.APPLICATIONS, body)
 	if err != nil {
-		return fmt.Errorf("error creating application: %w", err)
+		return "", fmt.Errorf("error creating application: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -226,14 +229,14 @@ func importAppWithCRUD(appName string, appMap map[string]interface{}) error {
 
 	location := resp.Header.Get("Location")
 	if location == "" {
-		return fmt.Errorf("no Location header in response")
+		return "", fmt.Errorf("no Location header in response")
 	}
 	appId := path.Base(location)
 	utils.AddToIdentifierMap(utils.APPLICATIONS, appId, appName, utils.IMPORT)
 
 	utils.UpdateSuccessSummary(utils.APPLICATIONS, utils.IMPORT)
 	utils.PrintLog(utils.LogLevelInfo, utils.APPLICATIONS, appName, "Imported successfully")
-	return nil
+	return appId, nil
 }
 
 func updateAppWithCRUD(appId, appName string, appMap map[string]interface{}) error {

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -126,7 +126,7 @@ func importApp(appId, appName, importFilePath string, exportAPIExists bool) erro
 		}
 	} else {
 		var appMap map[string]interface{}
-		appMap, err = utils.DeserializeToMap([]byte(modifiedFileData), format, utils.APPLICATIONS)
+		appMap, err = utils.DeserializeToMap([]byte(modifiedFileData), format, utils.APPLICATIONS, "clientId", "realm", "issuer")
 		if err != nil {
 			return fmt.Errorf("error deserializing application: %w", err)
 		}
@@ -210,6 +210,14 @@ func importAppWithCRUD(appName string, appMap map[string]interface{}) (string, e
 	newSecretCreated, err := processInboundProtocolsForPost(appMap)
 	if err != nil {
 		return "", fmt.Errorf("error processing inbound protocols: %w", err)
+	}
+
+	delete(appMap, "applicationVersion")
+	if err := removeAdditionalSpProperties(appMap); err != nil {
+		return "", fmt.Errorf("error removing additional sp properties: %w", err)
+	}
+	if err := removeRoleClaimUri(appMap); err != nil {
+		return "", fmt.Errorf("error clearing role claim uri: %w", err)
 	}
 
 	body, err := json.Marshal(appMap)
@@ -308,9 +316,7 @@ func updateResidentApp(appMap map[string]interface{}) error {
 func patchApplication(appId string, appMap map[string]interface{}) error {
 
 	delete(appMap, "inboundProtocolConfiguration")
-	delete(appMap, "clientId")
 	delete(appMap, "isManagementApp")
-	delete(appMap, "realm")
 	if err := removeAdditionalSpProperties(appMap); err != nil {
 		return fmt.Errorf("error removing additional sp properties: %w", err)
 	}

--- a/iamctl/pkg/claims/claimUtils.go
+++ b/iamctl/pkg/claims/claimUtils.go
@@ -222,3 +222,13 @@ func removeStaleClaimsFromLocalDialect() {
 	}
 	utils.UpdateSuccessSummary(utils.CLAIMS, utils.UPDATE)
 }
+
+func RoleClaimUnsupported() bool {
+
+	if utils.SERVER_CONFIGS.ServerVersion == "" {
+		return true
+	}
+	cmp, err := utils.CompareVersions(utils.SERVER_CONFIGS.ServerVersion, utils.MIN_VERSION_ROLE_CLAIM_REMOVED)
+	// Consider role claim unsupported when the server version is not properly configured
+	return err != nil || cmp >= 0
+}

--- a/iamctl/pkg/identityProviders/idpUtils.go
+++ b/iamctl/pkg/identityProviders/idpUtils.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/claims"
 	"github.com/wso2-extensions/identity-tools-cli/iamctl/pkg/utils"
 )
 
@@ -248,18 +249,18 @@ func processOutboundConnectors(idpId string, idpStruct idpConfig, idpMap map[str
 
 func processClaims(idpMap map[string]interface{}) error {
 
-	claims, ok := idpMap["claims"].(map[string]interface{})
+	claimMap, ok := idpMap["claims"].(map[string]interface{})
 	if !ok {
 		return fmt.Errorf("invalid format for claims")
 	}
 
 	for _, claimKey := range []string{"userIdClaim", "roleClaim"} {
-		claim, ok := claims[claimKey].(map[string]interface{})
+		claim, ok := claimMap[claimKey].(map[string]interface{})
 		if !ok {
 			return fmt.Errorf("invalid format for claim: %s", claimKey)
 		}
 		if len(claim) == 0 {
-			claims[claimKey] = map[string]interface{}{"uri": ""}
+			claimMap[claimKey] = map[string]interface{}{"uri": ""}
 			continue
 		}
 
@@ -268,7 +269,7 @@ func processClaims(idpMap map[string]interface{}) error {
 			if !ok {
 				return fmt.Errorf("invalid format for roleClaim uri")
 			}
-			if shouldRemoveRoleClaim() && roleClaimUri == "http://wso2.org/claims/role" {
+			if claims.RoleClaimUnsupported() && roleClaimUri == "http://wso2.org/claims/role" {
 				claim["uri"] = ""
 			}
 		}
@@ -647,15 +648,5 @@ func shouldRemoveOutboundProvisioningRoles() bool {
 	}
 	cmp, err := utils.CompareVersions(utils.SERVER_CONFIGS.ServerVersion, utils.MIN_VERSION_OUTBOUND_PROV_GROUPS)
 	// Consider outbound provisioning groups exist when the server version is not properly configured
-	return err != nil || cmp >= 0
-}
-
-func shouldRemoveRoleClaim() bool {
-
-	if utils.SERVER_CONFIGS.ServerVersion == "" {
-		return true
-	}
-	cmp, err := utils.CompareVersions(utils.SERVER_CONFIGS.ServerVersion, utils.MIN_VERSION_ROLE_CLAIM_REMOVED)
-	// Consider role claim unsupported when the server version is not properly configured
 	return err != nil || cmp >= 0
 }

--- a/iamctl/pkg/roles/export.go
+++ b/iamctl/pkg/roles/export.go
@@ -36,7 +36,7 @@ func ExportAll(exportFilePath string, format string) {
 	if utils.ShouldSkip(utils.ROLES) {
 		return
 	}
-	roles, err := getRoleList()
+	roles, err := GetRoleList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error retrieving the deployed roles list: %s", err))
 		utils.MarkResTypeFailure(utils.ROLES)

--- a/iamctl/pkg/roles/import.go
+++ b/iamctl/pkg/roles/import.go
@@ -41,7 +41,7 @@ func ImportAll(inputDirPath string) {
 		return
 	}
 
-	existingRoleList, err := getRoleList()
+	existingRoleList, err := GetRoleList()
 	if err != nil {
 		utils.PrintLog(utils.LogLevelError, utils.ROLES, "", fmt.Sprintf("Error retrieving the deployed role list: %s", err))
 		utils.MarkResTypeFailure(utils.ROLES)

--- a/iamctl/pkg/roles/rolesUtils.go
+++ b/iamctl/pkg/roles/rolesUtils.go
@@ -42,7 +42,7 @@ type rolePatchRequest struct {
 	Schemas    []string         `json:"schemas"`
 }
 
-func getRoleList() ([]role, error) {
+func GetRoleList() ([]role, error) {
 
 	data, err := utils.SendPaginatedGetListRequest(
 		utils.ROLES,

--- a/iamctl/pkg/utils/setup.go
+++ b/iamctl/pkg/utils/setup.go
@@ -189,7 +189,7 @@ func loadServerConfigsFromFile(configFilePath string) (serverConfigs ServerConfi
 	if err != nil {
 		log.Fatalln(err)
 	}
-	PrintLog(LogLevelInfo, NoResource, "", "Server configs loaded succesfully from the config file.")
+	PrintLog(LogLevelInfo, NoResource, "", "Server configs loaded successfully from the config file.")
 	return serverConfigs
 }
 

--- a/iamctl/pkg/utils/versionRequirements.go
+++ b/iamctl/pkg/utils/versionRequirements.go
@@ -68,7 +68,6 @@ var EntityMaxSupportedVersion = map[ResourceType]string{
 const (
 	MIN_VERSION_USERSTORE_EXPORT_API       = "6.1.0"
 	MIN_VERSION_IDP_EXPORT_API             = "6.1.0"
-	MIN_VERSION_APP_EXPORT_API             = "6.1.0"
 	MIN_VERSION_ROLES_V2_API               = "7.0.0"
 	MIN_VERSION_NOTIFICATION_TEMPLATES_API = "7.1.0"
 )
@@ -84,5 +83,4 @@ const (
 var ExportAPIMinVersionRequirements = map[ResourceType]string{
 	USERSTORES:         MIN_VERSION_USERSTORE_EXPORT_API,
 	IDENTITY_PROVIDERS: MIN_VERSION_IDP_EXPORT_API,
-	APPLICATIONS:       MIN_VERSION_APP_EXPORT_API,
 }


### PR DESCRIPTION
  ## Purpose
Application export/import previously had two code paths: the file-based export API for IS 6.1.0+, and the CRUD path for older versions. This PR removes `APPLICATIONS` from `ExportAPIMinVersionRequirements`, making the CRUD path the single implementation for all IS versions. The primary motivation is that the export API path does not properly support persisting associated application roles.

Related to https://github.com/wso2-enterprise/iam-product-management/issues/662
Merge After: https://github.com/wso2-extensions/identity-tools-cli/pull/107

  ## Goals

  - Use CRUD APIs for all regular application export and import across all IS versions
  - Correctly persist `associatedRoles` on import by resolving local role names to deployed IDs
  - Strip read-only fields (`additionalSpProperties`, `applicationVersion`, `isManagementApp`,`clientId`, `realm`, `issuer`) that cause API rejections
  - Wire authorized API management into the CRUD import/export path

  ## Approach

  ### Dropping the export API path

  All regular applications are now routed through `exportAppWithCRUD` and `importAppWithCRUD` / `updateAppWithCRUD`. 

  ### Associated roles

  `associatedRoles` contains an array of role objects with environment-specific IDs. On POST (new application) the field is stripped entirely via `removeAssociatedApplicationRoles`, because the roles must be assigned after the app exists. On PUT (existing application) `filterAssociatedApplicationRoles` iterates the local role names, looks up the deployed IDs from a pre-fetched `deployedRoleNameMap`, rewrites the `id` field, and drops any roles that do not exist in the target environment. `InitDeployedRoleIds` is called once at the start of `ImportAll` and populates the name→ID map from the roles API.

  ### Read-only field stripping on PATCH and POST

`clientId`, `realm`, `issuer` fields are read only and are removed from both post and patch paths. `patchApplication` now removes `isManagementApp` and calls `removeAdditionalSpProperties`. `importAppWithCRUD` removes `applicationVersion` in addition to the same two fields. Both paths also call `removeRoleClaimUri`, which clears `http://wso2.org/claims/role` from `claimConfiguration.role.claim.uri` when `claims.RoleClaimUnsupported()` returns true. 

  ### Authorized API management in the CRUD path

  `applicationAuthorizedApis.ExportAPIs` is now called from `exportAppWithCRUD`, and `applicationAuthorizedApis.ImportAPIs` is called after both the export-API and CRUD import paths succeed, using the resolved `finalAppId` in both cases.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved role claim support with version compatibility checks.
  * Enhanced authorized API import/export handling for applications.

* **Bug Fixes**
  * Corrected error status reporting during action import failures.
  * Fixed spelling in setup log message.
  * Improved role-related configuration validation and cleanup.

* **Improvements**
  * Refactored application import logic for better role filtering and API handling.
  * Enhanced warning messages for identity provider configurations with custom authenticators.
  * Updated version requirement constants for API compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->