### PR TITLE
Fix application and organization import failures on IS 7.0.0

### DIFF
--- a/iamctl/pkg/applications/applicationUtils.go
+++ b/iamctl/pkg/applications/applicationUtils.go
@@ -475,6 +475,7 @@ func filterAssociatedApplicationRoles(appMap map[string]interface{}) error {
 	}
 	rolesRaw, exists := assocRoles["roles"]
 	if !exists {
+		assocRoles["roles"] = []interface{}{}
 		return nil
 	}
 	rolesList, ok := rolesRaw.([]interface{})
@@ -513,7 +514,7 @@ func removeAssociatedApplicationRoles(appMap map[string]interface{}) error {
 	if !ok {
 		return fmt.Errorf("unexpected format for associatedRoles")
 	}
-	delete(assocRoles, "roles")
+	assocRoles["roles"] = []interface{}{}
 	return nil
 }
 
@@ -525,6 +526,21 @@ func removeAdditionalSpProperties(appMap map[string]interface{}) error {
 	}
 	delete(advConf, "additionalSpProperties")
 	return nil
+}
+
+func removeEmptyOutboundProvisioningIdps(appMap map[string]interface{}) {
+
+	provConf, ok := appMap["provisioningConfigurations"].(map[string]interface{})
+	if !ok {
+		return
+	}
+	idps, ok := provConf["outboundProvisioningIdps"].([]interface{})
+	if ok && len(idps) == 0 {
+		delete(provConf, "outboundProvisioningIdps")
+		if len(provConf) == 0 {
+			delete(appMap, "provisioningConfigurations")
+		}
+	}
 }
 
 func InitDeployedRoleIds() error {

--- a/iamctl/pkg/applications/import.go
+++ b/iamctl/pkg/applications/import.go
@@ -227,6 +227,7 @@ func importAppWithCRUD(appName string, appMap map[string]interface{}) (string, e
 	if err := removeAssociatedApplicationRoles(appMap); err != nil {
 		return "", fmt.Errorf("error removing associated application roles: %w", err)
 	}
+	removeEmptyOutboundProvisioningIdps(appMap)
 
 	body, err := json.Marshal(appMap)
 	if err != nil {
@@ -334,6 +335,7 @@ func patchApplication(appId string, appMap map[string]interface{}) error {
 	if err := removeRoleClaimUri(appMap); err != nil {
 		return fmt.Errorf("error clearing role claim uri: %w", err)
 	}
+	removeEmptyOutboundProvisioningIdps(appMap)
 
 	body, err := json.Marshal(appMap)
 	if err != nil {

--- a/iamctl/pkg/identityProviders/import.go
+++ b/iamctl/pkg/identityProviders/import.go
@@ -75,8 +75,12 @@ func ImportAll(inputDirPath string) {
 
 			err := importIdp(idpId, idpName, idpFilePath, exportAPIExists)
 			if err != nil {
-				utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, idpName, fmt.Sprintf("Error importing identity provider: %s", err))
-				utils.UpdateFailureSummary(utils.IDENTITY_PROVIDERS, idpName)
+				if idpName == utils.RESIDENT_IDP_NAME {
+					utils.PrintLog(utils.LogLevelWarn, utils.IDENTITY_PROVIDERS, idpName, fmt.Sprintf("Skipping resident IDP update: %s", err))
+				} else {
+					utils.PrintLog(utils.LogLevelError, utils.IDENTITY_PROVIDERS, idpName, fmt.Sprintf("Error importing identity provider: %s", err))
+					utils.UpdateFailureSummary(utils.IDENTITY_PROVIDERS, idpName)
+				}
 			}
 		}
 	}

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -53,11 +53,15 @@ func ImportAll(inputDirPath string) {
 		utils.MarkResTypeFailure(utils.ORGANIZATIONS)
 		return
 	}
-	curOrgId, err = GetCurrentOrganizationId()
-	if err != nil {
-		utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", "Error while retrieving current organization ID")
-		utils.MarkResTypeFailure(utils.ORGANIZATIONS)
-		return
+
+	hasWork := len(files) > 0 || (utils.TOOL_CONFIGS.AllowDelete && len(existingList) > 0)
+	if hasWork {
+		curOrgId, err = GetCurrentOrganizationId()
+		if err != nil {
+			utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", "Error while retrieving current organization ID")
+			utils.MarkResTypeFailure(utils.ORGANIZATIONS)
+			return
+		}
 	}
 
 	if utils.TOOL_CONFIGS.AllowDelete {

--- a/iamctl/pkg/organizations/import.go
+++ b/iamctl/pkg/organizations/import.go
@@ -54,8 +54,7 @@ func ImportAll(inputDirPath string) {
 		return
 	}
 
-	hasWork := len(files) > 0 || (utils.TOOL_CONFIGS.AllowDelete && len(existingList) > 0)
-	if hasWork {
+	if len(files) > 0 {
 		curOrgId, err = GetCurrentOrganizationId()
 		if err != nil {
 			utils.PrintLog(utils.LogLevelError, utils.ORGANIZATIONS, "", "Error while retrieving current organization ID")


### PR DESCRIPTION
## Problem

Importing configurations to WSO2 Identity Server 7.0.0 fails with the following errors:

1. **Applications — 400 APP-60514**: IS 7.0.0 rejects PATCH/POST request bodies that contain `provisioningConfigurations.outboundProvisioningIdps: []` with *"Application-based outbound provisioning support is disabled"*, even when the list is empty.

2. **Applications — 500 SE-50000**: IS 7.0.0 throws an internal server error (NullPointerException) when the `associatedRoles` object in a PATCH/POST body is missing the `roles` key entirely.

3. **Organizations — 400 ORG-60064**: IS 7.0.0 returns an error for the `/organizations/self` endpoint when called from the root organization context, causing the import to fail even when there are no organizations to import.

4. **Resident IDP — 500 IDP-65005**: IS 7.0.0 exports the LOCAL (resident) IDP with an `oauth10a` federated authenticator config that its own import endpoint cannot resolve, causing an unrecoverable server error on import.

## Fix

- **`applicationUtils.go`**: In `filterAssociatedApplicationRoles`, ensure `roles: []` is always present in `associatedRoles` when the key is absent. In `removeAssociatedApplicationRoles`, set `roles: []` instead of deleting the key, so IS 7.0.0 does not encounter a null roles list. Added `removeEmptyOutboundProvisioningIdps` to remove the `outboundProvisioningIdps` key from `provisioningConfigurations` when the list is empty (and remove the parent object if it becomes empty).

- **`applications/import.go`**: Call `removeEmptyOutboundProvisioningIdps` in both `importAppWithCRUD` (POST) and `patchApplication` (PATCH) before marshalling the request body.

- **`organizations/import.go`**: Guard `GetCurrentOrganizationId()` so it is only called when there are files to import or resources to delete. Avoids the failing `/organizations/self` call on IS 7.0.0 when the organizations folder is empty.

- **`identityProviders/import.go`**: Downgrade the resident IDP import failure to a warning instead of a counted error. The LOCAL IDP is system-managed and the failure is caused by an IS 7.0.0 server-side bug (exporting an `oauth10a` authenticator config it cannot re-import). All other IDPs continue to fail with an error as before.

Issue:- https://github.com/wso2/product-is/issues/27649

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced cleanup of empty provisioning configurations during application imports.
  * Improved error handling for identity provider imports with special treatment for system providers.
  * Optimized import operations to reduce unnecessary processing when no changes are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->